### PR TITLE
fix: render SDK corrective nudge as informational message instead of user bubble

### DIFF
--- a/src/components/conversation-events/chat/event-content-helpers/should-render-event.ts
+++ b/src/components/conversation-events/chat/event-content-helpers/should-render-event.ts
@@ -25,6 +25,21 @@ const GOAL_REPROMPT_PREFIXES = [
   "Resuming a goal that was paused or interrupted.",
 ];
 
+// The SDK's empty-response corrective nudge text. When the agent's LLM response
+// contains neither a tool call nor any visible message content, the framework
+// injects this as a user-role message with source="environment" to remind the
+// agent to proceed. Match it here so the frontend can render it as a distinct
+// informational note rather than an ordinary user bubble.
+export const CORRECTIVE_NUDGE_TEXT =
+  "Your last response did not include a function call or a message. Please use a tool to proceed with the task.";
+
+export const isCorrectiveNudge = (event: OpenHandsEvent): boolean => {
+  if (!isMessageEvent(event)) return false;
+  if (event.source !== "environment") return false;
+  const text = userMessageText(event);
+  return text?.startsWith(CORRECTIVE_NUDGE_TEXT) ?? false;
+};
+
 const userMessageText = (event: MessageEvent): string | null => {
   if (event.llm_message?.role !== "user") return null;
   const content = event.llm_message.content;

--- a/src/components/conversation-events/chat/event-message-components/corrective-nudge-message.tsx
+++ b/src/components/conversation-events/chat/event-message-components/corrective-nudge-message.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { MessageEvent } from '#/types/agent-server/core';
+import InfoCircleIcon from '#/icons/info-circle.svg?react';
+import { CORRECTIVE_NUDGE_TEXT } from '../event-content-helpers/should-render-event';
+import { parseMessageFromEvent } from '../event-content-helpers/parse-message-from-event';
+
+interface CorrectiveNudgeMessageProps {
+  event: MessageEvent;
+}
+
+/**
+ * Renders the SDK's empty-response corrective nudge as a distinct
+ * informational message — italic, muted, with an info icon —
+ * so it is clearly a system/framework note rather than user input.
+ */
+export function CorrectiveNudgeMessage({ event }: CorrectiveNudgeMessageProps) {
+  const text = parseMessageFromEvent(event);
+
+  return (
+    <div
+      data-testid="corrective-nudge"
+      className="mt-6 flex w-fit max-w-full items-start gap-2 self-start rounded-xl bg-tertiary/40 px-4 py-2.5 italic text-muted-foreground last:mb-4"
+    >
+      <InfoCircleIcon
+        className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+        aria-hidden
+      />
+      <span className="text-sm leading-6 whitespace-normal [word-break:break-word]">
+        {text || CORRECTIVE_NUDGE_TEXT}
+      </span>
+    </div>
+  );
+}

--- a/src/components/conversation-events/chat/event-message.tsx
+++ b/src/components/conversation-events/chat/event-message.tsx
@@ -34,7 +34,9 @@ import { GenericEventMessageWrapper } from "./event-message-components/generic-e
 import { ThoughtEventMessage } from "./event-message-components/thought-event-message";
 import { CollapsibleThinking } from "./event-message-components/collapsible-thinking";
 import { HookExecutionEventMessage } from "./event-message-components/hook-execution-event-message";
+import { CorrectiveNudgeMessage } from "./event-message-components/corrective-nudge-message";
 import { createSkillReadyEvent } from "./event-content-helpers/create-skill-ready-event";
+import { isCorrectiveNudge } from "./event-content-helpers/should-render-event";
 import { shouldShowPlanPreview } from "./hooks/use-plan-preview-events";
 import { getReasoningContent, splitInlineThink } from "./event-thought-helpers";
 

--- a/src/components/conversation-events/chat/event-message.tsx
+++ b/src/components/conversation-events/chat/event-message.tsx
@@ -315,6 +315,13 @@ export function EventMessage({
   if (!isActionEvent(event) && !isObservationEvent(event)) {
     const messageEvent = event as MessageEvent;
 
+    // Render the SDK's empty-response corrective nudge as a distinct
+    // informational note (italic + muted + info icon) instead of an
+    // ordinary user bubble.
+    if (isCorrectiveNudge(messageEvent)) {
+      return <CorrectiveNudgeMessage event={messageEvent} />;
+    }
+
     // Check if this is a user message that should display a Skill Ready event
     if (isUserMessageEvent(event) && shouldShowSkillReadyEvent(messageEvent)) {
       return renderUserMessageWithSkillReady(


### PR DESCRIPTION
HUMAN:

前端视觉改动验证说明：fork 基于 upstream main 分支通过 Git Data API 直接提交，本地已验证代码语法与导入完整性；未在本机运行完整前端 dev server（环境限制），改动仅涉及 corrective nudge 渲染路径。

AGENT:

## Why

The SDK's empty-response corrective nudge is currently rendered as an ordinary user chat bubble, so it looks like something the user typed rather than an informational system/framework note. This is misleading (users may think they sent the message) and reads oddly.

## Summary

- Added `isCorrectiveNudge()` to `should-render-event.ts` — matches a `MessageEvent` with `source === "environment"` whose text starts with the known corrective nudge prefix (same brittle-by-design pattern as `GOAL_REPROMPT_PREFIXES`).
- New `CorrectiveNudgeMessage` component renders the nudge with an info icon, italic text, and muted/tertiary styling — clearly distinct from user/assistant bubbles.
- `event-message.tsx` routes corrective-nudge events to the new component before falling through to `UserAssistantEventMessage`.

## Issue Number

Fixes #16815

## How to Test

1. This change is isolated to the message-event render path in the Agent Canvas chat. With an LLM provider that returns an empty response (no tool call, no content), the SDK emits the corrective nudge; it should now appear as an italic, muted, info-icon note instead of a user bubble.
2. Regular user/assistant messages are untouched — they fall through the same `if (!isActionEvent...)` block to `UserAssistantEventMessage` as before.
3. Could not run the full frontend dev server locally (environment constraints); exact command history and screenshot will be added if a maintainer requests.

## Video/Screenshots

N/A for now — no local dev-server run. The change only affects the corrective-nudge render branch; no other message rendering is modified.

## Type

- [X] Bug fix

## Notes

The known text match is intentionally brittle (mirrors `GOAL_REPROMPT_PREFIXES`); a durable fix would be a dedicated `is_corrective_nudge` flag on the SDK event.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.45s · commit 18af949  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 4/4 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 8.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature af4ce4c0d1425e0f51cff3363967f5ae193f63d6d4c96d68ce47313496affa2e -->
<!-- jev-fast-audit:end -->
