### PR TITLE
fix(websocket): ignore late closes from replaced sockets

### DIFF
--- a/__tests__/hooks/use-websocket.test.ts
+++ b/__tests__/hooks/use-websocket.test.ts
@@ -823,8 +823,14 @@ describe("useWebSocket", () => {
       expect(onCloseSpy).not.toHaveBeenCalled();
       expect(onErrorSpy).not.toHaveBeenCalled();
 
-      // ...while the current socket's close still notifies as before.
+      // ...and cannot overwrite the replacement's live connection state.
+      expect(result.current.isConnected).toBe(true);
+      expect(result.current.error).toBeNull();
+
+      // The current socket's close still updates state and notifies as before.
       act(() => currentSocket.emitClose());
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.error).not.toBeNull();
       expect(onCloseSpy).toHaveBeenCalledOnce();
       expect(onErrorSpy).toHaveBeenCalledOnce();
 

--- a/src/hooks/use-websocket.ts
+++ b/src/hooks/use-websocket.ts
@@ -82,6 +82,12 @@ export const useWebSocket = (url: string, options?: WebSocketHookOptions) => {
 
     ws.onclose = (event) => {
       cancelHandshakeWatchdog();
+      // A deliberately replaced socket can close after its replacement has
+      // already opened. Ignore that late event entirely so it cannot flip the
+      // live connection back to disconnected or surface a stale error.
+      const wasReplaced = wsRef.current !== null && wsRef.current !== ws;
+      if (wasReplaced) return;
+
       // Check if this specific WebSocket instance is allowed to reconnect
       const canReconnect = allowedToReconnectRef.current.has(ws);
       setIsConnected(false);
@@ -98,14 +104,9 @@ export const useWebSocket = (url: string, options?: WebSocketHookOptions) => {
           optionsRef.current?.onError?.(event);
         }
       }
-      // Notify the consumer unless this socket was deliberately replaced by a
-      // newer one — a replaced socket's close event arrives late and must not
-      // clobber the replacement's OPEN state in the consumer. Final closes
-      // (disconnect/unmount, nothing replacing the socket) still notify.
-      const wasReplaced = wsRef.current !== null && wsRef.current !== ws;
-      if (!wasReplaced) {
-        optionsRef.current?.onClose?.(event);
-      }
+      // Final closes (disconnect/unmount, nothing replacing the socket) still
+      // notify the consumer.
+      optionsRef.current?.onClose?.(event);
 
       // Attempt reconnection if enabled and allowed
       // IMPORTANT: Only reconnect if this specific instance is allowed to reconnect


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
I reviewed the linked WebSocket regression output on Windows and confirmed that the replacement connection remains active after the old socket closes. I also checked the passing build and platform test results.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Validated the stale-event boundary with a deterministic hook regression, the production application build, and the library build. The regression opens a replacement socket, delivers the old socket's close afterward, and verifies that the active connection stays healthy until the current socket closes.

---

## Why

`useWebSocket.reconnect()` can replace a socket before the old instance delivers its close event. The old handler already avoided notifying consumers in that case, but it still changed `isConnected`, stored a stale error, and could schedule reconnection work. That leaves the hook reporting a disconnect while its replacement is open.

## Summary

- Return before mutating state when a close belongs to a replaced socket.
- Preserve the existing close, error, callback, and retry behavior for the current socket.
- Extend the replacement regression to assert both stale-event isolation and final-close behavior.

## Issue Number

Fixes #16842

## How to Test

1. Run `npx vitest run __tests__/hooks/use-websocket.test.ts`.
2. Run `npm run lint`.
3. Run `npm run build`.
4. Run `npm run build:lib`.
5. In the regression, open the replacement socket, close the old socket with code 1006, and verify `isConnected` remains true with no error; then close the current socket and verify the normal disconnected state and callbacks.

## Video/Screenshots

Reproduction details and the event ordering are documented in #16842. The capture below shows the fixed branch passing the deterministic replacement-socket regression.

![Replacement socket state regression test](https://github.com/user-attachments/assets/a620bf5c-7a0e-4b12-93b1-26a63d62b233)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

A full local test run on Windows completed 598 files and 4,992 tests successfully; five unrelated files reported existing path-separator expectations or timeouts. The focused regression and all prescribed lint and build gates pass.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.39s · commit ff424c9  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 3/3 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 17.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 73.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 6490a09b5511fa363cb0b5ccf8607806ce3021b0d113035fcc57aeb8e6ba7295 -->
<!-- jev-fast-audit:end -->
