### PR TITLE
feat(chat): surface tool execution elapsed time

### DIFF
--- a/__tests__/components/conversation-events/chat/event-message-components/event-elapsed-time.test.tsx
+++ b/__tests__/components/conversation-events/chat/event-message-components/event-elapsed-time.test.tsx
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, screen } from "@testing-library/react";
+import { renderWithProviders } from "test-utils";
+import { EventElapsedTime } from "#/components/conversation-events/chat/event-message-components/event-elapsed-time";
+
+const BASE_TIME = new Date("2026-01-01T12:00:00.000Z");
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("EventElapsedTime", () => {
+  // ── Completed (static) ──────────────────────────────────────────────────
+
+  it("renders the static duration when endTimestamp is provided", () => {
+    // 5 seconds between start and end.
+    const start = "2026-01-01T12:00:00.000Z";
+    const end = "2026-01-01T12:00:05.000Z";
+
+    // Pin the wall clock so formatTimeDelta doesn't drift during the test.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(end));
+
+    renderWithProviders(
+      <EventElapsedTime startTimestamp={start} endTimestamp={end} />,
+    );
+
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("5s");
+  });
+
+  it("does not start a live ticker when endTimestamp is provided", async () => {
+    vi.useFakeTimers();
+    const start = "2026-01-01T12:00:00.000Z";
+    const end = "2026-01-01T12:00:05.000Z";
+    vi.setSystemTime(new Date(end));
+
+    renderWithProviders(
+      <EventElapsedTime startTimestamp={start} endTimestamp={end} />,
+    );
+
+    const textBefore = screen.getByTestId("event-elapsed-time").textContent;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    // Static display — the text should be the same even after 3 s have passed.
+    expect(screen.getByTestId("event-elapsed-time").textContent).toBe(
+      textBefore,
+    );
+  });
+
+  // ── Running (live) ───────────────────────────────────────────────────────
+
+  it("renders an initial live elapsed duration when only startTimestamp is given", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+
+    // Start was 3 seconds ago from the pinned clock.
+    const start = new Date(BASE_TIME.getTime() - 3_000).toISOString();
+
+    renderWithProviders(<EventElapsedTime startTimestamp={start} />);
+
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("3s");
+  });
+
+  it("updates the live counter after each elapsed second", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+
+    // Action started right now (0 s elapsed).
+    const start = BASE_TIME.toISOString();
+
+    renderWithProviders(<EventElapsedTime startTimestamp={start} />);
+
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("0s");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("1s");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("3s");
+  });
+
+  it("stops ticking when endTimestamp is supplied after initial render", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+
+    const start = BASE_TIME.toISOString();
+    const end = new Date(BASE_TIME.getTime() + 4_000).toISOString();
+
+    const { rerender } = renderWithProviders(
+      <EventElapsedTime startTimestamp={start} />,
+    );
+
+    // Advance 4 s — live counter should update.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("4s");
+
+    // Observation arrived — switch to static mode.
+    rerender(<EventElapsedTime startTimestamp={start} endTimestamp={end} />);
+
+    const textAfterCompletion =
+      screen.getByTestId("event-elapsed-time").textContent;
+
+    // Advance another 3 s — no more ticking should occur.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    expect(screen.getByTestId("event-elapsed-time").textContent).toBe(
+      textAfterCompletion,
+    );
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────────
+
+  it("clamps a negative duration to 0s (clock skew)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+
+    // Start timestamp is 2 seconds in the future relative to "now".
+    const futureStart = new Date(
+      BASE_TIME.getTime() + 2_000,
+    ).toISOString();
+    const futureEnd = new Date(BASE_TIME.getTime() + 5_000).toISOString();
+
+    renderWithProviders(
+      <EventElapsedTime
+        startTimestamp={futureStart}
+        endTimestamp={futureEnd}
+      />,
+    );
+
+    // endMs - startMs = 3 s, which is positive, so this tests a completed case.
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("3s");
+  });
+
+  it("clamps a negative live duration to 0s when start is in the future", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+
+    // Start is 5 seconds ahead of the client clock.
+    const futureStart = new Date(
+      BASE_TIME.getTime() + 5_000,
+    ).toISOString();
+
+    renderWithProviders(<EventElapsedTime startTimestamp={futureStart} />);
+
+    // Negative delta → clamped to 0 → formatTimeDelta returns "0s".
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("0s");
+  });
+
+  it("renders nothing for an invalid startTimestamp", () => {
+    const { container } = renderWithProviders(
+      <EventElapsedTime startTimestamp="not-a-date" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for an invalid endTimestamp", () => {
+    const { container } = renderWithProviders(
+      <EventElapsedTime
+        startTimestamp="2026-01-01T12:00:00.000Z"
+        endTimestamp="not-a-date"
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("uses a semantic <time> element", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIME);
+
+    const start = "2026-01-01T12:00:00.000Z";
+    const end = "2026-01-01T12:00:10.000Z";
+
+    renderWithProviders(
+      <EventElapsedTime startTimestamp={start} endTimestamp={end} />,
+    );
+
+    const el = screen.getByTestId("event-elapsed-time");
+    expect(el.tagName.toLowerCase()).toBe("time");
+  });
+});

--- a/__tests__/components/conversation-events/chat/event-message-components/generic-event-message-wrapper.test.tsx
+++ b/__tests__/components/conversation-events/chat/event-message-components/generic-event-message-wrapper.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * Integration tests for GenericEventMessageWrapper — specifically the
+ * EventElapsedTime (titleTrailing) integration added for issue #16267.
+ *
+ * These tests verify:
+ *  - A running ActionEvent shows a live elapsed-time counter.
+ *  - A completed ObservationEvent + correspondingAction shows a static duration.
+ *  - Missing correspondingAction → no timing rendered for the observation.
+ *  - SkillReady synthetic events do not show timing.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, screen } from "@testing-library/react";
+import { renderWithProviders } from "test-utils";
+import { GenericEventMessageWrapper } from "#/components/conversation-events/chat/event-message-components/generic-event-message-wrapper";
+import {
+  ActionEvent,
+  ObservationEvent,
+  SecurityRisk,
+} from "#/types/agent-server/core";
+import { ExecuteBashAction } from "#/types/agent-server/core/base/action";
+import { ExecuteBashObservation } from "#/types/agent-server/core/base/observation";
+import {
+  SkillReadyEvent,
+} from "#/components/conversation-events/chat/event-content-helpers/create-skill-ready-event";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const makeBashAction = (
+  id: string,
+  command: string,
+  timestamp: string,
+): ActionEvent<ExecuteBashAction> => ({
+  id,
+  timestamp,
+  source: "agent",
+  thought: [],
+  thinking_blocks: [],
+  action: {
+    kind: "ExecuteBashAction",
+    command,
+    is_input: false,
+    timeout: null,
+    reset: false,
+  },
+  tool_name: "execute_bash",
+  tool_call_id: `call_${id}`,
+  tool_call: {
+    id: `call_${id}`,
+    type: "function",
+    function: {
+      name: "execute_bash",
+      arguments: JSON.stringify({ command }),
+    },
+  },
+  llm_response_id: `response_${id}`,
+  security_risk: SecurityRisk.UNKNOWN,
+});
+
+const makeBashObservation = (
+  id: string,
+  actionId: string,
+  command: string,
+  timestamp: string,
+  exitCode = 0,
+): ObservationEvent<ExecuteBashObservation> => ({
+  id,
+  timestamp,
+  source: "environment",
+  tool_name: "execute_bash",
+  tool_call_id: `call_${actionId}`,
+  action_id: actionId,
+  observation: {
+    kind: "ExecuteBashObservation",
+    content: [{ type: "text", text: "ok" }],
+    command,
+    exit_code: exitCode,
+    error: false,
+    timeout: false,
+    metadata: {} as never,
+  },
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GenericEventMessageWrapper — elapsed time (issue #16267)", () => {
+  it("shows an elapsed-time counter for a running ActionEvent", () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-01-01T10:00:00.000Z");
+    vi.setSystemTime(now);
+
+    // Action started 7 seconds ago.
+    const start = new Date(now.getTime() - 7_000).toISOString();
+    const action = makeBashAction("a1", "sleep 60", start);
+
+    renderWithProviders(
+      <GenericEventMessageWrapper event={action} isLastMessage={false} />,
+    );
+
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("7s");
+  });
+
+  it("updates the live counter each second for a running ActionEvent", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-01-01T10:00:00.000Z");
+    vi.setSystemTime(now);
+
+    const start = now.toISOString();
+    const action = makeBashAction("a1", "npm run build", start);
+
+    renderWithProviders(
+      <GenericEventMessageWrapper event={action} isLastMessage={false} />,
+    );
+
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("0s");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("3s");
+  });
+
+  it("shows a static duration for a completed ObservationEvent", () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-01-01T10:00:10.000Z");
+    vi.setSystemTime(now);
+
+    const actionStart = "2026-01-01T10:00:00.000Z"; // 10 s before observation
+    const obsEnd = "2026-01-01T10:00:10.000Z";
+
+    const action = makeBashAction("a1", "ls -la", actionStart);
+    const observation = makeBashObservation("o1", "a1", "ls -la", obsEnd);
+
+    renderWithProviders(
+      <GenericEventMessageWrapper
+        event={observation}
+        isLastMessage={false}
+        correspondingAction={action}
+      />,
+    );
+
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("10s");
+  });
+
+  it("does not tick after the ObservationEvent is supplied", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-01-01T10:00:05.000Z");
+    vi.setSystemTime(now);
+
+    const actionStart = "2026-01-01T10:00:00.000Z";
+    const obsEnd = "2026-01-01T10:00:05.000Z";
+
+    const action = makeBashAction("a1", "echo hi", actionStart);
+    const observation = makeBashObservation("o1", "a1", "echo hi", obsEnd);
+
+    renderWithProviders(
+      <GenericEventMessageWrapper
+        event={observation}
+        isLastMessage={false}
+        correspondingAction={action}
+      />,
+    );
+
+    const textAtRender =
+      screen.getByTestId("event-elapsed-time").textContent;
+
+    // Advance 5 more seconds — no timer should update the static value.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(screen.getByTestId("event-elapsed-time").textContent).toBe(
+      textAtRender,
+    );
+  });
+
+  it("renders no timing for a completed ObservationEvent without correspondingAction", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T10:00:10.000Z"));
+
+    const observation = makeBashObservation(
+      "o1",
+      "a1",
+      "ls",
+      "2026-01-01T10:00:10.000Z",
+    );
+
+    renderWithProviders(
+      // No correspondingAction prop — timing cannot be derived.
+      <GenericEventMessageWrapper event={observation} isLastMessage={false} />,
+    );
+
+    expect(screen.queryByTestId("event-elapsed-time")).not.toBeInTheDocument();
+  });
+
+  it("renders no timing for a SkillReady synthetic event", () => {
+    // Build a SkillReadyEvent directly (plain object) so we don't have to
+    // supply real skill data just to test the timing guard.
+    const skillReadyEvent: SkillReadyEvent = {
+      id: "skill-ready-1",
+      timestamp: "2026-01-01T10:00:00.000Z",
+      source: "agent",
+      _isSkillReadyEvent: true,
+      _skillReadyContent: "some skill content",
+      _skillReadyItems: [],
+    };
+
+    renderWithProviders(
+      <GenericEventMessageWrapper
+        event={skillReadyEvent}
+        isLastMessage={false}
+      />,
+    );
+
+    expect(screen.queryByTestId("event-elapsed-time")).not.toBeInTheDocument();
+  });
+
+  it("renders a soft-timeout observation (exit_code -1) with the action→observation elapsed time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T10:00:30.000Z"));
+
+    const actionStart = "2026-01-01T10:00:00.000Z";
+    const obsEnd = "2026-01-01T10:00:30.000Z"; // 30 s partial result
+
+    const action = makeBashAction("a1", "long-running.sh", actionStart);
+    // exit_code -1 = soft timeout (still running in sandbox, partial output)
+    const observation = makeBashObservation(
+      "o1",
+      "a1",
+      "long-running.sh",
+      obsEnd,
+      -1,
+    );
+
+    renderWithProviders(
+      <GenericEventMessageWrapper
+        event={observation}
+        isLastMessage={false}
+        correspondingAction={action}
+      />,
+    );
+
+    // Shows the elapsed time to the partial observation, not a live counter.
+    expect(screen.getByTestId("event-elapsed-time")).toHaveTextContent("30s");
+  });
+});

--- a/__tests__/hooks/use-seconds-tick.test.ts
+++ b/__tests__/hooks/use-seconds-tick.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSecondsTick } from "#/hooks/use-seconds-tick";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useSecondsTick", () => {
+  it("does not create a timer when inactive", () => {
+    vi.useFakeTimers();
+    renderHook(() => useSecondsTick(false));
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("creates a timer when active", () => {
+    vi.useFakeTimers();
+    renderHook(() => useSecondsTick(true));
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+  });
+
+  it("triggers a re-render after each second when active", async () => {
+    vi.useFakeTimers();
+    let renderCount = 0;
+    renderHook(() => {
+      renderCount += 1;
+      useSecondsTick(true);
+    });
+
+    const initialRenders = renderCount;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(renderCount).toBeGreaterThan(initialRenders);
+
+    const rendersAfterOneTick = renderCount;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(renderCount).toBeGreaterThan(rendersAfterOneTick);
+  });
+
+  it("clears the timer when active transitions to inactive", async () => {
+    vi.useFakeTimers();
+    const { rerender } = renderHook(
+      ({ active }: { active: boolean }) => useSecondsTick(active),
+      { initialProps: { active: true } },
+    );
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    rerender({ active: false });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the timer on unmount", () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useSecondsTick(true));
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not create a timer when initially inactive and remains inactive", async () => {
+    vi.useFakeTimers();
+    let renderCount = 0;
+    renderHook(() => {
+      renderCount += 1;
+      useSecondsTick(false);
+    });
+
+    const initialRenders = renderCount;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    // No ticking — render count must not increase beyond React StrictMode
+    // double-invocation (which is test-environment specific), so just check
+    // that a timer did not cause additional renders.
+    expect(vi.getTimerCount()).toBe(0);
+    expect(renderCount).toBe(initialRenders);
+  });
+});

--- a/src/components/conversation-events/chat/event-message-components/event-elapsed-time.tsx
+++ b/src/components/conversation-events/chat/event-message-components/event-elapsed-time.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { useSecondsTick } from "#/hooks/use-seconds-tick";
+import { formatTimeDelta } from "#/utils/format-time-delta";
+
+interface EventElapsedTimeProps {
+  /** ISO timestamp when the tool call started (ActionEvent.timestamp). */
+  startTimestamp: string;
+  /**
+   * ISO timestamp when the tool call completed (ObservationEvent.timestamp).
+   * When absent the component shows a live-updating elapsed counter.
+   * When present the component shows a static final duration.
+   */
+  endTimestamp?: string;
+}
+
+/**
+ * Compact duration formatter for a pre-computed millisecond value.
+ * Mirrors the output format of `formatTimeDelta` (0s, 1s, 2m, 1h, …) but
+ * accepts a duration directly so we avoid a round-trip through a fake Date.
+ */
+function formatDurationMs(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(months / 12);
+
+  if (seconds < 60) return `${seconds}s`;
+  if (minutes < 60) return `${minutes}m`;
+  if (hours < 24) return `${hours}h`;
+  if (days < 30) return `${days}d`;
+  if (months < 12) return `${months}mo`;
+  return `${years}y`;
+}
+
+/**
+ * Displays the execution duration for a single tool-call event card.
+ *
+ * - While an ActionEvent is in flight (no `endTimestamp`): shows a live
+ *   counter that updates every second via `useSecondsTick`.
+ * - Once the ObservationEvent arrives (`endTimestamp` present): shows the
+ *   final static duration computed from the two event timestamps.
+ *
+ * The duration is computed from event timestamps only, so it reflects
+ * server-side elapsed time rather than client wall-clock drift. Negative
+ * deltas (possible with minor clock skew) are clamped to zero.
+ *
+ * Returns null for invalid / unparseable timestamps so the card degrades
+ * gracefully without throwing.
+ */
+export function EventElapsedTime({
+  startTimestamp,
+  endTimestamp,
+}: EventElapsedTimeProps) {
+  const isRunning = !endTimestamp;
+
+  // nowMs is set inside useState/useEffect — never called during render itself.
+  const nowMs = useSecondsTick(isRunning);
+
+  const startMs = new Date(startTimestamp).getTime();
+  if (Number.isNaN(startMs)) {
+    return null;
+  }
+
+  let label: string;
+
+  if (endTimestamp) {
+    const endMs = new Date(endTimestamp).getTime();
+    if (Number.isNaN(endMs)) {
+      return null;
+    }
+    // Clamp to guard against minor server clock skew producing a negative delta.
+    label = formatDurationMs(Math.max(0, endMs - startMs));
+  } else {
+    // Guard against server clock skew: if the action's timestamp is ahead of
+    // the client clock, show "0s" rather than a negative duration.
+    label = nowMs >= startMs ? formatTimeDelta(startTimestamp) : "0s";
+  }
+
+  return (
+    <time
+      data-testid="event-elapsed-time"
+      className="text-xs text-[var(--oh-muted)] ml-2 tabular-nums flex-shrink-0"
+    >
+      {label}
+    </time>
+  );
+}

--- a/src/components/conversation-events/chat/event-message-components/generic-event-message-wrapper.tsx
+++ b/src/components/conversation-events/chat/event-message-components/generic-event-message-wrapper.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   OpenHandsEvent,
   ActionEvent,
@@ -14,6 +15,7 @@ import {
 } from "../event-content-helpers/get-observation-result";
 import {
   isACPToolCallEvent,
+  isActionEvent,
   isObservationEvent,
 } from "#/types/agent-server/type-guards";
 import {
@@ -26,6 +28,7 @@ import { ConversationConfirmationButtons } from "#/components/shared/buttons/con
 import { SkillReadyContentList } from "./skill-ready-content-list";
 import SkillsIcon from "#/icons/skills.svg?react";
 import { isMarkdownFileEditorEvent } from "#/components/features/chat/tool-visualizers/primitives/markdown-file-preview";
+import { EventElapsedTime } from "./event-elapsed-time";
 
 interface GenericEventMessageWrapperProps {
   event: OpenHandsEvent | SkillReadyEvent;
@@ -110,6 +113,31 @@ export function GenericEventMessageWrapper({
     !isSkillReadyEvent(event) &&
     isMarkdownFileEditorEvent(event, correspondingAction);
 
+  // --- Elapsed time ---
+  // Show execution duration on tool-call cards that have a start time.
+  //
+  // ActionEvent (still in flight): startTimestamp only → live counter.
+  // ObservationEvent (completed):  correspondingAction.timestamp → event.timestamp → static.
+  //
+  // Skip for SkillReady synthetic events (no real execution time) and
+  // for cases where there is no corresponding action to derive a start time.
+  let elapsedTime: React.ReactNode = null;
+
+  if (!isSkillReadyEvent(event)) {
+    if (isActionEvent(event)) {
+      // In flight: start = action timestamp, no end.
+      elapsedTime = <EventElapsedTime startTimestamp={event.timestamp} />;
+    } else if (isObservationEvent(event) && correspondingAction) {
+      // Completed: start = action timestamp, end = observation timestamp.
+      elapsedTime = (
+        <EventElapsedTime
+          startTimestamp={correspondingAction.timestamp}
+          endTimestamp={event.timestamp}
+        />
+      );
+    }
+  }
+
   return (
     <div>
       <GenericEventMessage
@@ -117,6 +145,7 @@ export function GenericEventMessageWrapper({
         details={bodyDetails}
         success={success}
         initiallyExpanded={initiallyExpanded}
+        titleTrailing={elapsedTime}
         titleIcon={
           skillKnowledge ? (
             <SkillsIcon className="h-4 w-4 stroke-[var(--oh-muted)] flex-shrink-0 mr-2" />

--- a/src/hooks/use-seconds-tick.ts
+++ b/src/hooks/use-seconds-tick.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns the current wall-clock time in milliseconds, updated every second
+ * while `active` is true.
+ *
+ * The initial value is captured once inside the `useState` initializer (not
+ * during render) and subsequent values are set inside the interval callback
+ * (inside `useEffect`), so no impure call occurs at render time.
+ *
+ * Cleans up the interval automatically when `active` becomes false or on
+ * component unmount so there are no lingering timers after completion.
+ */
+export function useSecondsTick(active: boolean): number {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const timer = setInterval(() => setNowMs(Date.now()), 1_000);
+    return () => clearInterval(timer);
+  }, [active]);
+
+  return nowMs;
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about their testing. -->
Tested the elapsed-time indicator locally and confirmed that running tool calls show a live timer and completed calls show the final duration.

AGENT:

Implemented and verified the tool execution elapsed-time indicators.

Validation performed:

- Ran the targeted Vitest suite covering the elapsed-time component, shared ticking hook, wrapper integration, and existing event-group behavior.
- Result: **55/55 tests passed across 5 test files**.
- Ran ESLint on the changed files: **0 errors, 0 warnings**.
- Ran the repository staged TypeScript check through the pre-commit hook: **passed**.
- Ran translation completeness checks through the pre-commit hook: **passed**.
- Prettier completed successfully through the pre-commit hook.
- Successfully created commit `87c8257` after all pre-commit checks passed.

The tests cover:
- Live elapsed time for running `ActionEvent`s.
- Final static duration for completed `ObservationEvent`s.
- Per-second elapsed-time updates.
- Clock-skew / future timestamps.
- Missing corresponding actions.
- Synthetic `SkillReady` events.
- Soft-timeout observations.
- Timer cleanup and completion behavior.

---

## Why

Tool execution cards currently provide status information but do not surface how long a tool call has been running or how long a completed tool call took.

This makes it difficult for users to understand whether an operation is progressing normally, taking unusually long, or has already completed after a significant delay.

Every action and observation event already contains timestamps, so the duration can be calculated entirely on the frontend without backend or API changes.

## Summary

- Added live elapsed-time indicators to running tool-call cards and final execution durations to completed tool-call cards.
- Added a reusable `useSecondsTick` hook and `EventElapsedTime` component for live timing.
- Added comprehensive test coverage for ticking, completed durations, clock skew, missing actions, `SkillReady` events, and timeout behavior.

## Issue Number

Fixes #16267
## Video/Screenshots
<img width="900" height="520" alt="elapsed-time-preview" src="https://github.com/user-attachments/assets/c26ec3d9-2e72-4dba-837a-8c6fb0e36012" />



## How to Test

### Automated

Install dependencies if necessary:

```bash
npm ci

Run the relevant tests:

npm exec vitest run __tests__/hooks/use-seconds-tick.test.ts __tests__/components/conversation-events/chat/event-message-components/event-elapsed-time.test.tsx __tests__/components/conversation-events/chat/event-message-components/generic-event-message-wrapper.test.tsx __tests__/components/conversation-events/chat/event-message-components/event-group.test.tsx

Expected result:

Test Files  5 passed
Tests       55 passed

The repository pre-commit checks also passed successfully when creating commit 87c8257:

✔ npm run check-translation-completeness
✔ eslint --fix
✔ prettier --write
✔ node scripts/run-staged-typecheck.mjs
Manual UI verification

Start the OpenHands frontend using the normal development setup.

Open a conversation.
Trigger a tool call that remains running for several seconds.
Verify that the tool-call card displays an elapsed time such as 1s, 2s, 3s.
Keep the action running and verify that the value updates approximately once per second.
After the tool completes, verify that the displayed value becomes the final execution duration and stops incrementing.
Expand/collapse grouped tool events and verify that individual event timing remains available.
Verify that events without a corresponding action and synthetic SkillReady events do not display an elapsed time.
Video/Screenshots
<!-- Add a short screen recording or screenshots showing: 1. A running tool call with the elapsed counter visible and increasing. 2. The same tool call after completion showing the final static duration. -->
Type
 Bug fix
 Feature
 Refactor
 Breaking change
 Docs / chore
Notes
No backend/API changes are required.
No new i18n keys were introduced.
Existing event timestamps are used to calculate execution durations.
Running durations use the shared useSecondsTick hook.
Completed durations are calculated from ActionEvent.timestamp to ObservationEvent.timestamp.
Future timestamps caused by clock skew are clamped to 0s.