### PR TITLE
fix(acp): force dontAsk session mode for Claude Code

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1774,3 +1774,103 @@ describe("buildStartConversationRequest — ACP discriminator", () => {
     expect(acpPayload.agent_settings.condenser).toBeUndefined();
   });
 });
+
+describe("buildStartConversationRequest — Claude Code dontAsk override", () => {
+  // Claude Code's ACP provider defaults to bypassPermissions when no session
+  // mode is set, which the subprocess rejects outright ("bypassPermissions
+  // error") when its own config disables that mode — the conversation never
+  // starts. Forcing dontAsk on every Claude Code launch path avoids it.
+
+  it("forces dontAsk on the inline agent_settings payload when unset", () => {
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "claude-code",
+          acp_command: [],
+          acp_model: "claude-opus-4-5",
+        },
+      },
+    }) as { agent_settings: { acp_session_mode?: string } };
+
+    expect(payload.agent_settings.acp_session_mode).toBe("dontAsk");
+  });
+
+  it("overrides a stale non-dontAsk session mode saved on Claude Code settings", () => {
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "claude-code",
+          acp_command: [],
+          acp_session_mode: "bypassPermissions",
+        },
+      },
+    }) as { agent_settings: { acp_session_mode?: string } };
+
+    expect(payload.agent_settings.acp_session_mode).toBe("dontAsk");
+  });
+
+  it("leaves other ACP providers' session mode untouched", () => {
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "codex",
+          acp_command: [],
+        },
+      },
+    }) as { agent_settings: { acp_session_mode?: string } };
+
+    expect(payload.agent_settings.acp_session_mode).toBeUndefined();
+  });
+
+  it("stamps the top-level acp_session_mode for an inline Claude Code launch", () => {
+    const payload = buildStartConversationRequest({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "claude-code",
+          acp_command: [],
+        },
+      },
+    }) as { acp_session_mode?: string };
+
+    expect(payload.acp_session_mode).toBe("dontAsk");
+  });
+
+  it("stamps the top-level acp_session_mode for a Claude Code agent-profile launch", () => {
+    // Profile launches omit agent_settings entirely (mutually exclusive with
+    // agent_profile_id), so the override has to land as a top-level field
+    // the server applies when rebuilding the agent from the profile — a
+    // pre-existing profile predating this fix wouldn't carry it otherwise.
+    const payload = buildStartConversationRequest({
+      settings: DEFAULT_SETTINGS,
+      agentProfileId: "profile-claude-code",
+      agentProfileKind: "acp",
+      agentProfileAcpServer: "claude-code",
+    }) as { acp_session_mode?: string; agent_settings?: unknown };
+
+    expect(payload.agent_settings).toBeUndefined();
+    expect(payload.acp_session_mode).toBe("dontAsk");
+  });
+
+  it("does not stamp acp_session_mode for a non-Claude-Code agent-profile launch", () => {
+    const payload = buildStartConversationRequest({
+      settings: DEFAULT_SETTINGS,
+      agentProfileId: "profile-codex",
+      agentProfileKind: "acp",
+      agentProfileAcpServer: "codex",
+    }) as { acp_session_mode?: string };
+
+    expect(payload.acp_session_mode).toBeUndefined();
+  });
+});

--- a/__tests__/components/onboarding/choose-agent-step.test.tsx
+++ b/__tests__/components/onboarding/choose-agent-step.test.tsx
@@ -172,6 +172,10 @@ describe("ChooseAgentStep", () => {
       // command at conversation-create time.
       acp_args: [],
       acp_model: "opus[1m]",
+      // Claude Code's ACP provider defaults to bypassPermissions, which its
+      // subprocess rejects outright — dontAsk is seeded so the very first
+      // conversation from this diff can start.
+      acp_session_mode: "dontAsk",
     });
   });
 

--- a/__tests__/components/onboarding/setup-acp-secrets-step.test.tsx
+++ b/__tests__/components/onboarding/setup-acp-secrets-step.test.tsx
@@ -25,6 +25,15 @@ vi.mock("#/hooks/query/use-acp-auth-status", () => ({
   useAcpAuthStatus: (...args: unknown[]) => acpAuthStatusMock(...args),
 }));
 
+// applyAgentProfile persistence is exercised in its own hook test; here we
+// stub it so we can assert what the step passes it without a real mutation.
+const applyAgentProfileMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+);
+vi.mock("#/hooks/mutation/use-apply-onboarding-agent-profile", () => ({
+  useApplyOnboardingAgentProfile: () => applyAgentProfileMock,
+}));
+
 function renderStep(
   providerKey: OnboardingAgentId = "claude-code",
   isActive = true,
@@ -77,6 +86,7 @@ beforeEach(() => {
     isChecking: false,
     isSupported: false,
   });
+  applyAgentProfileMock.mockClear().mockResolvedValue(undefined);
   vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([]);
   vi.spyOn(SecretsService, "createSecret").mockResolvedValue();
 });
@@ -487,6 +497,43 @@ describe("SetupAcpSecretsStep", () => {
     expect(
       screen.getByTestId("acp-credential-conflict-warning"),
     ).toBeInTheDocument();
+  });
+
+  it("seeds the onboarding Claude Code profile with dontAsk session mode", async () => {
+    // Claude Code's ACP provider defaults to bypassPermissions, which its
+    // subprocess rejects outright — the profile applied at onboarding must
+    // carry dontAsk so the very first conversation can start.
+    const { user } = renderStep("claude-code");
+
+    await user.type(
+      screen.getByTestId("onboarding-acp-secret-ANTHROPIC_API_KEY"),
+      "sk-ant-123",
+    );
+    await user.click(screen.getByTestId("onboarding-acp-secrets-next"));
+
+    await waitFor(() =>
+      expect(applyAgentProfileMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          acp_server: "claude-code",
+          acp_session_mode: "dontAsk",
+        }),
+      ),
+    );
+  });
+
+  it("does not set a session mode for a non-Claude-Code onboarding profile", async () => {
+    const { user } = renderStep("codex");
+
+    await user.type(
+      screen.getByTestId("onboarding-acp-secret-OPENAI_API_KEY"),
+      "sk-codex-123",
+    );
+    await user.click(screen.getByTestId("onboarding-acp-secrets-next"));
+
+    await waitFor(() => expect(applyAgentProfileMock).toHaveBeenCalled());
+    expect(applyAgentProfileMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ acp_session_mode: expect.anything() }),
+    );
   });
 });
 

--- a/__tests__/constants/acp-providers.test.ts
+++ b/__tests__/constants/acp-providers.test.ts
@@ -117,6 +117,30 @@ describe("ACP provider registry", () => {
   });
 });
 
+describe("buildAcpAgentSettingsDiff — Claude Code dontAsk seeding", () => {
+  // Claude Code's ACP provider defaults to bypassPermissions when no session
+  // mode is saved, which its subprocess rejects outright. Seeding dontAsk
+  // here means it persists in saved settings even before the agent-server
+  // adapter's own launch-time override runs.
+  it("seeds acp_session_mode: dontAsk for claude-code", () => {
+    expect(buildAcpAgentSettingsDiff("claude-code")).toMatchObject({
+      acp_session_mode: "dontAsk",
+    });
+  });
+
+  it("does not seed acp_session_mode for other providers", () => {
+    expect(buildAcpAgentSettingsDiff("codex")).not.toHaveProperty(
+      "acp_session_mode",
+    );
+    expect(buildAcpAgentSettingsDiff("gemini-cli")).not.toHaveProperty(
+      "acp_session_mode",
+    );
+    expect(buildAcpAgentSettingsDiff(ACP_CUSTOM_PRESET_KEY)).not.toHaveProperty(
+      "acp_session_mode",
+    );
+  });
+});
+
 describe("getAcpProviderSecrets — containerized credentials", () => {
   // These are the credentials a fresh container (no host login) needs, sourced
   // from the validated container contract (agent-canvas#1013/#1014) — if a

--- a/__tests__/routes/agent-settings.test.tsx
+++ b/__tests__/routes/agent-settings.test.tsx
@@ -461,6 +461,10 @@ describe("AgentSettingsScreen", () => {
       // command at conversation-create time.
       acp_args: [],
       acp_model: "opus[1m]",
+      // Claude Code's ACP provider defaults to bypassPermissions, which its
+      // subprocess rejects outright — dontAsk is seeded so the very first
+      // conversation from this diff can start.
+      acp_session_mode: "dontAsk",
     });
   });
 

--- a/examples/acp-docker/docker-compose.yml
+++ b/examples/acp-docker/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     ports:
       # host:container — Canvas points VITE_BACKEND_BASE_URL at http://localhost:8010.
       - "8010:8000"
+    command: ["--host", "0.0.0.0", "--port", "8000"]
     environment:
       # New conversations define canvas_ui_control through client_tools. Keep the
       # old Python module importable so conversations persisted before that migration

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -881,6 +881,12 @@ function buildConfiguredAcpAgentSettings(
     payload.acp_model = effectiveModel;
   }
 
+  // Force dontAsk session mode for Claude Code — prevents the provider's
+  // default (bypassPermissions) from silently stripping policy controls.
+  if (serverKey === "claude-code") {
+    payload.acp_session_mode = "dontAsk";
+  }
+
   return payload;
 }
 
@@ -1047,6 +1053,7 @@ export interface StartConversationOptions {
   // server-side) instead of an inline ``agent_settings`` dump (#3727).
   agentProfileId?: string;
   agentProfileKind?: AgentKind;
+  agentProfileAcpServer?: string;
   titleLlmProfile?: string;
   runtimeServicesInfo?: RuntimeServicesInfo | null;
 }
@@ -1146,6 +1153,17 @@ export function buildStartConversationRequest(
     };
   } else {
     payload.tags = { [CLIENT_SOURCE_TAG_KEY]: AGENT_CANVAS_SOURCE };
+  }
+
+  // Force dontAsk session mode for Claude Code on BOTH launch paths.
+  // Profile-resolved settings may not include it (pre-existing profiles),
+  // and the provider default is bypassPermissions which Claude Code rejects
+  // when its config disables that mode.
+  const isClaudeCode =
+    options.agentProfileAcpServer === "claude-code" ||
+    (!options.agentProfileId && acpServerTag === "claude-code");
+  if (isClaudeCode) {
+    payload.acp_session_mode = "dontAsk";
   }
 
   // ``secrets_encrypted`` makes the agent-server decrypt request secrets at
@@ -1266,6 +1284,7 @@ export async function buildStartConversationRequestWithEncryptedSettings(options
   worktree?: boolean;
   agentProfileId?: string;
   agentProfileKind?: AgentKind;
+  agentProfileAcpServer?: string;
   titleLlmProfile?: string;
 }): Promise<Record<string, unknown>> {
   const { SecretsService } = await import("./secrets-service");

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -352,6 +352,7 @@ export interface CreateConversationOptions {
   // encrypted-settings builder; cloud sends it as a flat request field.
   agentProfileId?: string;
   agentProfileKind?: AgentKind;
+  agentProfileAcpServer?: string;
 }
 
 class AgentServerConversationService {
@@ -416,6 +417,7 @@ class AgentServerConversationService {
       sandboxId,
       agentProfileId,
       agentProfileKind,
+      agentProfileAcpServer,
     } = options;
 
     if (getActiveBackend().backend.kind === "cloud") {
@@ -484,6 +486,7 @@ class AgentServerConversationService {
       worktree: resolvedWorkspaceMode === "new_worktree",
       agentProfileId,
       agentProfileKind,
+      agentProfileAcpServer,
       titleLlmProfile,
     });
 

--- a/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
+++ b/src/components/features/onboarding/steps/setup-acp-secrets-step.tsx
@@ -128,6 +128,9 @@ export function SetupAcpSecretsStep({
           agent_kind: "acp",
           acp_server: providerKey,
           acp_model: getAcpPreferredDefaultModel(providerKey) ?? undefined,
+          ...(providerKey === "claude-code"
+            ? { acp_session_mode: "dontAsk" }
+            : {}),
         });
       }
       onNext();

--- a/src/constants/acp-providers.ts
+++ b/src/constants/acp-providers.ts
@@ -516,11 +516,19 @@ export function buildAcpAgentSettingsDiff(
   // payload from a textarea that already shows the merged command
   // (Settings → Agent) round-trip correctly — the merged tokens land in
   // ``acp_command`` here, so no args are lost.
-  return {
+  const diff: Record<string, unknown> = {
     agent_kind: "acp",
     acp_server: providerKey,
     acp_command: options.command ?? [],
     acp_args: [],
     acp_model: model ?? null,
   };
+
+  // Seed dontAsk session mode for Claude Code so it persists in saved
+  // settings and the agent-server adapter enforces it at start time.
+  if (providerKey === "claude-code") {
+    diff.acp_session_mode = "dontAsk";
+  }
+
+  return diff;
 }

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -237,6 +237,9 @@ export const useCreateConversation = () => {
             ? {
                 agentProfileId: effectiveAgentProfileId,
                 agentProfileKind: resolvedAgentProfile?.agent_kind,
+                agentProfileAcpServer:
+                  (resolvedAgentProfile as unknown as Record<string, unknown>)
+                    ?.acp_server as string | undefined,
               }
             : {}),
         });

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -237,9 +237,9 @@ export const useCreateConversation = () => {
             ? {
                 agentProfileId: effectiveAgentProfileId,
                 agentProfileKind: resolvedAgentProfile?.agent_kind,
-                agentProfileAcpServer:
-                  (resolvedAgentProfile as unknown as Record<string, unknown>)
-                    ?.acp_server as string | undefined,
+                agentProfileAcpServer: (
+                  resolvedAgentProfile as unknown as Record<string, unknown>
+                )?.acp_server as string | undefined,
               }
             : {}),
         });


### PR DESCRIPTION
## What

Forces `acp_session_mode=dontAsk` on every Claude Code ACP conversation launch path (inline `agent_settings`, both `buildStartConversationRequest` code paths, the onboarding profile, and the Settings → Agent diff builder) and fixes the Docker agent-server example to bind `--host 0.0.0.0`.

## Why

Claude Code's ACP provider defaults to `bypassPermissions` when no session mode is set. Its subprocess rejects that outright when its own config disables that mode, so the conversation never starts ("bypassPermissions error"). Forcing `dontAsk` on every launch surface avoids it — including pre-existing profiles/settings that predate this fix and never saved a session mode.

## Testing

- Added regression tests for the override across all launch surfaces: `buildStartConversationRequest` (inline settings, top-level payload, both `agentProfileId` paths), `buildAcpAgentSettingsDiff` (seeds `dontAsk` for `claude-code` only), and the onboarding `SetupAcpSecretsStep`.
- **Verified RED**: reverted just the fix's source files to their pre-fix state and confirmed exactly the new bug-relevant tests fail (right assertion, right reason); unrelated tests were unaffected. Restored the fix — all green.
- Along the way, found and fixed two **pre-existing tests** (`choose-agent-step.test.tsx`, `agent-settings.test.tsx`) that the original fix silently broke — their `toEqual` assertions never accounted for the new `acp_session_mode` field.
- Full suite: `602/603` files pass on top of latest `main` (`npm ci` synced to the current `@openhands/typescript-client` pin). The one pre-existing failure (`__tests__/scripts/stryker-diff.test.ts`) is an unrelated flake — a `git init` in a temp dir race under full-parallel test load — reproduces on `main` alone, unrelated to any file this PR touches, and passes standalone.

## Test plan

- [ ] Start a Claude Code ACP conversation from onboarding (fresh user) and confirm it starts without a `bypassPermissions` error
- [ ] Start a Claude Code ACP conversation from Settings → Agent
- [ ] Start a Claude Code ACP conversation from an agent profile
- [ ] `npx vitest run` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)