### PR TITLE
fix(workspaces): scope cached lists by backend

### DIFF
--- a/__tests__/hooks/query/use-resolved-workspaces-backend-switch.test.tsx
+++ b/__tests__/hooks/query/use-resolved-workspaces-backend-switch.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WorkspacesService from "#/api/workspaces-service/workspaces-service.api";
+import {
+  __resetActiveStoreForTests,
+  getActiveBackend,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { useResolvedWorkspaces } from "#/hooks/query/use-resolved-workspaces";
+import { searchAllSubdirectories } from "#/hooks/query/use-search-subdirs";
+import { LOCAL_WORKSPACES_QUERY_KEYS } from "#/hooks/query/query-keys";
+
+vi.mock("#/api/workspaces-service/workspaces-service.api");
+vi.mock("#/hooks/query/use-search-subdirs", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("#/hooks/query/use-search-subdirs")>();
+  return { ...original, searchAllSubdirectories: vi.fn() };
+});
+
+const firstBackend: Backend = {
+  id: "workspace-one",
+  name: "Workspace one",
+  host: "http://localhost:8101",
+  apiKey: "first-key",
+  kind: "local",
+};
+
+const secondBackend: Backend = {
+  id: "workspace-two",
+  name: "Workspace two",
+  host: "http://localhost:8102",
+  apiKey: "second-key",
+  kind: "local",
+};
+
+describe("resolved workspace query backend isolation", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    __resetActiveStoreForTests();
+    setRegisteredBackends([firstBackend, secondBackend]);
+    setActiveSelection({ backendId: firstBackend.id, orgId: null });
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    vi.mocked(WorkspacesService.listWorkspaces).mockImplementation(async () => {
+      const backendId = getActiveBackend().backend.id;
+      return {
+        workspaces: [
+          {
+            id: `${backendId}-saved`,
+            name: `${backendId} saved`,
+            path: `/${backendId}/saved`,
+          },
+        ],
+        workspaceParents: [
+          { id: "shared-parent", name: "Shared", path: "/shared" },
+        ],
+      };
+    });
+    vi.mocked(searchAllSubdirectories).mockImplementation(async (path) => {
+      const backendId = getActiveBackend().backend.id;
+      return {
+        items: [
+          {
+            name: `${backendId} child`,
+            path: `${path}/${backendId}`,
+          },
+        ],
+        next_page_id: null,
+      };
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+    __resetActiveStoreForTests();
+  });
+
+  it("does not reuse saved or parent-derived workspaces after a backend switch", async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <ActiveBackendProvider>{children}</ActiveBackendProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(() => useResolvedWorkspaces(), { wrapper });
+
+    await waitFor(() => {
+      expect(
+        result.current.workspaces.map((workspace) => workspace.name),
+      ).toEqual(
+        expect.arrayContaining(["workspace-one saved", "workspace-one child"]),
+      );
+    });
+
+    act(() => {
+      setActiveSelection({ backendId: secondBackend.id, orgId: null });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.workspaces.map((workspace) => workspace.name),
+      ).toEqual(
+        expect.arrayContaining(["workspace-two saved", "workspace-two child"]),
+      );
+    });
+    expect(
+      result.current.workspaces.map((workspace) => workspace.name),
+    ).not.toEqual(
+      expect.arrayContaining(["workspace-one saved", "workspace-one child"]),
+    );
+
+    expect(
+      queryClient
+        .getQueryCache()
+        .findAll({ queryKey: LOCAL_WORKSPACES_QUERY_KEYS.all })
+        .map((query) => query.queryKey),
+    ).toEqual([
+      LOCAL_WORKSPACES_QUERY_KEYS.byBackend(firstBackend.id, null),
+      LOCAL_WORKSPACES_QUERY_KEYS.byBackend(secondBackend.id, null),
+    ]);
+
+    const sharedParentKeys = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["file", "search_subdirs", "/shared"] })
+      .map((query) => query.queryKey);
+    expect(sharedParentKeys).toEqual([
+      ["file", "search_subdirs", "/shared", firstBackend.id, null],
+      ["file", "search_subdirs", "/shared", secondBackend.id, null],
+    ]);
+  });
+});

--- a/src/hooks/query/query-keys.ts
+++ b/src/hooks/query/query-keys.ts
@@ -43,6 +43,8 @@ export const LLM_SUBSCRIPTION_QUERY_KEYS = {
 
 export const LOCAL_WORKSPACES_QUERY_KEYS = {
   all: ["local-workspaces"] as const,
+  byBackend: (backendId: string, orgId: string | null) =>
+    ["local-workspaces", backendId, orgId] as const,
 } as const;
 
 export const PLUGINS_QUERY_KEYS = {

--- a/src/hooks/query/use-local-workspaces.ts
+++ b/src/hooks/query/use-local-workspaces.ts
@@ -4,6 +4,7 @@ import { isAgentServerVersionError } from "@openhands/typescript-client/clients"
 import WorkspacesService, {
   WorkspacesListResponse,
 } from "#/api/workspaces-service/workspaces-service.api";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { LOCAL_WORKSPACES_QUERY_KEYS } from "#/hooks/query/query-keys";
 
 interface UseLocalWorkspacesOptions {
@@ -13,8 +14,12 @@ interface UseLocalWorkspacesOptions {
 export function useLocalWorkspaces({
   enabled = true,
 }: UseLocalWorkspacesOptions = {}) {
+  const active = useActiveBackend();
   return useQuery<WorkspacesListResponse>({
-    queryKey: LOCAL_WORKSPACES_QUERY_KEYS.all,
+    queryKey: LOCAL_WORKSPACES_QUERY_KEYS.byBackend(
+      active.backend.id,
+      active.orgId,
+    ),
     queryFn: () => WorkspacesService.listWorkspaces(),
     enabled,
     retry: (failureCount, error) =>

--- a/src/hooks/query/use-resolved-workspaces.ts
+++ b/src/hooks/query/use-resolved-workspaces.ts
@@ -3,7 +3,11 @@ import { useQueries } from "@tanstack/react-query";
 import { isAgentServerVersionError } from "@openhands/typescript-client/clients";
 
 import { useLocalWorkspaces } from "#/hooks/query/use-local-workspaces";
-import { searchAllSubdirectories } from "#/hooks/query/use-search-subdirs";
+import {
+  searchAllSubdirectories,
+  searchSubdirsQueryKey,
+} from "#/hooks/query/use-search-subdirs";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { LocalWorkspace, LocalWorkspaceParent } from "#/types/workspace";
 
 interface UseResolvedWorkspacesResult {
@@ -50,6 +54,7 @@ const IMPLICIT_WORKSPACE_PARENTS: LocalWorkspaceParent[] = [
  * same path so that user-selected names/ids are preserved.
  */
 export function useResolvedWorkspaces(): UseResolvedWorkspacesResult {
+  const active = useActiveBackend();
   const {
     data,
     isLoading: isLoadingList,
@@ -78,7 +83,11 @@ export function useResolvedWorkspaces(): UseResolvedWorkspacesResult {
     queries: workspacesUnsupported
       ? []
       : workspaceParents.map((parent) => ({
-          queryKey: ["file", "search_subdirs", parent.path],
+          queryKey: searchSubdirsQueryKey(
+            parent.path,
+            active.backend.id,
+            active.orgId,
+          ),
           queryFn: () => searchAllSubdirectories(parent.path),
           retry: false,
           meta: { disableToast: true },

--- a/src/hooks/query/use-search-subdirs.ts
+++ b/src/hooks/query/use-search-subdirs.ts
@@ -50,10 +50,16 @@ export async function searchAllSubdirectories(
   }
 }
 
+export const searchSubdirsQueryKey = (
+  path: string | null,
+  backendId: string,
+  orgId: string | null,
+) => ["file", "search_subdirs", path, backendId, orgId] as const;
+
 export const useSearchSubdirs = (path: string | null) => {
   const active = useActiveBackend();
   return useQuery({
-    queryKey: ["file", "search_subdirs", path, active.backend.id, active.orgId],
+    queryKey: searchSubdirsQueryKey(path, active.backend.id, active.orgId),
     queryFn: () => searchAllSubdirectories(path as string),
     enabled: !!path,
     retry: false,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
I reviewed the backend-switch regression output for workspaces on Windows and confirmed that saved workspaces and directory-search results remain scoped to the selected backend. I also checked the passing build and platform test results.
<!-- Human contributors: add a short note about your testing. -->

AGENT:

Validated workspace isolation with a two-backend regression, the existing workspace-selection suite, the production application build, and the library build. The regression gives both backends distinct saved workspaces and distinct children under the same parent path, then verifies that switching never reuses the other server's data.

---

## Why

Saved workspaces and parent-directory searches use cache keys that do not fully identify the active backend. After switching registered backends, the picker can display absolute paths from the previous server and submit a path that does not exist on the selected server.

## Summary

- Add backend- and organization-scoped keys for saved workspace lists.
- Centralize directory-search keys and include backend, organization, and path.
- Use the scoped search key for parent-derived workspace queries.
- Add regression coverage for saved and parent-derived workspaces across a backend switch.

## Issue Number

Fixes #16844

## How to Test

1. Run `npx vitest run __tests__/hooks/query/use-resolved-workspaces-backend-switch.test.tsx __tests__/components/features/home/workspace-selection-form.test.tsx`.
2. Run `npm run lint`.
3. Run `npm run build`.
4. Run `npm run build:lib`.
5. Configure two registered backends with different saved workspaces and different children under the same parent path, warm the first backend's picker, switch to the second, and verify that only the second backend's paths are offered.

## Video/Screenshots

The reproduction and expected cache boundaries are documented in #16844. The capture below shows the fixed branch passing the two-backend workspace regression.

![Backend-scoped workspace regression test](https://github.com/user-attachments/assets/fa233460-5cd7-42c1-84cf-3c6890d23651)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No API shape or persistence format changes are required. Existing cache entries naturally expire; newly fetched entries use the scoped keys.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.48s · commit 9b4ccf8  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 8/8 hunks, 5/5 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 7.0% | No direct hunk selected |
| Contract regression | 11.0% | No direct hunk selected |
| Data loss | 4.0% | No direct hunk selected |
| Sensitive data disclosure | 4.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 6.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature a2eef91baa07ae4d7d2cb0e77fa508cb6dbe4373f0778410e069780563bd017d -->
<!-- jev-fast-audit:end -->
