### PR TITLE
fix: stop showing Thinking when no live activity exists

### DIFF
--- a/src/components/features/chat/typing-indicator.test.tsx
+++ b/src/components/features/chat/typing-indicator.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { deriveLiveActivity } from "./typing-indicator";
+import type { ActionEvent, ObservationEvent } from "#/types/agent-server/core";
+import type { ExecuteBashAction } from "#/types/agent-server/core/base/action";
+import type { ExecuteBashObservation } from "#/types/agent-server/core/base/observation";
+import { SecurityRisk } from "#/types/agent-server/core/base/common";
+
+const terminalAction: ActionEvent<ExecuteBashAction> = {
+  id: "action-1",
+  timestamp: "2026-08-21T12:00:00.000Z",
+  source: "agent",
+  thought: [],
+  thinking_blocks: [],
+  action: {
+    kind: "ExecuteBashAction",
+    command: "npm test",
+    is_input: false,
+    timeout: null,
+    reset: false,
+  },
+  tool_name: "terminal",
+  tool_call_id: "tool-1",
+  tool_call: {
+    id: "tool-1",
+    type: "function",
+    function: { name: "terminal", arguments: "{}" },
+  },
+  llm_response_id: "response-1",
+  security_risk: SecurityRisk.LOW,
+  summary: "Run tests",
+};
+
+const terminalObservation: ObservationEvent<ExecuteBashObservation> = {
+  id: "observation-1",
+  timestamp: "2026-08-21T12:00:01.000Z",
+  source: "environment",
+  tool_name: "terminal",
+  tool_call_id: "tool-1",
+  action_id: "action-1",
+  observation: {
+    kind: "ExecuteBashObservation",
+    command: "npm test",
+    content: [{ type: "text", text: "Tests passed" }],
+    exit_code: 0,
+    error: false,
+    timeout: false,
+    metadata: {
+      exit_code: 0,
+      pid: 123,
+      username: "openhands",
+      hostname: "sandbox",
+      working_dir: "/workspace/project",
+      py_interpreter_path: null,
+      prefix: "",
+      suffix: "",
+    },
+  },
+};
+
+describe("deriveLiveActivity", () => {
+  it("does not invent Thinking when there are no live events", () => {
+    expect(deriveLiveActivity([])).toBeNull();
+  });
+
+  it("does not invent Thinking after the latest action has resolved", () => {
+    expect(
+      deriveLiveActivity([terminalAction, terminalObservation]),
+    ).toBeNull();
+  });
+});

--- a/src/components/features/chat/typing-indicator.tsx
+++ b/src/components/features/chat/typing-indicator.tsx
@@ -69,7 +69,7 @@ const isUserRejectObservation = (
 
 export const deriveLiveActivity = (
   events: readonly OHEvent[],
-): EventTitleDescriptor => {
+): EventTitleDescriptor | null => {
   const resolvedActionIds = new Set<string>();
   const resolvedToolCallIds = new Set<string>();
 
@@ -120,7 +120,7 @@ export const deriveLiveActivity = (
     }
   }
 
-  return THINKING_ACTIVITY;
+  return null;
 };
 
 interface TypingIndicatorProps {
@@ -129,6 +129,10 @@ interface TypingIndicatorProps {
 
 export function TypingIndicator({ events }: TypingIndicatorProps) {
   const activity = deriveLiveActivity(events);
+
+  if (!activity) {
+    return null;
+  }
 
   return (
     <div


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

The chat live activity indicator used `Thinking` as the default fallback whenever the agent state was `running`, even when there was no unresolved action or tool call in the event stream. This made the UI report that the agent was thinking when it had no concrete live activity to show.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Stop `deriveLiveActivity` from falling back to `Thinking` when no live activity exists.
- Hide `TypingIndicator` when there is no unresolved live activity.
- Add regression coverage for empty live events and resolved action/observation events.


## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #16719

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Manual check:

1. Run `npm run dev`.
2. Open a conversation in Agent Canvas.
3. Put the UI in the stale state where the agent is `running` but there are no unresolved live events.
4. Confirm the chat footer no longer shows a green `Thinking` chip.

Automated checks run:

```bash
npm test -- src/components/features/chat/typing-indicator.test.tsx
npm run typecheck
npm run lint
npm run build
``` 

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

Before fix: the UI showed a green `Thinking` chip when `execution_status` was `running` but there were no live events.<img width="1440" height="1000" alt="openhands-issue-16719-repro-conversation" src="https://github.com/user-attachments/assets/06c359c9-63f2-4c37-adbb-df1833bca077" />

After fix: with the same frontend state, no `Thinking` chip is rendered.
<img width="1440" height="1000" alt="openhands-issue-16719-after-fix-current-chat" src="https://github.com/user-attachments/assets/2ac3c7e6-26ec-4fa6-a101-451aa9d2a20b" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.48s · commit 94e366f  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 4/4 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 20.0% | [F002H001 · src/components/features/chat/typing-indicator.tsx:69–75](https://github.com/OpenHands/OpenHands/blob/94e366fa4062373d524070bc7ef9676f84044a69/src/components/features/chat/typing-indicator.tsx#L69-L75) |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 56.0% | No primary concern to locate |

</details>


<!-- jev-input-signature e12db025ef3eeb491282b15f9dcd9c56866f74f6b80a0f573951a9b51ebf9865 -->
<!-- jev-fast-audit:end -->
