### PR TITLE
fix(query): cap automation run-history fan-out and pause background conversation polling

### DIFF
--- a/__tests__/hooks/query/concurrency-limiter.test.ts
+++ b/__tests__/hooks/query/concurrency-limiter.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ConcurrencyLimiter,
+  automationRunRequestsLimiter,
+} from "#/hooks/query/concurrency-limiter";
+
+describe("ConcurrencyLimiter", () => {
+  it("runs a task immediately when a slot is available", async () => {
+    const limiter = new ConcurrencyLimiter(2);
+    const result = await limiter.run(async () => "done");
+    expect(result).toBe("done");
+  });
+
+  it("does not exceed the configured maximum concurrency", async () => {
+    const limiter = new ConcurrencyLimiter(2);
+    let running = 0;
+    let maxObserved = 0;
+
+    const makeTask = async (id: number) => {
+      running += 1;
+      maxObserved = Math.max(maxObserved, running);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      running -= 1;
+      return id;
+    };
+
+    const ids = await Promise.all(
+      Array.from({ length: 5 }, (_, i) => limiter.run(() => makeTask(i))),
+    );
+
+    expect(ids).toEqual([0, 1, 2, 3, 4]);
+    expect(maxObserved).toBe(2);
+    expect(running).toBe(0);
+  });
+
+  it("propagates task errors without leaking the active slot", async () => {
+    const limiter = new ConcurrencyLimiter(1);
+    await expect(
+      limiter.run(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // A subsequent task should still be able to run.
+    const result = await limiter.run(async () => "ok");
+    expect(result).toBe("ok");
+  });
+
+  it("queues tasks and keeps order under the shared cap", async () => {
+    const limiter = new ConcurrencyLimiter(1);
+    const order: number[] = [];
+
+    const task = (id: number) =>
+      limiter.run(async () => {
+        order.push(id);
+        return id;
+      });
+
+    await Promise.all(Array.from({ length: 4 }, (_, i) => task(i)));
+
+    expect(order).toEqual([0, 1, 2, 3]);
+  });
+
+  it("shares the same automation-run limiter across tests", () => {
+    // The exported limiter is a singleton so multiple fan-out sites cannot
+    // accidentally create their own limiters and bypass the global cap.
+    expect(automationRunRequestsLimiter).toBeInstanceOf(ConcurrencyLimiter);
+  });
+});

--- a/__tests__/hooks/query/use-paginated-conversations.test.tsx
+++ b/__tests__/hooks/query/use-paginated-conversations.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import { usePaginatedConversations } from "#/hooks/query/use-paginated-conversations";
+
+vi.mock("#/hooks/query/use-is-authed", () => ({
+  useIsAuthed: () => ({ data: true }),
+}));
+
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => ({
+    backend: { id: "local", kind: "local", host: "http://127.0.0.1:18000" },
+    orgId: null,
+  }),
+}));
+
+vi.mock("#/api/backend-registry/active-store", () => ({
+  isNoBackend: () => false,
+}));
+
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: {
+      searchConversations: vi.fn(async () => ({
+        items: [],
+        next_page_id: null,
+      })),
+    },
+  }),
+);
+
+describe("usePaginatedConversations", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(AgentServerConversationService.searchConversations).mockClear();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("fetches and returns the configured refetch options", async () => {
+    renderHook(() => usePaginatedConversations(), { wrapper });
+
+    await waitFor(() => {
+      expect(
+        AgentServerConversationService.searchConversations,
+      ).toHaveBeenCalled();
+    });
+
+    const query = queryClient
+      .getQueryCache()
+      .getAll()
+      .find(
+        (entry) =>
+          entry.queryKey[0] === "user" && entry.queryKey[1] === "conversations",
+      );
+
+    const options = query?.options as {
+      refetchInterval?: number | false;
+      refetchIntervalInBackground?: boolean;
+    };
+
+    expect(options.refetchInterval).toBe(30_000);
+    expect(options.refetchIntervalInBackground).toBe(false);
+  });
+});

--- a/src/hooks/query/concurrency-limiter.ts
+++ b/src/hooks/query/concurrency-limiter.ts
@@ -1,0 +1,55 @@
+/**
+ * Simple FIFO concurrency limiter for async work. Keeps at most `max` tasks
+ * running at once; additional tasks are queued and start as soon as a slot
+ * frees up.
+ *
+ * Used to bound request fan-out that would otherwise saturate the browser's
+ * per-origin connection pool and starve unrelated queries (e.g. the
+ * conversation list while many automation run-history requests are in flight).
+ */
+export class ConcurrencyLimiter {
+  private active = 0;
+
+  private readonly queue: Array<() => void> = [];
+
+  constructor(private readonly max: number) {}
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    } else {
+      this.active -= 1;
+    }
+  }
+}
+
+/**
+ * Shared limiter for automation run-history requests.
+ *
+ * The home page and automations list page fan out one `getAutomationRuns`
+ * request per automation. Left unbounded, a large number of enabled
+ * automations can consume the browser's connection pool and prevent other
+ * requests (such as the conversation list `searchConversations`) from making
+ * progress while an automation run is keeping those requests slow.
+ */
+export const automationRunRequestsLimiter = new ConcurrencyLimiter(3);

--- a/src/hooks/query/use-automation-run-summaries.ts
+++ b/src/hooks/query/use-automation-run-summaries.ts
@@ -6,6 +6,7 @@ import {
   summarizeAutomationRuns,
   type RunSummaryState,
 } from "#/manifests/automation-insights";
+import { automationRunRequestsLimiter } from "./concurrency-limiter";
 import type { Automation } from "#/types/automation";
 
 /**
@@ -40,10 +41,12 @@ export function useAutomationRunSummaries(
         active.orgId,
       ],
       queryFn: () =>
-        AutomationService.getAutomationRuns(
-          automation.id,
-          RECENT_RUN_SAMPLE_SIZE,
-          0,
+        automationRunRequestsLimiter.run(() =>
+          AutomationService.getAutomationRuns(
+            automation.id,
+            RECENT_RUN_SAMPLE_SIZE,
+            0,
+          ),
         ),
       staleTime: 60 * 1000,
       enabled: enabled && !!automation.id,

--- a/src/hooks/query/use-latest-automation-runs.ts
+++ b/src/hooks/query/use-latest-automation-runs.ts
@@ -7,6 +7,7 @@ import {
   type AutomationRun,
   type AutomationRunsResponse,
 } from "#/types/automation";
+import { automationRunRequestsLimiter } from "./concurrency-limiter";
 import { AUTOMATION_RUNS_QUERY_KEY } from "./use-automation-detail";
 
 /**
@@ -54,10 +55,12 @@ export function useLatestAutomationRuns(
         active.orgId,
       ],
       queryFn: () =>
-        AutomationService.getAutomationRuns(
-          automation.id,
-          AUTOMATION_RUN_ACTIVITY_LIMIT,
-          0,
+        automationRunRequestsLimiter.run(() =>
+          AutomationService.getAutomationRuns(
+            automation.id,
+            AUTOMATION_RUN_ACTIVITY_LIMIT,
+            0,
+          ),
         ),
       staleTime: 60 * 1000,
       // No retries: the home section settles into its degraded "unknown"

--- a/src/hooks/query/use-paginated-conversations.ts
+++ b/src/hooks/query/use-paginated-conversations.ts
@@ -43,6 +43,11 @@ export const usePaginatedConversations = (limit: number = 20) => {
     // true on every background refetch, which would cause the skeleton to
     // flicker on each poll when the list is empty.
     refetchInterval: 30_000,
+    // Do not keep refetching in hidden/background tabs. Background polling
+    // while the user is away can stack up behind slow automation runs and
+    // make the sidebar conversation list appear hung when the tab is
+    // reactivated.
+    refetchIntervalInBackground: false,
     // A successful fetch proves the backend is reachable. The global
     // QueryCache onSuccess handler reads this to clear any persisted
     // failure state, re-arming the status dot without user intervention.


### PR DESCRIPTION
HUMAN:

Rebased onto upstream `main` (`9e8ba84f` @ 2026-08-22), reran the targeted unit tests locally (151/151 passed across `__tests__/hooks/query`), ran `npm run lint` (clean — pre-existing warnings only) and `npm run build` (succeeded). Sabotage validation: the new `use-paginated-conversations.test.tsx` regression fails on unmodified `main` (asserts `refetchIntervalInBackground === false`, but the field is `undefined` on `main`) and passes on this branch. Mock-LLM E2E suite is green on this head (63/63, see bot comment below for the workflow run + test artifacts zip).

AGENT:

---

## Why

The conversation list (`usePaginatedConversations`) can hang in a loading skeleton while an automation run is active. The home page and automations list fan out one `getAutomationRuns` request per enabled automation through `useLatestAutomationRuns` and `useAutomationRunSummaries`. When a run is active, those requests are slow; an unbounded fan-out can saturate the browser's per-origin connection pool and queue other requests such as the conversation-list `searchConversations` until the run finishes.

## Summary

- Add a shared `automationRunRequestsLimiter` (`max: 3`) in `src/hooks/query/concurrency-limiter.ts` and wrap `AutomationService.getAutomationRuns` calls in `useLatestAutomationRuns` and `useAutomationRunSummaries`.
- Set `refetchIntervalInBackground: false` on `usePaginatedConversations` so background tabs cannot stack polling behind slow runs.
- Add unit tests for the limiter and for the conversation list refetch options.

## Issue Number

Fixes #16750

This change is adjacent to the run-history fan-out work in #16638 (issue #16559). #16638 addresses the Automation View; this PR addresses the same fan-out starving the conversation list on the home / automations surfaces.

## How to Test

```bash
npm test -- __tests__/hooks/query/concurrency-limiter.test.ts __tests__/hooks/query/use-paginated-conversations.test.tsx
npm test -- __tests__/hooks/query
npm run lint
npm run build
```

All passed:
- `__tests__/hooks/query` (28 files, 151 tests)
- `npm run lint` (pre-existing warnings only)
- `npm run build` (production build succeeded)

Sabotage validation: the new `use-paginated-conversations.test.tsx` fails on unmodified `main` (`refetchIntervalInBackground` is `undefined`) and passes with this fix.

## Video/Screenshots

The Mock-LLM E2E suite on this head passed 63/63; the test report (with run + artifact links) is posted in the PR comments by the `mock-llm-e2e` workflow. The artifacts zip (`mock-llm-e2e-results`, ~21 MB, expires 2026-09-05) under `playwright-report-mock-llm/data/*.webm` contains the full Playwright traces; one representative trace is `https://github.com/OpenHands/OpenHands/actions/runs/32603280296/artifacts/9483600166`.

## Type

- [x] Bug fix

## Notes

The new `concurrency-limiter.ts` intentionally mirrors the limiter pattern introduced in the in-flight #16638 branch, scoped to the conversation-list starvation path described in #16750.