### PR TITLE
fix: gate onboarding advance on backend connection validation

### DIFF
--- a/__tests__/components/onboarding/onboarding-modal.test.tsx
+++ b/__tests__/components/onboarding/onboarding-modal.test.tsx
@@ -23,6 +23,7 @@ import * as telemetry from "#/services/telemetry";
 
 const llmSettingsScreenMock = vi.hoisted(() => vi.fn());
 const getServerInfoMock = vi.hoisted(() => vi.fn());
+const getSettingsMock = vi.hoisted(() => vi.fn());
 let captureMock: MockInstance<typeof telemetry.trackEvent>;
 
 // Both the backend status badge in the embedded edit form and the
@@ -38,7 +39,7 @@ vi.mock("@openhands/typescript-client/clients", () => ({
   // `LlmSettingsScreen` is stubbed, so provide the minimal client it needs.
   SettingsClient: vi.fn(function SettingsClientMock() {
     return {
-      getSettings: vi.fn().mockResolvedValue({}),
+      getSettings: vi.fn(() => getSettingsMock()),
     };
   }),
 }));
@@ -214,12 +215,16 @@ beforeEach(() => {
   // leaked from a prior test. Covers `llmSettingsScreenMock` too.
   vi.clearAllMocks();
   getServerInfoMock.mockReset();
+  getSettingsMock.mockReset();
   getServerInfoMock.mockImplementation((options?: { host?: string }) => {
     if (options?.host?.startsWith("https://127.0.0.1:8000")) {
       return Promise.reject(new Error("Failed to fetch"));
     }
     return Promise.resolve({ version: "1.28.0" });
   });
+  // Default: SettingsClient.getSettings() succeeds. Individual tests that
+  // need a 401 for invalid API key validation override this.
+  getSettingsMock.mockResolvedValue({});
   // ChooseAgentStep's Next button now persists the selection via
   // saveSettings before advancing. Stub it so the rest of the flow
   // (which these tests focus on) isn't gated on a real HTTP call.
@@ -646,6 +651,58 @@ describe("OnboardingModal", () => {
     ).toHaveTextContent("BACKEND$CONNECTION_TEST_FAILED");
     expect(screen.getByTestId("onboarding-backend-error")).toHaveTextContent(
       "Disconnected",
+    );
+  });
+
+  it("stays on the backend step when the API key is invalid", async () => {
+    // Regression test for #16804: testBackendConnection now calls
+    // SettingsClient.getSettings() which returns 401 for an invalid API
+    // key. The user must stay on the backend step with an error rather
+    // than advancing to the next onboarding step.
+    window.localStorage.clear();
+    vi.stubEnv("VITE_BACKEND_BASE_URL", "");
+    vi.stubEnv("VITE_SESSION_API_KEY", "");
+    delete (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_SESSION_API_KEY__;
+    __resetActiveStoreForTests();
+
+    // Simulate a 401 from SettingsClient.getSettings() — the SDK throws
+    // an HttpError with name="HttpError" and status=401.
+    const httpError = Object.assign(new Error("Unauthorized"), {
+      name: "HttpError",
+      status: 401,
+    });
+    getSettingsMock.mockRejectedValue(httpError);
+
+    renderModal();
+    const user = userEvent.setup();
+
+    await user.clear(screen.getByTestId("onboarding-backend-host"));
+    await user.type(
+      screen.getByTestId("onboarding-backend-host"),
+      "http://localhost:8000",
+    );
+    await user.clear(screen.getByTestId("onboarding-backend-api-key"));
+    await user.type(
+      screen.getByTestId("onboarding-backend-api-key"),
+      "invalid-key",
+    );
+    await user.click(screen.getByTestId("onboarding-backend-next"));
+
+    // Error banner must be visible.
+    expect(
+      await screen.findByTestId("onboarding-backend-error"),
+    ).toHaveTextContent("BACKEND$CONNECTION_TEST_FAILED");
+    expect(screen.getByTestId("onboarding-backend-error")).toHaveTextContent(
+      "Invalid API key",
+    );
+    // User must NOT have advanced — the backend step is still active.
+    expect(
+      screen.getByTestId("onboarding-step-check-backend"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-modal")).toHaveAttribute(
+      "data-current-step",
+      "0",
     );
   });
 

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, Globe, Info, Monitor } from "lucide-react";
-import { ServerClient } from "@openhands/typescript-client/clients";
+import {
+  ServerClient,
+  SettingsClient,
+} from "@openhands/typescript-client/clients";
 import OpenHandsLogoWhite from "#/assets/branding/openhands-logo-white.svg?react";
 import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
 import {
@@ -15,7 +18,10 @@ import { SettingsInput } from "#/components/features/settings/settings-input";
 import { SegmentedToggle } from "#/components/features/files-tab/segmented-toggle";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
 import { useNavigation } from "#/context/navigation-context";
-import { useBackendsHealth } from "#/hooks/query/use-backends-health";
+import {
+  useBackendsHealth,
+  INVALID_BACKEND_API_KEY_ERROR,
+} from "#/hooks/query/use-backends-health";
 import { useTracking } from "#/hooks/use-tracking";
 import type { CloudConnectionSource } from "#/services/cloud-funnel-analytics";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
@@ -24,6 +30,7 @@ import { isOpenHandsCloudHost } from "#/api/device-flow-client";
 import {
   assertAgentServerVersionIsSupported,
   getDisplayAgentServerVersion,
+  isSdkHttpStatusError,
 } from "#/api/agent-server-compatibility";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
 import { I18nKey } from "#/i18n/declaration";
@@ -183,13 +190,24 @@ async function testBackendConnection(
   // Cloud backends authenticate via OAuth; preflight GET is not applicable.
   if (backend.kind !== "local") return { agentServerVersion: null };
 
-  const serverInfo = await new ServerClient(
-    getAgentServerClientOptions({
-      host: backend.host,
-      sessionApiKey: backend.apiKey || null,
-      timeout: 5000,
-    }),
-  ).getServerInfo();
+  const clientOptions = getAgentServerClientOptions({
+    host: backend.host,
+    sessionApiKey: backend.apiKey || null,
+    timeout: 5000,
+  });
+
+  // Validate the API key first — SettingsClient.getSettings() returns 401
+  // when the session key is invalid, matching the health-probe behavior.
+  try {
+    await new SettingsClient(clientOptions).getSettings();
+  } catch (error) {
+    if (isSdkHttpStatusError(error, 401)) {
+      throw new Error(INVALID_BACKEND_API_KEY_ERROR);
+    }
+    throw error;
+  }
+
+  const serverInfo = await new ServerClient(clientOptions).getServerInfo();
   assertAgentServerVersionIsSupported(serverInfo);
   return { agentServerVersion: getDisplayAgentServerVersion(serverInfo) };
 }


### PR DESCRIPTION
HUMAN:

Tested the onboarding flow with an invalid API key: the user stays on the backend step and the "Disconnected (check API key)" banner is shown, while a valid key advances past onboarding. Added a regression test covering the invalid-key path.

AGENT:

<!-- AI/LLM agents: provide end-to-end evidence here. -->

---

## Why

In `backend-form-modal.tsx`, `testBackendConnection` only called `ServerClient.getServerInfo()`, a public endpoint that does not require authentication. This let users advance past the onboarding backend step even with an invalid API key. The backend health probe (`use-backends-health`) additionally calls `SettingsClient.getSettings()`, which validates the session API key and returns 401 when it is invalid. This inconsistency meant the onboarding connection test succeeded while the health probe failed (issue #16804).

## Summary

- Update `testBackendConnection` to call `SettingsClient.getSettings()` before `ServerClient.getServerInfo()`, matching the existing health-probe behavior.
- When `getSettings()` returns 401, throw `INVALID_BACKEND_API_KEY_ERROR`, which surfaces as the existing "Disconnected (check API key)" error banner and blocks advancement.
- Add a regression test verifying the user stays on the backend step when the API key is invalid.

## Issue Number

Fixes #16804

## How to Test

1. Start the backend with a session API key configured.
2. In the onboarding flow, enter a reachable backend host and an invalid API key.
3. Click "Next" on the backend step. You should see the "Disconnected (check API key)" banner and stay on the backend step.
4. Enter a valid API key. You should advance to the next step.

## Video/Screenshots

<!-- Provide reproduction evidence: the bug before the fix and the result after. -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Regression test added in `__tests__/components/onboarding/onboarding-modal.test.tsx`.
