### PR TITLE
fix: rename conversation title on cloud backends

### DIFF
--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -1224,5 +1224,31 @@ describe("AgentServerConversationService", () => {
         `${cloudBackend.host}/api/v1/app-conversations/conv-cloud-1/file?file_path=%2Fworkspace%2Fproject%2F.agents_tmp%2FPLAN.md`,
       );
     });
+
+    it("renames a cloud conversation title via PATCH without touching the local agent-server", async () => {
+      // Arrange
+      fetchMock.mockResolvedValueOnce(
+        mockJsonResponse({ id: "conv-cloud-1", title: "Renamed" }),
+      );
+
+      // Act
+      const result =
+        await AgentServerConversationService.updateConversationTitle(
+          "conv-cloud-1",
+          "Renamed",
+        );
+
+      // Assert
+      expect(result).toMatchObject({ id: "conv-cloud-1", title: "Renamed" });
+      const [url, init] = getFetchCall(fetchMock);
+      expect(url).toBe(
+        `${cloudBackend.host}/api/v1/app-conversations/conv-cloud-1`,
+      );
+      expect(init).toMatchObject({
+        method: "PATCH",
+        headers: { Authorization: "Bearer bearer-token" },
+      });
+      expect(getJsonBody(init)).toEqual({ title: "Renamed" });
+    });
   });
 });

--- a/__tests__/api/cloud-conversation-service.test.ts
+++ b/__tests__/api/cloud-conversation-service.test.ts
@@ -11,6 +11,7 @@ import {
   createCloudAppConversation,
   pickCloudBackendForLaunch,
   searchCloudConversations,
+  updateCloudConversationTitle,
 } from "#/api/cloud/conversation-service.api";
 import { AGENT_CANVAS_CLIENT_HEADERS } from "#/api/client-source";
 
@@ -173,6 +174,29 @@ describe("cloud conversation-service overlay", () => {
 
     expect(result).toEqual([]);
     expect(mockCallCloudProxy).not.toHaveBeenCalled();
+  });
+
+  it("renames a Cloud conversation title via PATCH", async () => {
+    const updated = {
+      id: "conv-1",
+      title: "Renamed",
+      selected_repository: null,
+      selected_branch: null,
+      git_provider: null,
+    };
+    mockCallCloudProxy.mockResolvedValueOnce(updated);
+
+    const result = await updateCloudConversationTitle("conv-1", "Renamed");
+
+    expect(mockCallCloudProxy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: cloudBackend,
+        method: "PATCH",
+        path: "/api/v1/app-conversations/conv-1",
+        body: { title: "Renamed" },
+      }),
+    );
+    expect(result).toEqual(updated);
   });
 
   it("only fills server-side nulls — server-populated fields are preserved", async () => {

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -221,6 +221,26 @@ export async function updateCloudConversationPublicFlag(
 }
 
 /**
+ * Update a cloud v1 app-conversation's title. Mirrors the local
+ * `AgentServerConversationService.updateConversationTitle` interface:
+ * `PATCH /api/v1/app-conversations/{id}` with `{ title }`, returning the
+ * updated conversation.
+ */
+export async function updateCloudConversationTitle(
+  conversationId: string,
+  title: string,
+): Promise<AppConversation> {
+  const backend = getActiveCloudBackend();
+  const data = await callCloudProxy<AppConversation>({
+    backend,
+    method: "PATCH",
+    path: `/api/v1/app-conversations/${conversationId}`,
+    body: { title },
+  });
+  return data;
+}
+
+/**
  * Pause the cloud sandbox backing a v1 app-conversation. Mirrors
  * OpenHands' `SandboxService.pauseSandbox`:
  * `POST /api/v1/sandboxes/{sandboxId}/pause` on the cloud backend, which stops

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -34,6 +34,7 @@ import {
   readCloudConversationFile,
   searchCloudConversations,
   updateCloudConversationPublicFlag,
+  updateCloudConversationTitle,
 } from "../cloud/conversation-service.api";
 import {
   DirectConversationInfo,
@@ -783,6 +784,10 @@ class AgentServerConversationService {
     conversationId: string,
     title: string,
   ): Promise<AppConversation> {
+    if (getActiveBackend().backend.kind === "cloud") {
+      return updateCloudConversationTitle(conversationId, title);
+    }
+
     await new ConversationClient(
       getAgentServerClientOptions(),
     ).updateConversation(conversationId, {


### PR DESCRIPTION
HUMAN:

Ran `npx vitest run __tests__/api/cloud-conversation-service.test.ts __tests__/api/agent-server-conversation-service.test.ts` after `npm ci` + `npm run make-i18n`. Both files pass (12 + 36 tests), including the two new tests added for this fix. `npx eslint` passes on all four changed files.

AGENT:

---

## Why

Renaming a conversation on a Cloud backend fails with `NoBackendAvailableError` ("No backend is configured."). `AgentServerConversationService.updateConversationTitle` unconditionally calls `getAgentServerClientOptions()`, which throws when the active backend is Cloud because `getEffectiveLocalBackend()` returns null for non-local backends. Other update methods (`deleteConversation`, `updateConversationPublicFlag`) already branch on `getActiveBackend().backend.kind === "cloud"`; the title update did not.

## Summary

- Added `updateCloudConversationTitle` in `src/api/cloud/conversation-service.api.ts` (`PATCH /api/v1/app-conversations/{id}` with `{ title }`).
- Branched `updateConversationTitle` on the cloud backend to route through the new cloud path.
- Added tests covering the cloud PATCH and the service-level routing.

## Issue Number

Fixes #15830

## How to Test

1. Connect a Cloud backend.
2. Open a conversation and use the Rename option to change its title.
3. Verify the title persists (no revert) and appears on the cloud backend.

Unit tests: `npx vitest run __tests__/api/cloud-conversation-service.test.ts __tests__/api/agent-server-conversation-service.test.ts`

## Video/Screenshots

<!-- Provide a video or screenshots of testing your PR. -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.40s · commit 93ca3ff  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 6/6 hunks, 4/4 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 8.0% | No direct hunk selected |
| Weakened authorization | 12.0% | No direct hunk selected |
| Contract regression | 10.0% | No direct hunk selected |
| Data loss | 5.0% | No direct hunk selected |
| Sensitive data disclosure | 4.0% | No direct hunk selected |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 8.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 5.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 6d69c8f91f45740d2ffe452722f49fa40c1deb367675982043c70f388570bb3a -->
<!-- jev-fast-audit:end -->
