### PR TITLE
fix: correlate local conversation telemetry with Canvas identity

### DIFF
--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -1,5 +1,4 @@
 import {
-  AgentServerClient,
   ConversationClient,
   FileClient,
   ProfilesClient,
@@ -24,8 +23,6 @@ const {
   mockHttpPost,
   mockHttpDelete,
   mockConversationClient,
-  mockAgentServerClient,
-  mockAgentServerRequest,
   mockFileClient,
   mockSettingsClient,
   mockSwitchProfile,
@@ -41,8 +38,6 @@ const {
   mockHttpPost: vi.fn(),
   mockHttpDelete: vi.fn(),
   mockConversationClient: vi.fn(),
-  mockAgentServerClient: vi.fn(),
-  mockAgentServerRequest: vi.fn(),
   mockFileClient: vi.fn(),
   mockSettingsClient: vi.fn(),
   mockSwitchProfile: vi.fn(),
@@ -64,9 +59,6 @@ vi.mock("@openhands/typescript-client/clients", async () => {
   >("@openhands/typescript-client/clients");
   return {
     ...actual,
-    AgentServerClient: vi.fn(function AgentServerClientMock() {
-      return mockAgentServerClient();
-    }),
     ConversationClient: vi.fn(function ConversationClientMock() {
       return mockConversationClient();
     }),
@@ -120,7 +112,6 @@ describe("AgentServerConversationService", () => {
     mockHttpGet.mockReset();
     mockHttpPost.mockReset();
     mockHttpDelete.mockReset();
-    mockAgentServerRequest.mockReset();
     mockGetProfile.mockReset();
     mockActivateProfile.mockReset();
     mockListProfiles.mockReset().mockResolvedValue({
@@ -131,21 +122,11 @@ describe("AgentServerConversationService", () => {
     mockSwitchLLM.mockReset();
     fetchMock.mockReset();
     global.fetch = originalFetch;
-    vi.mocked(AgentServerClient).mockClear();
     vi.mocked(ConversationClient).mockClear();
     vi.mocked(FileClient).mockClear();
     vi.mocked(ProfilesClient).mockClear();
     vi.mocked(SettingsClient).mockClear();
 
-    mockAgentServerRequest.mockImplementation(
-      async (request: { path: string; body: unknown }) => {
-        const response = await mockHttpPost(request.path, request.body);
-        return response.data;
-      },
-    );
-    mockAgentServerClient.mockReturnValue({
-      request: mockAgentServerRequest,
-    });
     mockConversationClient.mockReturnValue({
       createConversation: async (payload: unknown) => {
         const response = await mockHttpPost("/api/conversations", payload);
@@ -296,21 +277,35 @@ describe("AgentServerConversationService", () => {
 
       await AgentServerConversationService.createConversation();
 
-      expect(AgentServerClient).toHaveBeenCalledWith({
-        host: "http://localhost:54928",
-        apiKey: "test-api-key",
-        timeout: 5 * 60 * 1000,
-        workingDir: "/workspace/project/agent-canvas",
-      });
-      expect(mockAgentServerRequest).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "POST",
-          path: "/api/conversations",
-          headers: {
-            "X-OpenHands-Telemetry-Distinct-Id": "ph-canvas-user",
-          },
-        }),
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        "/api/conversations",
+        expect.objectContaining({ user_id: "ph-canvas-user" }),
       );
+    });
+
+    it("omits user_id when Canvas telemetry has no consented identity", async () => {
+      mockGetTelemetryDistinctId.mockResolvedValue(null);
+      mockGetSettings.mockResolvedValue({
+        agent_settings: { llm: { model: "gpt-4o" } },
+        conversation_settings: {},
+      });
+      mockGetSettingsForConversation.mockResolvedValue({
+        agentSettings: { llm: { model: "gpt-4o" } },
+        conversationSettings: {},
+        secretsEncrypted: true,
+      });
+      mockHttpPost.mockResolvedValue({
+        data: {
+          id: "conversation-1",
+          created_at: "2024-01-01",
+          updated_at: "2024-01-01",
+        },
+      });
+
+      await AgentServerConversationService.createConversation();
+
+      const payload = mockHttpPost.mock.calls[0][1] as Record<string, unknown>;
+      expect(payload).not.toHaveProperty("user_id");
     });
 
     it("passes the selected title profile to local conversation starts", async () => {

--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -1,4 +1,5 @@
 import {
+  AgentServerClient,
   ConversationClient,
   FileClient,
   ProfilesClient,
@@ -23,6 +24,8 @@ const {
   mockHttpPost,
   mockHttpDelete,
   mockConversationClient,
+  mockAgentServerClient,
+  mockAgentServerRequest,
   mockFileClient,
   mockSettingsClient,
   mockSwitchProfile,
@@ -38,6 +41,8 @@ const {
   mockHttpPost: vi.fn(),
   mockHttpDelete: vi.fn(),
   mockConversationClient: vi.fn(),
+  mockAgentServerClient: vi.fn(),
+  mockAgentServerRequest: vi.fn(),
   mockFileClient: vi.fn(),
   mockSettingsClient: vi.fn(),
   mockSwitchProfile: vi.fn(),
@@ -59,6 +64,9 @@ vi.mock("@openhands/typescript-client/clients", async () => {
   >("@openhands/typescript-client/clients");
   return {
     ...actual,
+    AgentServerClient: vi.fn(function AgentServerClientMock() {
+      return mockAgentServerClient();
+    }),
     ConversationClient: vi.fn(function ConversationClientMock() {
       return mockConversationClient();
     }),
@@ -112,6 +120,7 @@ describe("AgentServerConversationService", () => {
     mockHttpGet.mockReset();
     mockHttpPost.mockReset();
     mockHttpDelete.mockReset();
+    mockAgentServerRequest.mockReset();
     mockGetProfile.mockReset();
     mockActivateProfile.mockReset();
     mockListProfiles.mockReset().mockResolvedValue({
@@ -122,11 +131,21 @@ describe("AgentServerConversationService", () => {
     mockSwitchLLM.mockReset();
     fetchMock.mockReset();
     global.fetch = originalFetch;
+    vi.mocked(AgentServerClient).mockClear();
     vi.mocked(ConversationClient).mockClear();
     vi.mocked(FileClient).mockClear();
     vi.mocked(ProfilesClient).mockClear();
     vi.mocked(SettingsClient).mockClear();
 
+    mockAgentServerRequest.mockImplementation(
+      async (request: { path: string; body: unknown }) => {
+        const response = await mockHttpPost(request.path, request.body);
+        return response.data;
+      },
+    );
+    mockAgentServerClient.mockReturnValue({
+      request: mockAgentServerRequest,
+    });
     mockConversationClient.mockReturnValue({
       createConversation: async (payload: unknown) => {
         const response = await mockHttpPost("/api/conversations", payload);
@@ -277,8 +296,16 @@ describe("AgentServerConversationService", () => {
 
       await AgentServerConversationService.createConversation();
 
-      expect(ConversationClient).toHaveBeenCalledWith(
+      expect(AgentServerClient).toHaveBeenCalledWith({
+        host: "http://localhost:54928",
+        apiKey: "test-api-key",
+        timeout: 5 * 60 * 1000,
+        workingDir: "/workspace/project/agent-canvas",
+      });
+      expect(mockAgentServerRequest).toHaveBeenCalledWith(
         expect.objectContaining({
+          method: "POST",
+          path: "/api/conversations",
           headers: {
             "X-OpenHands-Telemetry-Distinct-Id": "ph-canvas-user",
           },

--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -32,6 +32,7 @@ const {
   mockGetProfile,
   mockActivateProfile,
   mockListProfiles,
+  mockGetTelemetryDistinctId,
 } = vi.hoisted(() => ({
   mockHttpGet: vi.fn(),
   mockHttpPost: vi.fn(),
@@ -46,6 +47,7 @@ const {
   mockGetProfile: vi.fn(),
   mockActivateProfile: vi.fn(),
   mockListProfiles: vi.fn(),
+  mockGetTelemetryDistinctId: vi.fn(),
 }));
 
 const originalFetch = global.fetch;
@@ -98,6 +100,10 @@ vi.mock("#/api/settings-service/settings-service.api", () => ({
     getSettings: mockGetSettings,
     getSettingsForConversation: mockGetSettingsForConversation,
   },
+}));
+
+vi.mock("#/services/telemetry", () => ({
+  getTelemetryDistinctId: mockGetTelemetryDistinctId,
 }));
 
 describe("AgentServerConversationService", () => {
@@ -250,6 +256,36 @@ describe("AgentServerConversationService", () => {
   });
 
   describe("createConversation", () => {
+    it("forwards the Canvas telemetry identity to the local agent server", async () => {
+      mockGetTelemetryDistinctId.mockResolvedValue("ph-canvas-user");
+      mockGetSettings.mockResolvedValue({
+        agent_settings: { llm: { model: "gpt-4o" } },
+        conversation_settings: {},
+      });
+      mockGetSettingsForConversation.mockResolvedValue({
+        agentSettings: { llm: { model: "gpt-4o" } },
+        conversationSettings: {},
+        secretsEncrypted: true,
+      });
+      mockHttpPost.mockResolvedValue({
+        data: {
+          id: "conversation-1",
+          created_at: "2024-01-01",
+          updated_at: "2024-01-01",
+        },
+      });
+
+      await AgentServerConversationService.createConversation();
+
+      expect(ConversationClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: {
+            "X-OpenHands-Telemetry-Distinct-Id": "ph-canvas-user",
+          },
+        }),
+      );
+    });
+
     it("passes the selected title profile to local conversation starts", async () => {
       mockGetSettings.mockResolvedValue({
         title_llm_profile: "Titles",

--- a/__tests__/api/use-create-conversation-metadata.test.ts
+++ b/__tests__/api/use-create-conversation-metadata.test.ts
@@ -17,6 +17,7 @@ const {
   mockGetSettingsForConversation,
   mockUseLlmProfiles,
   mockListInstalledPlugins,
+  mockGetTelemetryDistinctId,
 } = vi.hoisted(() => ({
   mockHttpPost: vi.fn(),
   mockConversationClient: vi.fn(),
@@ -25,6 +26,7 @@ const {
   mockGetSettingsForConversation: vi.fn(),
   mockUseLlmProfiles: vi.fn(),
   mockListInstalledPlugins: vi.fn(),
+  mockGetTelemetryDistinctId: vi.fn(),
 }));
 
 vi.mock("@openhands/typescript-client/clients", async () => {
@@ -70,6 +72,10 @@ vi.mock("#/hooks/use-tracking", () => ({
   useTracking: () => ({ trackConversationCreated: vi.fn() }),
 }));
 
+vi.mock("#/services/telemetry", () => ({
+  getTelemetryDistinctId: mockGetTelemetryDistinctId,
+}));
+
 vi.mock("#/hooks/query/use-llm-profiles", () => ({
   useLlmProfiles: () => mockUseLlmProfiles(),
 }));
@@ -98,6 +104,7 @@ describe("useCreateConversation persists selected repository metadata", () => {
     // Default: no installed plugins, so the existing repo/workspace/profile
     // assertions are unaffected. Plugin-specific tests override this.
     mockListInstalledPlugins.mockResolvedValue([]);
+    mockGetTelemetryDistinctId.mockReset().mockResolvedValue(null);
     mockHttpPost.mockReset();
     mockGetSettings.mockReset();
     mockGetSettingsForConversation.mockReset();

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -11,7 +11,6 @@ import type {
   AppConversationStartTask,
 } from "../conversation-service/agent-server-conversation-service.types";
 import { AGENT_CANVAS_CLIENT_HEADERS } from "../client-source";
-import { getTelemetryDistinctId } from "../../services/telemetry";
 import { callCloudProxy } from "./proxy";
 
 /**
@@ -154,20 +153,12 @@ export async function createCloudAppConversation(
   backendOverride?: Backend,
 ): Promise<AppConversationStartTask> {
   const backend = backendOverride ?? getActiveCloudBackend();
-  const telemetryDistinctId = await getTelemetryDistinctId();
   const data = await callCloudProxy<AppConversationStartTask>({
     backend,
     method: "POST",
     path: "/api/v1/app-conversations",
     body: request as unknown as Record<string, unknown>,
-    headers: {
-      ...AGENT_CANVAS_CLIENT_HEADERS,
-      ...(telemetryDistinctId
-        ? {
-            "X-OpenHands-Telemetry-Distinct-Id": telemetryDistinctId,
-          }
-        : {}),
-    },
+    headers: AGENT_CANVAS_CLIENT_HEADERS,
   });
   return data;
 }

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -11,6 +11,7 @@ import type {
   AppConversationStartTask,
 } from "../conversation-service/agent-server-conversation-service.types";
 import { AGENT_CANVAS_CLIENT_HEADERS } from "../client-source";
+import { getTelemetryDistinctId } from "../../services/telemetry";
 import { callCloudProxy } from "./proxy";
 
 /**
@@ -153,12 +154,20 @@ export async function createCloudAppConversation(
   backendOverride?: Backend,
 ): Promise<AppConversationStartTask> {
   const backend = backendOverride ?? getActiveCloudBackend();
+  const telemetryDistinctId = await getTelemetryDistinctId();
   const data = await callCloudProxy<AppConversationStartTask>({
     backend,
     method: "POST",
     path: "/api/v1/app-conversations",
     body: request as unknown as Record<string, unknown>,
-    headers: AGENT_CANVAS_CLIENT_HEADERS,
+    headers: {
+      ...AGENT_CANVAS_CLIENT_HEADERS,
+      ...(telemetryDistinctId
+        ? {
+            "X-OpenHands-Telemetry-Distinct-Id": telemetryDistinctId,
+          }
+        : {}),
+    },
   });
   return data;
 }

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -5,7 +5,6 @@ import {
   type VSCodeStatusResponse,
 } from "@openhands/typescript-client";
 import {
-  AgentServerClient,
   ConversationClient,
   FileClient,
   ProfilesClient,
@@ -489,19 +488,11 @@ class AgentServerConversationService {
     });
 
     const telemetryDistinctId = await getTelemetryDistinctId();
-    const data = await new AgentServerClient(
+    const data = await new ConversationClient(
       getAgentServerClientOptions({ timeout: CREATE_CONVERSATION_TIMEOUT_MS }),
-    ).request<DirectConversationInfo>({
-      method: "POST",
-      path: "/api/conversations",
-      body: payload,
-      ...(telemetryDistinctId
-        ? {
-            headers: {
-              "X-OpenHands-Telemetry-Distinct-Id": telemetryDistinctId,
-            },
-          }
-        : {}),
+    ).createConversation<DirectConversationInfo>({
+      ...payload,
+      ...(telemetryDistinctId ? { user_id: telemetryDistinctId } : {}),
     });
     const localBackend = getEffectiveLocalBackend();
     if (!localBackend) throw new NoBackendAvailableError();

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -5,6 +5,7 @@ import {
   type VSCodeStatusResponse,
 } from "@openhands/typescript-client";
 import {
+  AgentServerClient,
   ConversationClient,
   FileClient,
   ProfilesClient,
@@ -50,6 +51,7 @@ import {
   NoBackendAvailableError,
 } from "../agent-server-client-options";
 import SettingsService from "../settings-service/settings-service.api";
+import { getTelemetryDistinctId } from "../../services/telemetry";
 import {
   ConversationMetadata,
   getStoredConversationMetadata,
@@ -486,9 +488,21 @@ class AgentServerConversationService {
       titleLlmProfile,
     });
 
-    const data = await new ConversationClient(
+    const telemetryDistinctId = await getTelemetryDistinctId();
+    const data = await new AgentServerClient(
       getAgentServerClientOptions({ timeout: CREATE_CONVERSATION_TIMEOUT_MS }),
-    ).createConversation<DirectConversationInfo>(payload);
+    ).request<DirectConversationInfo>({
+      method: "POST",
+      path: "/api/conversations",
+      body: payload,
+      ...(telemetryDistinctId
+        ? {
+            headers: {
+              "X-OpenHands-Telemetry-Distinct-Id": telemetryDistinctId,
+            },
+          }
+        : {}),
+    });
     const localBackend = getEffectiveLocalBackend();
     if (!localBackend) throw new NoBackendAvailableError();
 


### PR DESCRIPTION
HUMAN:
<!-- Add a short human-written note here before merging. -->

See the comments below. I created a simple conversation manually and monitored the posthog telemetry to make sure everything is wired together properly so we can check full canvas->agent server sessions and make sure that things aren't breaking in handoff.

<img width="1151" height="209" alt="Screenshot 2026-08-22 at 9 20 22 AM" src="https://github.com/user-attachments/assets/d98a6b32-0073-4536-a9a2-fc4656f7c660" />

AGENT:
## Summary

Pass the consent-aware Canvas PostHog distinct ID through the SDK's existing `StartConversationRequest.user_id` field when creating a local conversation. This lets canonical `agent_server.conversation_created` lifecycle events correlate with Canvas funnel events while preserving anonymous behavior for users without telemetry consent.

## Why

Before this change, Canvas left `StartConversationRequest.user_id` unset. The SDK therefore correctly fell back to a process-local `anon:<session_ref>` identity for canonical conversation lifecycle telemetry, preventing those events from joining `canvas_new_session`, `conversation_start_requested`, and `initial_query_submitted` for the same Canvas user.

The SDK already defines the intended boundary:

- `StartConversationRequest.user_id` is the hosting deployment's conversation identity, reused verbatim for lifecycle analytics and observability.
- `X-OpenHands-Telemetry-Distinct-Id` is for request-scoped telemetry that has no conversation identity, such as `request_failed`.

This PR follows that existing contract rather than introducing a new SDK event or reinterpreting the request-scoped header. Cloud creation is unchanged because the app server already owns the authenticated cloud user identity.

## Evidence

### Before the fix

A real local conversation created through Canvas persisted with no hosting identity:

```json
{
  "id": "8817436d7e544650ab3edeb2ef84e111",
  "user_id": null
}
```

Canonical SDK events therefore used an anonymous identity:

```text
agent_server.conversation_created
distinct_id: anon:<session_ref>
```

### After the fix

A real conversation created through the rebuilt isolated Canvas stack persisted the consented Canvas PostHog identity:

```json
{
  "id": "402136e741a04ca29fc06119cf72f002",
  "user_id": "01a02905-dc41-7e73-a0c1-89e68759a8d7"
}
```

For deterministic exporter-boundary validation, the isolated agent server was pointed at a local HTTP telemetry collector. A controlled conversation created with `user_id = canvas-e2e-1787403819` emitted:

```json
{
  "event": "agent_server.conversation_created",
  "distinct_id": "canvas-e2e-1787403819",
  "properties": {
    "conversation_ref": "e50621e1b1ae3541fdd80847775877da",
    "server_version": "1.43.1",
    "deployment_kind": "local"
  }
}
```

This verifies the complete path:

```text
Canvas consented PostHog identity
→ StartConversationRequest.user_id
→ StoredConversation.user_id
→ ConversationTelemetryContext.user_id
→ DiagnosticEvent.distinct_id
→ exported agent_server.conversation_created
```

Historical anonymous events remain anonymous. PostHog funnel overlap will improve progressively as fixed Canvas versions create new conversations.

## How to Test

Run the focused regression tests:

```bash
npm run make-i18n
npx vitest run __tests__/api/agent-server-conversation-service.test.ts \
  -t "telemetry identity|omits user_id"
```

Expected behavior:

- When `getTelemetryDistinctId()` returns a consented identity, the outgoing local conversation payload includes that value as `user_id`.
- When it returns `null`, the outgoing payload omits `user_id`, preserving the SDK's anonymous fallback.

Type validation:

```bash
npx tsc --noEmit --skipLibCheck
```

Both focused tests and the full TypeScript validation pass locally.

## Video/Screenshots

No user-visible UI changes. Validation is captured above as the exact exporter payload because this change affects telemetry request data rather than rendered behavior.

## Issue Number

Fixes #16795

This pull request was created by an AI agent (OpenHands) on behalf of the user.



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `696dac19f21df2f3258061dc858917143420a7ea` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-696dac1
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-696dac1
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-696dac1-amd64
ghcr.io/openhands/agent-canvas:fix-propagate-telemetry-identity-amd64
ghcr.io/openhands/agent-canvas:pr-16796-amd64
ghcr.io/openhands/agent-canvas:sha-696dac1-arm64
ghcr.io/openhands/agent-canvas:fix-propagate-telemetry-identity-arm64
ghcr.io/openhands/agent-canvas:pr-16796-arm64
ghcr.io/openhands/agent-canvas:sha-696dac1
ghcr.io/openhands/agent-canvas:fix-propagate-telemetry-identity
ghcr.io/openhands/agent-canvas:pr-16796
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-696dac1`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-696dac1-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->
