### PR TITLE
fix(ci): check out PR-description script at base branch tip, not frozen base SHA

### DIFF
--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -24,9 +24,16 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout trusted workflow scripts
+              # Check out the base BRANCH tip, not the PR's frozen base SHA. Both
+              # are trusted base-repo code under pull_request_target, but the
+              # workflow body always runs from the base-branch tip, so the script
+              # must too — otherwise a PR based on an older commit runs a stale
+              # check_pr_description.py that predates the flags this job passes it
+              # (e.g. --files-file), and the job crashes on argparse instead of
+              # validating the description.
               uses: actions/checkout@v7
               with:
-                  ref: ${{ github.event.pull_request.base.sha }}
+                  ref: ${{ github.event.pull_request.base.ref }}
 
             - name: Fetch changed file paths
               id: pr_files


### PR DESCRIPTION
HUMAN:

<!-- Human contributors: add a short note about your testing. -->
<!-- @sainikhiljuluri: this section is reserved for you. This PR was prepared by an
     automated analysis, which per this template must not write the HUMAN note.
     Please add your own note and mark the PR ready when you're satisfied. -->

AGENT:

This change was prepared by automated static analysis plus a runtime reproduction.
Evidence is below (command, real CI log, and the fix rationale).

---

## Why

The `PR Description Check` job runs under `pull_request_target`, so its **workflow
body always executes from the base-branch tip**. However, the checkout step pinned
the **validation script** to the PR's frozen base SHA:

```yaml
- uses: actions/checkout@v7
  with:
      ref: ${{ github.event.pull_request.base.sha }}
- run: python .github/scripts/check_pr_description.py --files-file pr-files.txt
```

The `--files-file` argument was added to both the workflow and the script in #16325
(2026-08-04). Any open PR whose recorded `base.sha` predates that commit checks out
an **older** `check_pr_description.py` that does not accept the flag, so the job
crashes instead of validating the description:

```
check_pr_description.py: error: unrecognized arguments: --files-file pr-files.txt
##[error]Process completed with exit code 2
```

The check then reports FAILURE regardless of the PR's actual description, and
`all-hands-bot` posts "CI is currently failing… fix the failing checks before
OpenHands reviews it", silently blocking review on otherwise-fine PRs. This affects
a large share of the older open PRs (those based before 2026-08-04).

## Summary

- Check out the base **branch** tip (`base.ref`) instead of the frozen base **SHA**
  (`base.sha`) for the "Checkout trusted workflow scripts" step, so the validation
  script stays in lockstep with the workflow body that invokes it.
- `base.ref` is the base repository's own branch, so it is exactly as trusted as
  `base.sha` under `pull_request_target` — the security property in the step's
  comment ("only run trusted validation code from the base branch checkout") is
  preserved.

## Issue Number

<!-- No `ready-for-dev`-labeled issue exists for this CI regression yet. This PR is
     a draft precisely so a maintainer can open/label a tracking issue (or apply
     `ready-for-dev` to one) per the process below. Filing details are in Notes. -->
Fixes #

## How to Test

Reproduction of the crash on an affected PR (real CI log from run 32644049846 on an
existing PR whose base predated #16325):

```
HEAD is now at 49b5fd4 ...            # base.sha checkout = pre-2026-08-04 script
python .github/scripts/check_pr_description.py --files-file pr-files.txt
check_pr_description.py: error: unrecognized arguments: --files-file pr-files.txt
Process completed with exit code 2
```

To confirm the fix logic locally without CI:

```bash
# Old (pre-#16325) script rejects the flag -> crash:
git show <pre-16325-sha>:.github/scripts/check_pr_description.py > /tmp/old.py
python /tmp/old.py --files-file /dev/null    # -> "unrecognized arguments"

# Current (main) script accepts it:
python .github/scripts/check_pr_description.py --files-file /dev/null   # parses fine
```

With this change, the checkout resolves to the base-branch tip, so the *current*
script (which accepts `--files-file`) is always the one that runs — the argparse
crash cannot occur regardless of how old the PR's base is.

## Video/Screenshots

Non-UI CI change; reproduction evidence is the terminal log under **How to Test**
(the `unrecognized arguments: --files-file` argparse error before the fix).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Root cause is a version skew intrinsic to `pull_request_target`: the workflow YAML
  is read from the default-branch tip while the checked-out script was pinned to the
  PR base SHA. Aligning both on `base.ref` fixes it with a one-line change.
- Suggested tracking issue title if one is desired: *"PR Description Check crashes
  (`argparse: unrecognized arguments: --files-file`) on PRs based before #16325"*.
- Prepared with automated assistance; opened as a draft pending a human note and a
  `ready-for-dev` tracking issue, per this template's process.
