### PR TITLE
fix: validate api key before advancing backend connection step

### DIFF
--- a/__tests__/components/backends/add-backend-modal.test.tsx
+++ b/__tests__/components/backends/add-backend-modal.test.tsx
@@ -14,6 +14,7 @@ import { AddBackendModal } from "#/components/features/backends/add-backend-moda
 import * as telemetry from "#/services/telemetry";
 
 const getServerInfoMock = vi.hoisted(() => vi.fn());
+const getSettingsMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
 
 const deviceFlowMocks = vi.hoisted(() => ({
   startDeviceFlow: vi.fn(),
@@ -36,6 +37,11 @@ vi.mock("@openhands/typescript-client/clients", () => ({
   ServerClient: vi.fn(function ServerClientMock() {
     return {
       getServerInfo: getServerInfoMock,
+    };
+  }),
+  SettingsClient: vi.fn(function SettingsClientMock() {
+    return {
+      getSettings: getSettingsMock,
     };
   }),
 }));
@@ -89,7 +95,7 @@ beforeEach(() => {
     interval: 5,
   });
   deviceFlowMocks.pollForToken.mockReset();
-  deviceFlowMocks.pollForToken.mockImplementation(() => new Promise(() => {}));
+  deviceFlowMocks.pollForToken.mockImplementation(() => new Promise(() => { }));
   __resetActiveStoreForTests();
 });
 

--- a/__tests__/components/backends/backend-form-modal.test.tsx
+++ b/__tests__/components/backends/backend-form-modal.test.tsx
@@ -16,11 +16,17 @@ import {
 import { BackendFormModal } from "#/components/features/backends/backend-form-modal";
 
 const getServerInfoMock = vi.hoisted(() => vi.fn());
+const getSettingsMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
 
 vi.mock("@openhands/typescript-client/clients", () => ({
   ServerClient: vi.fn(function ServerClientMock() {
     return {
       getServerInfo: getServerInfoMock,
+    };
+  }),
+  SettingsClient: vi.fn(function SettingsClientMock() {
+    return {
+      getSettings: getSettingsMock,
     };
   }),
 }));

--- a/__tests__/components/onboarding/onboarding-modal.test.tsx
+++ b/__tests__/components/onboarding/onboarding-modal.test.tsx
@@ -23,6 +23,7 @@ import * as telemetry from "#/services/telemetry";
 
 const llmSettingsScreenMock = vi.hoisted(() => vi.fn());
 const getServerInfoMock = vi.hoisted(() => vi.fn());
+const getSettingsMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
 let captureMock: MockInstance<typeof telemetry.trackEvent>;
 
 // Both the backend status badge in the embedded edit form and the
@@ -38,7 +39,7 @@ vi.mock("@openhands/typescript-client/clients", () => ({
   // `LlmSettingsScreen` is stubbed, so provide the minimal client it needs.
   SettingsClient: vi.fn(function SettingsClientMock() {
     return {
-      getSettings: vi.fn().mockResolvedValue({}),
+      getSettings: vi.fn(() => getSettingsMock()),
     };
   }),
 }));
@@ -618,6 +619,47 @@ describe("OnboardingModal", () => {
     expect(screen.queryByText("BACKEND$LOGIN_OR")).toBeNull();
   });
 
+  it("shows a connection error when the backend API key is invalid", async () => {
+    window.localStorage.clear();
+    vi.stubEnv("VITE_BACKEND_BASE_URL", "");
+    vi.stubEnv("VITE_SESSION_API_KEY", "");
+    delete (window as unknown as Record<string, unknown>)
+      .__AGENT_CANVAS_SESSION_API_KEY__;
+    __resetActiveStoreForTests();
+
+    // Mock SettingsClient to throw a 401 error
+    const authError = new Error("Unauthorized");
+    authError.name = "HttpError";
+    (authError as any).status = 401;
+    getSettingsMock.mockRejectedValueOnce(authError);
+    // getServerInfoMock implicitly resolves, but shouldn't be reached if test is correct
+
+    renderModal();
+    const user = userEvent.setup();
+
+    await user.clear(screen.getByTestId("onboarding-backend-host"));
+    await user.type(
+      screen.getByTestId("onboarding-backend-host"),
+      "https://127.0.0.1:8000",
+    );
+    await user.clear(screen.getByTestId("onboarding-backend-api-key"));
+    await user.type(
+      screen.getByTestId("onboarding-backend-api-key"),
+      "invalid-session-key",
+    );
+    await user.click(screen.getByTestId("onboarding-backend-next"));
+
+    expect(
+      await screen.findByTestId("onboarding-backend-error"),
+    ).toHaveTextContent("BACKEND$CONNECTION_TEST_FAILED");
+    expect(screen.getByTestId("onboarding-backend-error")).toHaveTextContent(
+      "Invalid API key", // This comes from INVALID_BACKEND_API_KEY_ERROR
+    );
+
+    // Should not advance to the next step
+    expect(screen.queryByText("BACKEND$LOGIN_OR")).toBeNull();
+  });
+
   it("shows a connection error when saving an unreachable backend", async () => {
     window.localStorage.clear();
     vi.stubEnv("VITE_BACKEND_BASE_URL", "");
@@ -977,7 +1019,7 @@ describe("OnboardingModal", () => {
     );
     expect(
       helloInput.compareDocumentPosition(recommendations) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+      Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
       within(recommendations).getByTestId(

--- a/src/api/agent-server-compatibility.ts
+++ b/src/api/agent-server-compatibility.ts
@@ -10,6 +10,7 @@ import {
   getEffectiveLocalBackend,
   isNoBackend,
 } from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
 import defaults from "../../config/defaults.json";
 
 const AGENT_SERVER_INFO_TIMEOUT_MS = 5000;
@@ -21,6 +22,14 @@ export const AGENT_SERVER_UNSUPPORTED_VERSION_ERROR_CODE =
   "AGENT_SERVER_UNSUPPORTED_VERSION";
 export const AGENT_SERVER_UNKNOWN_VERSION_ERROR_CODE =
   "AGENT_SERVER_UNKNOWN_VERSION";
+
+/**
+ * Sentinel string thrown (as an Error message) when a local backend
+ * rejects the configured session API key with HTTP 401.
+ * Shared between the backend health probe ({@link validateLocalBackend})
+ * and any consumer that needs to detect this specific failure.
+ */
+export const INVALID_BACKEND_API_KEY_ERROR = "Invalid API key";
 
 export interface AgentServerInfo extends BaseServerInfo {
   sdk_version?: string;
@@ -314,6 +323,41 @@ export function assertAgentServerVersionIsSupported(
   if (comparison < 0) {
     clearCachedAgentServerInfo();
     throw new AgentServerUnsupportedVersionError(actualVersion);
+  }
+}
+
+/**
+ * Validates a local agent-server backend with a two-step probe:
+ *  1. GET /api/settings — authenticates the configured session API key;
+ *     a 401 throws an Error with message {@link INVALID_BACKEND_API_KEY_ERROR}.
+ *  2. GET /server_info  — asserts the server meets the minimum version floor.
+ *
+ * Returns the display version string reported by the server, or `null` when
+ * the server does not report a parseable version. Throws on any failure.
+ *
+ * Used by both the backend health poller and the backend-form connection test
+ * so that auth-check semantics (status codes, error messages) stay in one place.
+ */
+export async function validateLocalBackend(
+  backend: Pick<Backend, "host" | "apiKey">,
+  timeout: number,
+): Promise<string | null> {
+  const clientOptions = getAgentServerClientOptions({
+    host: backend.host,
+    sessionApiKey: backend.apiKey || null,
+    timeout,
+  });
+
+  try {
+    await new SettingsClient(clientOptions).getSettings();
+    const serverInfo = await new ServerClient(clientOptions).getServerInfo();
+    assertAgentServerVersionIsSupported(serverInfo);
+    return getDisplayAgentServerVersion(serverInfo);
+  } catch (error) {
+    if (isSdkHttpStatusError(error, 401)) {
+      throw new Error(INVALID_BACKEND_API_KEY_ERROR);
+    }
+    throw error;
   }
 }
 

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, Globe, Info, Monitor } from "lucide-react";
-import {
-  ServerClient,
-  SettingsClient,
-} from "@openhands/typescript-client/clients";
+import { ServerClient } from "@openhands/typescript-client/clients";
 import OpenHandsLogoWhite from "#/assets/branding/openhands-logo-white.svg?react";
 import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
 import {
@@ -18,19 +15,15 @@ import { SettingsInput } from "#/components/features/settings/settings-input";
 import { SegmentedToggle } from "#/components/features/files-tab/segmented-toggle";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
 import { useNavigation } from "#/context/navigation-context";
-import {
-  INVALID_BACKEND_API_KEY_ERROR,
-  useBackendsHealth,
-} from "#/hooks/query/use-backends-health";
+import { useBackendsHealth } from "#/hooks/query/use-backends-health";
 import { useTracking } from "#/hooks/use-tracking";
 import type { CloudConnectionSource } from "#/services/cloud-funnel-analytics";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
 import { getLockedCloudHost } from "#/api/agent-server-config";
 import { isOpenHandsCloudHost } from "#/api/device-flow-client";
 import {
-  assertAgentServerVersionIsSupported,
   getDisplayAgentServerVersion,
-  isSdkHttpStatusError,
+  validateLocalBackend,
 } from "#/api/agent-server-compatibility";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
 import { I18nKey } from "#/i18n/declaration";
@@ -189,24 +182,8 @@ async function testBackendConnection(
 ): Promise<BackendConnectionTestMetadata> {
   // Cloud backends authenticate via OAuth; preflight GET is not applicable.
   if (backend.kind !== "local") return { agentServerVersion: null };
-
-  const clientOptions = getAgentServerClientOptions({
-    host: backend.host,
-    sessionApiKey: backend.apiKey || null,
-    timeout: 5000,
-  });
-
-  try {
-    await new SettingsClient(clientOptions).getSettings();
-    const serverInfo = await new ServerClient(clientOptions).getServerInfo();
-    assertAgentServerVersionIsSupported(serverInfo);
-    return { agentServerVersion: getDisplayAgentServerVersion(serverInfo) };
-  } catch (error) {
-    if (isSdkHttpStatusError(error, 401)) {
-      throw new Error(INVALID_BACKEND_API_KEY_ERROR);
-    }
-    throw error;
-  }
+  const agentServerVersion = await validateLocalBackend(backend, 5000);
+  return { agentServerVersion };
 }
 
 /**

--- a/src/components/features/backends/backend-form-modal.tsx
+++ b/src/components/features/backends/backend-form-modal.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, Globe, Info, Monitor } from "lucide-react";
-import { ServerClient } from "@openhands/typescript-client/clients";
+import {
+  ServerClient,
+  SettingsClient,
+} from "@openhands/typescript-client/clients";
 import OpenHandsLogoWhite from "#/assets/branding/openhands-logo-white.svg?react";
 import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
 import {
@@ -15,7 +18,10 @@ import { SettingsInput } from "#/components/features/settings/settings-input";
 import { SegmentedToggle } from "#/components/features/files-tab/segmented-toggle";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
 import { useNavigation } from "#/context/navigation-context";
-import { useBackendsHealth } from "#/hooks/query/use-backends-health";
+import {
+  INVALID_BACKEND_API_KEY_ERROR,
+  useBackendsHealth,
+} from "#/hooks/query/use-backends-health";
 import { useTracking } from "#/hooks/use-tracking";
 import type { CloudConnectionSource } from "#/services/cloud-funnel-analytics";
 import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
@@ -24,6 +30,7 @@ import { isOpenHandsCloudHost } from "#/api/device-flow-client";
 import {
   assertAgentServerVersionIsSupported,
   getDisplayAgentServerVersion,
+  isSdkHttpStatusError,
 } from "#/api/agent-server-compatibility";
 import ChevronDownSmallIcon from "#/icons/chevron-down-small.svg?react";
 import { I18nKey } from "#/i18n/declaration";
@@ -183,15 +190,23 @@ async function testBackendConnection(
   // Cloud backends authenticate via OAuth; preflight GET is not applicable.
   if (backend.kind !== "local") return { agentServerVersion: null };
 
-  const serverInfo = await new ServerClient(
-    getAgentServerClientOptions({
-      host: backend.host,
-      sessionApiKey: backend.apiKey || null,
-      timeout: 5000,
-    }),
-  ).getServerInfo();
-  assertAgentServerVersionIsSupported(serverInfo);
-  return { agentServerVersion: getDisplayAgentServerVersion(serverInfo) };
+  const clientOptions = getAgentServerClientOptions({
+    host: backend.host,
+    sessionApiKey: backend.apiKey || null,
+    timeout: 5000,
+  });
+
+  try {
+    await new SettingsClient(clientOptions).getSettings();
+    const serverInfo = await new ServerClient(clientOptions).getServerInfo();
+    assertAgentServerVersionIsSupported(serverInfo);
+    return { agentServerVersion: getDisplayAgentServerVersion(serverInfo) };
+  } catch (error) {
+    if (isSdkHttpStatusError(error, 401)) {
+      throw new Error(INVALID_BACKEND_API_KEY_ERROR);
+    }
+    throw error;
+  }
 }
 
 /**

--- a/src/hooks/query/use-backends-health.ts
+++ b/src/hooks/query/use-backends-health.ts
@@ -3,19 +3,14 @@ import axios from "axios";
 import { useQueries } from "@tanstack/react-query";
 import { HttpError } from "@openhands/typescript-client";
 import {
-  ServerClient,
-  SettingsClient,
-} from "@openhands/typescript-client/clients";
-import {
   getCloudOrganizations,
   getCurrentCloudApiKey,
 } from "#/api/cloud/organization-service.api";
 import {
-  assertAgentServerVersionIsSupported,
-  isSdkHttpStatusError,
+  validateLocalBackend,
+  INVALID_BACKEND_API_KEY_ERROR,
 } from "#/api/agent-server-compatibility";
 import type { Backend } from "#/api/backend-registry/types";
-import { getAgentServerClientOptions } from "#/api/agent-server-client-options";
 import {
   isCorsOrNetworkError,
   isCorsOrNetworkErrorMessage,
@@ -33,7 +28,7 @@ import { MAX_CONSECUTIVE_FAILURES } from "#/api/backend-registry/health-storage"
 // traffic for the browser's per-origin HTTP/1.1 connection pool.
 const REFRESH_INTERVAL_MS = 30000;
 const PROBE_TIMEOUT_MS = 4000;
-export const INVALID_BACKEND_API_KEY_ERROR = "Invalid API key";
+export { INVALID_BACKEND_API_KEY_ERROR } from "#/api/agent-server-compatibility";
 export const MISSING_BACKEND_API_KEY_ERROR = "API key required";
 export const CLOUD_BACKEND_API_KEY_OR_NETWORK_ERROR =
   "Cloud API key or network issue";
@@ -114,22 +109,7 @@ async function probeBackend(backend: Backend): Promise<true> {
     return true;
   }
 
-  try {
-    const clientOptions = getAgentServerClientOptions({
-      host: backend.host,
-      sessionApiKey: backend.apiKey || null,
-      timeout: PROBE_TIMEOUT_MS,
-    });
-
-    await new SettingsClient(clientOptions).getSettings();
-    const serverInfo = await new ServerClient(clientOptions).getServerInfo();
-    assertAgentServerVersionIsSupported(serverInfo);
-  } catch (error) {
-    if (isSdkHttpStatusError(error, 401)) {
-      throw new Error(INVALID_BACKEND_API_KEY_ERROR);
-    }
-    throw error;
-  }
+  await validateLocalBackend(backend, PROBE_TIMEOUT_MS);
   return true;
 }
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
I reproduced the bug by running the dev stack locally and entering an invalid API key 
in the backend setup form  the step incorrectly advanced without any error. After 
applying the fix, I confirmed the "Invalid API key" error banner appears immediately 
and the step no longer advances. I also ran `npm run lint` and `npm test` locally 
both passed cleanly with no errors.
<!-- Human contributors: add a short note about your testing. -->

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why
When a user sets up a local backend with an invalid API key, the onboarding connection test incorrectly passes and advances the user to the next step. This happens because `testBackendConnection` only calls the unauthenticated `/server_info` endpoint, which returns `200 OK` regardless of whether the API key is valid.
<!-- Describe problem, motivation, etc. -->

## Summary

<!-- 1-3 bullets describing what changed. -->
- Added an authenticated pre-flight call to `SettingsClient.getSettings()` in `testBackendConnection`, mirroring the existing `probeBackend` approach in `use-backends-health.ts`
- A `401 Unauthorized` response is now explicitly caught and mapped to `INVALID_BACKEND_API_KEY_ERROR`, blocking the step and displaying the inline error banner
- Updated test mocks and added a new 401 test case to `onboarding-modal.test.tsx`

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #16804

## How to Test
1. Run `npm install` then `npm run dev`
2. Open the backend connection modal and enter a valid host URL (e.g. `http://localhost:3000`) with an **invalid** API key
3. Click the connect/next button
4. **Expected (after fix):** An inline "Invalid API key" error banner appears and the step does not advance
5. **Expected (before fix):** The step incorrectly advances despite the bad key
<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

https://github.com/user-attachments/assets/7c43a9fd-db18-4178-bf8c-7e5fe9aa113d


https://github.com/user-attachments/assets/9de06f3e-b5d1-4c1e-a951-a8580e20214a


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
