### PR TITLE
fix: reduce codeblock padding/border in markdown rich view

### DIFF
--- a/src/components/features/files-tab/file-content-viewer.tsx
+++ b/src/components/features/files-tab/file-content-viewer.tsx
@@ -197,7 +197,7 @@ export function FileContentViewer({ path, viewMode }: FileContentViewerProps) {
         data-testid="file-content-viewer-markdown"
         className="h-full w-full overflow-auto bg-[var(--oh-surface)] text-white custom-scrollbar-always [--oh-scroll-fade-from:var(--oh-surface)]"
       >
-        <div className="prose prose-sm prose-invert max-w-none p-6 [--tw-prose-body:#fff] [--tw-prose-bold:#fff] [--tw-prose-headings:#fff] [--tw-prose-lead:#fff] [--tw-prose-counters:#fff] [--tw-prose-quotes:#fff] [--tw-prose-quote-borders:var(--oh-border-subtle)] [--tw-prose-bullets:var(--oh-muted)] [--tw-prose-hr:var(--oh-border-subtle)] [--tw-prose-captions:var(--oh-muted)] [--tw-prose-kbd:#fff]">
+        <div className="prose prose-sm prose-invert max-w-none p-6 prose-pre:m-0 prose-pre:p-0 prose-pre:border-0 prose-pre:bg-transparent [--tw-prose-body:#fff] [--tw-prose-bold:#fff] [--tw-prose-headings:#fff] [--tw-prose-lead:#fff] [--tw-prose-counters:#fff] [--tw-prose-quotes:#fff] [--tw-prose-quote-borders:var(--oh-border-subtle)] [--tw-prose-bullets:var(--oh-muted)] [--tw-prose-hr:var(--oh-border-subtle)] [--tw-prose-captions:var(--oh-muted)] [--tw-prose-kbd:#fff] [--tw-prose-pre-code:inherit] [--tw-prose-pre-bg:transparent]">
           <MarkdownRenderer
             content={text ?? ""}
             includeStandard


### PR DESCRIPTION
## Summary

Fixes #16802 — code blocks in the markdown "rich" file view were rendering with excessive padding and borders around them.

The rich view wraps rendered markdown in a `prose` container (via `@tailwindcss/typography`), which applies its **own** default styling to `<pre>` elements (padding `0.85714em 1.14286em`, vertical margins `1.714em`, border-radius, and background). Those prose defaults stacked on top of the markdown components' own `p-4`/`rounded`/`border` classes, producing the boxy, padded-out look reported in the issue.

## Fix

In `src/components/features/files-tab/file-content-viewer.tsx`, the markdown prose container now explicitly resets the typography plugin's `<pre>` styling via:

- `prose-pre:m-0` — remove the `1.714em` top/bottom margins the plugin adds around each block
- `prose-pre:p-0` — remove the plugin's default padding (the code components already apply their own padding)
- `prose-pre:border-0` — remove the plugin's default border treatment
- `prose-pre:bg-transparent` — remove the plugin's default background (the components supply their own surface)
- `--tw-prose-pre-code:inherit` / `--tw-prose-pre-bg:transparent` — neutralize the plugin's pre color/background CSS variables

The markdown code-block components (`code.tsx`, `syntax-highlighter.ts`) keep their own intentionally padded, rounded styling — they just no longer have the prose plugin's defaults stacked on top.

## Verification

- No test changes needed (class-only change).
- Ran `eslint` on the modified file — clean.