### PR TITLE
fix(plugins): isolate cached data by backend

### DIFF
--- a/__tests__/hooks/query/use-plugins-backend-switch.test.tsx
+++ b/__tests__/hooks/query/use-plugins-backend-switch.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PluginsManagementService from "#/api/plugins-management-service";
+import PluginsService from "#/api/plugins-service";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { useLocalPlugins } from "#/hooks/query/use-local-plugins";
+import { usePluginFileContent } from "#/hooks/query/use-plugin-file-content";
+import { usePlugins } from "#/hooks/query/use-plugins";
+import { usePluginsMarketplace } from "#/hooks/query/use-plugins-marketplace";
+import { PLUGINS_QUERY_KEYS } from "#/hooks/query/query-keys";
+
+vi.mock("#/api/plugins-management-service");
+vi.mock("#/api/plugins-service");
+
+const firstBackend: Backend = {
+  id: "local-one",
+  name: "Local one",
+  host: "http://localhost:8001",
+  apiKey: "first-key",
+  kind: "local",
+};
+
+const secondBackend: Backend = {
+  id: "local-two",
+  name: "Local two",
+  host: "http://localhost:8002",
+  apiKey: "second-key",
+  kind: "local",
+};
+
+describe("plugin query backend isolation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    __resetActiveStoreForTests();
+    setRegisteredBackends([firstBackend, secondBackend]);
+    setActiveSelection({ backendId: firstBackend.id, orgId: null });
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+    __resetActiveStoreForTests();
+  });
+
+  it("loads separate installed, local, and marketplace data after a backend switch", async () => {
+    vi.mocked(PluginsManagementService.listInstalledPlugins)
+      .mockResolvedValueOnce([
+        {
+          name: "installed-one",
+          version: "1.0.0",
+          description: null,
+          enabled: true,
+          source: "https://example.com/one.git",
+          installed_at: "2026-08-24T00:00:00Z",
+          install_path: "/plugins/one",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          name: "installed-two",
+          version: "1.0.0",
+          description: null,
+          enabled: true,
+          source: "https://example.com/two.git",
+          installed_at: "2026-08-24T00:00:00Z",
+          install_path: "/plugins/two",
+        },
+      ]);
+    vi.mocked(PluginsService.getLocalPlugins)
+      .mockResolvedValueOnce([
+        { name: "local-one", version: "1.0.0", description: "First" },
+      ])
+      .mockResolvedValueOnce([
+        { name: "local-two", version: "1.0.0", description: "Second" },
+      ]);
+    vi.mocked(PluginsService.getPluginsMarketplace)
+      .mockResolvedValueOnce([
+        {
+          name: "market-one",
+          description: "First",
+          source: "https://example.com/market-one.git",
+          installed: false,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          name: "market-two",
+          description: "Second",
+          source: "https://example.com/market-two.git",
+          installed: false,
+        },
+      ]);
+    vi.mocked(PluginsService.getPluginFileContent)
+      .mockResolvedValueOnce({ kind: "text", text: "first backend" })
+      .mockResolvedValueOnce({ kind: "text", text: "second backend" });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <ActiveBackendProvider>{children}</ActiveBackendProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () => ({
+        installed: usePlugins(),
+        local: useLocalPlugins(),
+        marketplace: usePluginsMarketplace(),
+        file: usePluginFileContent("/plugins/shared", "README.md"),
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.installed.data?.[0]?.name).toBe("installed-one");
+      expect(result.current.local.data?.[0]?.name).toBe("local-one");
+      expect(result.current.marketplace.data?.[0]?.name).toBe("market-one");
+      expect(result.current.file.data?.text).toBe("first backend");
+    });
+
+    act(() => {
+      setActiveSelection({ backendId: secondBackend.id, orgId: null });
+    });
+
+    await waitFor(() => {
+      expect(result.current.installed.data?.[0]?.name).toBe("installed-two");
+      expect(result.current.local.data?.[0]?.name).toBe("local-two");
+      expect(result.current.marketplace.data?.[0]?.name).toBe("market-two");
+      expect(result.current.file.data?.text).toBe("second backend");
+    });
+
+    expect(
+      queryClient
+        .getQueryCache()
+        .findAll({ queryKey: PLUGINS_QUERY_KEYS.installed })
+        .map((query) => query.queryKey),
+    ).toEqual([
+      [...PLUGINS_QUERY_KEYS.installed, firstBackend.id, null],
+      [...PLUGINS_QUERY_KEYS.installed, secondBackend.id, null],
+    ]);
+    expect(
+      queryClient
+        .getQueryCache()
+        .findAll({ queryKey: PLUGINS_QUERY_KEYS.local }),
+    ).toHaveLength(2);
+    expect(
+      queryClient
+        .getQueryCache()
+        .findAll({ queryKey: PLUGINS_QUERY_KEYS.marketplace }),
+    ).toHaveLength(2);
+    expect(
+      queryClient
+        .getQueryCache()
+        .findAll({ queryKey: PLUGINS_QUERY_KEYS.fileContent }),
+    ).toHaveLength(2);
+  });
+});

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -261,7 +261,7 @@ export const useCreateConversation = () => {
         let installed: InstalledPluginInfo[] = [];
         try {
           installed = await queryClient.ensureQueryData({
-            queryKey: PLUGINS_QUERY_KEYS.installed,
+            queryKey: [...PLUGINS_QUERY_KEYS.installed, backend.id, orgId],
             queryFn: () => PluginsManagementService.listInstalledPlugins(),
           });
         } catch {

--- a/src/hooks/query/query-keys.ts
+++ b/src/hooks/query/query-keys.ts
@@ -52,6 +52,8 @@ export const PLUGINS_QUERY_KEYS = {
   installed: ["plugins-installed"] as const,
   /** Locally-discovered ambient plugins (used by `use-local-plugins`). */
   local: ["plugins-local"] as const,
+  /** A file displayed from a plugin installed on the active backend. */
+  fileContent: ["plugin-file-content"] as const,
 } as const;
 
 export const SETUP_QUERY_KEYS = {

--- a/src/hooks/query/use-local-plugins.ts
+++ b/src/hooks/query/use-local-plugins.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import PluginsService, { type LocalPlugin } from "#/api/plugins-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { PLUGINS_QUERY_KEYS } from "./query-keys";
 
 /**
@@ -8,10 +9,12 @@ import { PLUGINS_QUERY_KEYS } from "./query-keys";
  * cloud backend yields an empty list. Rendered as the read-only "Local" group on
  * the Plugins page. Mirrors `usePlugins`.
  */
-export const useLocalPlugins = () =>
-  useQuery<LocalPlugin[]>({
-    queryKey: PLUGINS_QUERY_KEYS.local,
+export const useLocalPlugins = () => {
+  const active = useActiveBackend();
+  return useQuery<LocalPlugin[]>({
+    queryKey: [...PLUGINS_QUERY_KEYS.local, active.backend.id, active.orgId],
     queryFn: () => PluginsService.getLocalPlugins(),
     staleTime: 1000 * 60 * 10, // 10 minutes
     refetchOnWindowFocus: false,
   });
+};

--- a/src/hooks/query/use-plugin-file-content.ts
+++ b/src/hooks/query/use-plugin-file-content.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import PluginsService, { type PluginFileContent } from "#/api/plugins-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { PLUGINS_QUERY_KEYS } from "./query-keys";
 
 /**
  * Query hook for one plugin file's content, shown in the plugin detail
@@ -9,9 +11,16 @@ import PluginsService, { type PluginFileContent } from "#/api/plugins-service";
 export const usePluginFileContent = (
   basePath: string | null,
   relativePath: string | null,
-) =>
-  useQuery<PluginFileContent>({
-    queryKey: ["plugin-file-content", basePath, relativePath],
+) => {
+  const active = useActiveBackend();
+  return useQuery<PluginFileContent>({
+    queryKey: [
+      ...PLUGINS_QUERY_KEYS.fileContent,
+      active.backend.id,
+      active.orgId,
+      basePath,
+      relativePath,
+    ],
     queryFn: () => {
       if (!basePath || !relativePath) throw new Error("No file selected");
       return PluginsService.getPluginFileContent(basePath, relativePath);
@@ -21,3 +30,4 @@ export const usePluginFileContent = (
     staleTime: 1000 * 60 * 10, // 10 minutes
     refetchOnWindowFocus: false,
   });
+};

--- a/src/hooks/query/use-plugins-marketplace.ts
+++ b/src/hooks/query/use-plugins-marketplace.ts
@@ -1,15 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
 import PluginsService, { type MarketplacePlugin } from "#/api/plugins-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { PLUGINS_QUERY_KEYS } from "./query-keys";
 
 /**
  * Query hook for the dynamic plugins marketplace catalog. The catalog is global
  * (not project-scoped), and currently local-backend only — a cloud backend
  * yields an empty list. Mirrors `useSkills`.
  */
-export const usePluginsMarketplace = () =>
-  useQuery<MarketplacePlugin[]>({
-    queryKey: ["plugins-marketplace"],
+export const usePluginsMarketplace = () => {
+  const active = useActiveBackend();
+  return useQuery<MarketplacePlugin[]>({
+    queryKey: [
+      ...PLUGINS_QUERY_KEYS.marketplace,
+      active.backend.id,
+      active.orgId,
+    ],
     queryFn: () => PluginsService.getPluginsMarketplace(),
     staleTime: 1000 * 60 * 10, // 10 minutes – catalog rarely changes
     refetchOnWindowFocus: false,
   });
+};

--- a/src/hooks/query/use-plugins.ts
+++ b/src/hooks/query/use-plugins.ts
@@ -2,16 +2,23 @@ import { useQuery } from "@tanstack/react-query";
 import PluginsManagementService, {
   type InstalledPluginInfo,
 } from "#/api/plugins-management-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { PLUGINS_QUERY_KEYS } from "./query-keys";
 
 /**
  * Query hook for the plugins installed on the local agent-server. Local-backend
  * only — a cloud backend yields an empty list. Mirrors `useSkills`.
  */
-export const usePlugins = () =>
-  useQuery<InstalledPluginInfo[]>({
-    queryKey: PLUGINS_QUERY_KEYS.installed,
+export const usePlugins = () => {
+  const active = useActiveBackend();
+  return useQuery<InstalledPluginInfo[]>({
+    queryKey: [
+      ...PLUGINS_QUERY_KEYS.installed,
+      active.backend.id,
+      active.orgId,
+    ],
     queryFn: () => PluginsManagementService.listInstalledPlugins(),
     staleTime: 1000 * 60 * 10, // 10 minutes
     refetchOnWindowFocus: false,
   });
+};


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
I reviewed the backend-switch regression output for plugins on Windows and confirmed that installed, local, marketplace, and file-content data remain separated by backend. I also checked the passing build and platform test results.
<!-- Human contributors: add a short note about your testing. -->

AGENT:

Validated backend isolation with a two-backend regression, conversation-metadata coverage, the production application build, and the library build. The regression switches between servers with distinct installed, local, marketplace, and file-content data and checks that each cache entry remains separate.

---

## Why

Plugin queries currently keep data fresh for ten minutes without identifying the active backend in their keys. Switching registered backends can therefore show lists and file content from the previous server. Conversation creation can also snapshot enabled plugins from that stale entry into a conversation on another server.

## Summary

- Scope installed, local, marketplace, and file-content plugin queries by backend and organization.
- Add a shared file-content key prefix and retain the requested file path as part of the key.
- Read enabled plugins from the active backend's scoped cache during conversation creation.
- Add regression coverage for backend switching and separate cache entries.

## Issue Number

Fixes #16843

## How to Test

1. Run `npx vitest run __tests__/hooks/query/use-plugins-backend-switch.test.tsx __tests__/api/use-create-conversation-metadata.test.ts`.
2. Run `npm run lint`.
3. Run `npm run build`.
4. Run `npm run build:lib`.
5. Configure two registered backends with different plugin data, warm the first backend's plugin queries, switch to the second, and verify its lists, file content, and new-conversation metadata use only the second backend's data.

## Video/Screenshots

The reproduction and expected cache boundaries are documented in #16843. The capture below shows the fixed branch passing the two-backend regression.

![Backend-scoped plugin regression test](https://github.com/user-attachments/assets/ab87c796-967d-490d-a83c-2620c2c46c67)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No API shape or persistence format changes are required. Existing cache entries naturally expire; newly fetched entries use the scoped keys.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.62s · commit 05b7d41  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 10/10 hunks, 7/7 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 11.0% | No direct hunk selected |
| Contract regression | 14.0% | No direct hunk selected |
| Data loss | 5.0% | No direct hunk selected |
| Sensitive data disclosure | 5.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 8.0% | No direct hunk selected |
| Untrusted instruction authority | 3.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 92.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 2ae259f44b5157f02b709fbeaf684c0b0c7c5a02bcca526ca66f52aef627845f -->
<!-- jev-fast-audit:end -->
