### PR TITLE
feat: add OH_FRONTEND_ONLY and OH_BACKEND_ONLY entrypoint modes

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -52,10 +52,10 @@
 #                          Override in production when the external URL differs.
 #   AUTOMATION_WORKSPACE_BASE – Directory for automation run workspaces
 #                          (default: ~/.openhands/workspaces)
-#   OPENHANDS_FRONTEND_ONLY – If "true", skip the agent-server and automation
+#   OH_FRONTEND_ONLY – If "true", skip the agent-server and automation
 #                          backends; only the static server (frontend + proxy)
 #                          is started
-#   OPENHANDS_BACKEND_ONLY – If "true", skip the static server (frontend +
+#   OH_BACKEND_ONLY – If "true", skip the static server (frontend +
 #                          proxy); only the backends are started
 #   Any agent-server or automation env vars are passed through.
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -288,12 +288,12 @@ cleanup() {
 }
 trap cleanup EXIT SIGINT SIGTERM
 
-if [ "${OPENHANDS_FRONTEND_ONLY:-}" = "true" ] && [ "${OPENHANDS_BACKEND_ONLY:-}" = "true" ]; then
-  log_error "OPENHANDS_FRONTEND_ONLY and OPENHANDS_BACKEND_ONLY cannot both be true."
+if [ "${OH_FRONTEND_ONLY:-}" = "true" ] && [ "${OH_BACKEND_ONLY:-}" = "true" ]; then
+  log_error "OH_FRONTEND_ONLY and OH_BACKEND_ONLY cannot both be true."
   exit 1
 fi
 
-if [ "${OPENHANDS_FRONTEND_ONLY:-}" = "true" ]; then
+if [ "${OH_FRONTEND_ONLY:-}" = "true" ]; then
 log "Frontend-Only Mode: Skipping Agent Server, Automation, and Port Checks."
 else
 
@@ -378,10 +378,10 @@ wait_for_port "$AUTOMATION_PORT" "Automation Server" 60 &
 WAIT_PID2=$!
 wait "$WAIT_PID1" "$WAIT_PID2"
 
-fi # End of OPENHANDS_FRONTEND_ONLY skip block
+fi # End of OH_FRONTEND_ONLY skip block
 
 # ── 4. Start static server (frontend + proxy) ────────────────────────────────
-if [ "${OPENHANDS_BACKEND_ONLY:-}" = "true" ]; then
+if [ "${OH_BACKEND_ONLY:-}" = "true" ]; then
 log "Backend-Only Mode: Frontend and Proxy disabled. Keeping backend services alive."
 # Same trap-friendly pattern as the ingress watchdog below: the builtin
 # `wait` is interrupted immediately by SIGTERM/SIGINT so cleanup() fires

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -383,10 +383,12 @@ fi # End of OH_FRONTEND_ONLY skip block
 # ── 4. Start static server (frontend + proxy) ────────────────────────────────
 if [ "${OH_BACKEND_ONLY:-}" = "true" ]; then
 log "Backend-Only Mode: Frontend and Proxy disabled. Keeping backend services alive."
-# Same trap-friendly pattern as the ingress watchdog below: the builtin
-# `wait` is interrupted immediately by SIGTERM/SIGINT so cleanup() fires
-# without delay.
-while true; do sleep 10 & wait $!; done
+# The builtin `wait` is interrupted immediately by trapped SIGTERM/SIGINT,
+# so cleanup() fires without delay; otherwise it returns once every backend
+# has exited, so the container stops rather than idling with nothing running.
+wait "${PIDS[@]}"
+log_error "Backend services exited"
+exit 1
 fi
 
 log "Starting frontend + proxy on port $PORT..."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -52,6 +52,11 @@
 #                          Override in production when the external URL differs.
 #   AUTOMATION_WORKSPACE_BASE – Directory for automation run workspaces
 #                          (default: ~/.openhands/workspaces)
+#   OPENHANDS_FRONTEND_ONLY – If "true", skip the agent-server and automation
+#                          backends; only the static server (frontend + proxy)
+#                          is started
+#   OPENHANDS_BACKEND_ONLY – If "true", skip the static server (frontend +
+#                          proxy); only the backends are started
 #   Any agent-server or automation env vars are passed through.
 # ═══════════════════════════════════════════════════════════════════════════════
 set -uo pipefail
@@ -283,6 +288,15 @@ cleanup() {
 }
 trap cleanup EXIT SIGINT SIGTERM
 
+if [ "${OPENHANDS_FRONTEND_ONLY:-}" = "true" ] && [ "${OPENHANDS_BACKEND_ONLY:-}" = "true" ]; then
+  log_error "OPENHANDS_FRONTEND_ONLY and OPENHANDS_BACKEND_ONLY cannot both be true."
+  exit 1
+fi
+
+if [ "${OPENHANDS_FRONTEND_ONLY:-}" = "true" ]; then
+log "Frontend-Only Mode: Skipping Agent Server, Automation, and Port Checks."
+else
+
 # ── 1. Start Agent Server ────────────────────────────────────────────────────
 log "Starting agent-server on port $AGENT_SERVER_PORT..."
 
@@ -364,8 +378,23 @@ wait_for_port "$AUTOMATION_PORT" "Automation Server" 60 &
 WAIT_PID2=$!
 wait "$WAIT_PID1" "$WAIT_PID2"
 
+fi # End of OPENHANDS_FRONTEND_ONLY skip block
+
 # ── 4. Start static server (frontend + proxy) ────────────────────────────────
+if [ "${OPENHANDS_BACKEND_ONLY:-}" = "true" ]; then
+log "Backend-Only Mode: Frontend and Proxy disabled. Keeping backend services alive."
+# Same trap-friendly pattern as the ingress watchdog below: the builtin
+# `wait` is interrupted immediately by SIGTERM/SIGINT so cleanup() fires
+# without delay.
+while true; do sleep 10 & wait $!; done
+fi
+
 log "Starting frontend + proxy on port $PORT..."
+
+# AUTOMATION_BASE_URL is normally exported in section 2; re-derive the same
+# default here so frontend-only mode (which skips that section) still works
+# under `set -u`.
+export AUTOMATION_BASE_URL="${AUTOMATION_BASE_URL:-http://127.0.0.1:${PORT}}"
 
 # Describe the local runtime services so the frontend can populate the agent's
 # <RUNTIME_SERVICES> system-prompt block (without it the agent does not know how


### PR DESCRIPTION
HUMAN:

Reviewed the diff and the stubbed smoke-test output below; the change only touches `docker/entrypoint.sh`.

AGENT:

Verified end-to-end by running `docker/entrypoint.sh` directly with stub binaries on PATH standing in for `openhands-agent-server`, `uvicorn` (both listen on their assigned ports via `python3 -m http.server`) and `node` (static-server stub). Commands and logs:

**Frontend-only** — backends and port checks skipped, static server started:

```
$ OH_FRONTEND_ONLY=true bash docker/entrypoint.sh
[agent-canvas] Frontend-Only Mode: Skipping Agent Server, Automation, and Port Checks.
[agent-canvas] Starting frontend + proxy on port 8000...
[agent-canvas] All services started. Unified entry point: http://0.0.0.0:8000/
[stub static-server] listening (args ok)
[agent-canvas] Shutting down...        # on SIGTERM
```

**Backend-only** — backends start, port checks pass, no static server, SIGTERM cleanup fires promptly:

```
$ OH_BACKEND_ONLY=true bash docker/entrypoint.sh
[agent-canvas] Starting agent-server on port 18000...
[agent-canvas] Starting automation server on port 18001...
[agent-canvas] Automation Server is ready on port 18001
[agent-canvas] Agent Server is ready on port 18000
[agent-canvas] Backend-Only Mode: Frontend and Proxy disabled. Keeping backend services alive.
[agent-canvas] Shutting down...        # on SIGTERM
```

**Both set** — fails fast:

```
$ OH_FRONTEND_ONLY=true OH_BACKEND_ONLY=true bash docker/entrypoint.sh
[agent-canvas] ERROR: OH_FRONTEND_ONLY and OH_BACKEND_ONLY cannot both be true.
```

`bash -n docker/entrypoint.sh` passes, and the `>>> vscode-config` markers extracted by `__tests__/scripts/docker-vscode-route-sync.test.ts` are untouched.

---

## Why

The all-in-one image always starts every service. Running only the frontend (against an external agent-server) or only the backends (with the frontend served elsewhere) currently requires replacing the entrypoint and duplicating its env-resolution and key-generation logic.

## Summary

- Add `OH_FRONTEND_ONLY=true`: skips the agent-server and automation backends and their port checks; only the static server (frontend + proxy) starts. `AUTOMATION_BASE_URL` gets its usual default re-derived in the static-server section since the section that normally exports it is skipped (`set -u`).
- Add `OH_BACKEND_ONLY=true`: skips the static server; `wait`s on the backend PIDs so the container stays alive while they run, exits if they all stop, and still responds immediately to SIGTERM/SIGINT via the existing trap.
- Setting both to `true` errors out at startup; both variables are documented in the header env list. Default behavior is unchanged.

## Issue Number

Fixes #16824

## How to Test

Build the image, then:

1. `docker run -e OH_FRONTEND_ONLY=true -p 8000:8000 <image>` — only the static server starts (no agent-server/automation processes, no port-wait delay); the frontend is served on `:8000`.
2. `docker run -e OH_BACKEND_ONLY=true -p 18000:18000 -p 18001:18001 <image>` — only the backends start and the container stays up; `docker stop` terminates it promptly.
3. `docker run -e OH_FRONTEND_ONLY=true -e OH_BACKEND_ONLY=true <image>` — exits immediately with an error.
4. `docker run <image>` with neither variable — behavior identical to before.

## Video/Screenshots

Terminal logs from the stubbed runs are included in the AGENT section above; this change has no UI surface.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `exit 1` paths still route through the `EXIT` trap whose `cleanup()` ends with `exit 0` — same pre-existing behavior as the static-server watchdog, left unchanged for consistency.
