### PR TITLE
fix: bound automation run-history fan-out and pause sidebar polling

### DIFF
--- a/__tests__/hooks/query/concurrency-limiter.test.ts
+++ b/__tests__/hooks/query/concurrency-limiter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { ConcurrencyLimiter } from "#/hooks/query/concurrency-limiter";
+
+/** A task whose completion the test controls. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("ConcurrencyLimiter", () => {
+  it("runs at most `limit` tasks at once and starts queued tasks in FIFO order as slots free", async () => {
+    // Arrange — five controllable tasks behind a limit of two.
+    const limiter = new ConcurrencyLimiter(2);
+    const started: number[] = [];
+    const gates = [0, 1, 2, 3, 4].map(() => deferred<void>());
+    const runs = gates.map((gate, index) =>
+      limiter.run(() => {
+        started.push(index);
+        return gate.promise;
+      }),
+    );
+
+    // Act & Assert — only the first two start; each completion admits the
+    // next waiter in arrival order.
+    await flushMicrotasks();
+    expect(started).toEqual([0, 1]);
+
+    gates[0].resolve();
+    await flushMicrotasks();
+    expect(started).toEqual([0, 1, 2]);
+
+    gates[1].resolve();
+    gates[2].resolve();
+    await flushMicrotasks();
+    expect(started).toEqual([0, 1, 2, 3, 4]);
+
+    gates[3].resolve();
+    gates[4].resolve();
+    await expect(Promise.all(runs)).resolves.toBeDefined();
+  });
+
+  it("releases a slot when a task rejects, so later tasks still run", async () => {
+    // Arrange — a single slot occupied by a failing task.
+    const limiter = new ConcurrencyLimiter(1);
+
+    // Act
+    const failing = limiter.run(() => Promise.reject(new Error("boom")));
+
+    // Assert — the failure propagates and the slot is free for the next task.
+    await expect(failing).rejects.toThrow("boom");
+    await expect(limiter.run(() => Promise.resolve("next"))).resolves.toBe(
+      "next",
+    );
+  });
+
+  it("rejects a task whose signal aborted while queued, without running it", async () => {
+    // Arrange — one slot held open so the second task queues, then gets
+    // aborted before a slot frees (a query unmounting while it waits).
+    const limiter = new ConcurrencyLimiter(1);
+    const gate = deferred<void>();
+    const first = limiter.run(() => gate.promise);
+    const controller = new AbortController();
+    let queuedTaskRan = false;
+    const queued = limiter.run(() => {
+      queuedTaskRan = true;
+      return Promise.resolve("ran");
+    }, controller.signal);
+    queued.catch(() => {}); // observed below; avoid an unhandled rejection
+
+    // Act
+    controller.abort();
+    gate.resolve();
+
+    // Assert — the aborted task rejects without executing, and its slot is
+    // handed on to later work.
+    await expect(queued).rejects.toThrow();
+    expect(queuedTaskRan).toBe(false);
+    await expect(limiter.run(() => Promise.resolve("after"))).resolves.toBe(
+      "after",
+    );
+    await first;
+  });
+});

--- a/__tests__/hooks/query/use-automation-run-summaries.test.tsx
+++ b/__tests__/hooks/query/use-automation-run-summaries.test.tsx
@@ -1,12 +1,14 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
-import { useAutomationRunSummaries } from "#/hooks/query/use-automation-run-summaries";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AutomationService from "#/api/automation-service/automation-service.api";
+import { useAutomationRunSummaries } from "#/hooks/query/use-automation-run-summaries";
 import {
   AutomationRunStatus,
   type Automation,
   type AutomationRun,
+  type AutomationRunsResponse,
 } from "#/types/automation";
 
 vi.mock("#/api/automation-service/automation-service.api", () => ({
@@ -39,10 +41,26 @@ function makeRun(status: AutomationRunStatus): AutomationRun {
   };
 }
 
+function makeAutomation(id: string): Automation {
+  return {
+    id,
+    name: `Automation ${id}`,
+    prompt: "p",
+    trigger: { type: "schedule", schedule_human: "Daily" },
+    enabled: true,
+    repository: "acme/repo",
+    model: "daily-profile",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+const emptyRuns: AutomationRunsResponse = { runs: [], total: 0 };
+
 function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
+  // No retry default override here: the hook's own `retry: false` is under
+  // test, and a global override would mask a regression.
+  const queryClient = new QueryClient();
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
@@ -126,5 +144,79 @@ describe("useAutomationRunSummaries — keeping an in-flight card current", () =
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useAutomationRunSummaries", () => {
+  beforeEach(() => {
+    vi.mocked(AutomationService.getAutomationRuns).mockReset();
+  });
+
+  it("keeps at most three runs requests in flight and starts the rest as responses arrive", async () => {
+    // Arrange — five automations, each runs request held open by the test.
+    const pending: Array<(response: AutomationRunsResponse) => void> = [];
+    vi.mocked(AutomationService.getAutomationRuns).mockImplementation(
+      () =>
+        new Promise<AutomationRunsResponse>((resolve) => {
+          pending.push(resolve);
+        }),
+    );
+    const fanOut = ["a-1", "a-2", "a-3", "a-4", "a-5"].map(makeAutomation);
+
+    // Act
+    const { result } = renderHook(() => useAutomationRunSummaries(fanOut), {
+      wrapper: createWrapper(),
+    });
+
+    // Assert — only three requests start despite five queries mounting.
+    await waitFor(() => {
+      expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(3);
+    });
+    expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(3);
+
+    // One response frees a slot for exactly one queued request.
+    await act(async () => {
+      pending.shift()!(emptyRuns);
+    });
+    await waitFor(() => {
+      expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(4);
+    });
+
+    // Draining the rest completes the whole fan-out.
+    await act(async () => {
+      pending.splice(0).forEach((resolve) => resolve(emptyRuns));
+    });
+    await waitFor(() => {
+      expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(5);
+    });
+    await act(async () => {
+      pending.splice(0).forEach((resolve) => resolve(emptyRuns));
+    });
+    await waitFor(() => {
+      fanOut.forEach((automation) => {
+        expect(result.current.get(automation.id)?.isLoading).toBe(false);
+      });
+    });
+  });
+
+  it("settles a failed summary into the error state without retrying", async () => {
+    // Arrange — the runs request fails outright.
+    vi.mocked(AutomationService.getAutomationRuns).mockRejectedValue(
+      new Error("automation service unavailable"),
+    );
+
+    // Act
+    const { result } = renderHook(
+      () => useAutomationRunSummaries([makeAutomation("a-1")]),
+      { wrapper: createWrapper() },
+    );
+
+    // Assert — the entry reports the error promptly (retries would keep it
+    // loading for seconds) and the service was asked exactly once.
+    await waitFor(() => {
+      expect(result.current.get("a-1")?.isError).toBe(true);
+    });
+    expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(1);
+    expect(result.current.get("a-1")?.summary).toBeNull();
   });
 });

--- a/__tests__/hooks/query/use-automations-backend-switch.test.tsx
+++ b/__tests__/hooks/query/use-automations-backend-switch.test.tsx
@@ -12,6 +12,7 @@ import {
 import { ActiveBackendProvider } from "#/contexts/active-backend-context";
 import {
   useAutomations,
+  useCancelAutomationRun,
   useDispatchAutomation,
   useDeleteAutomation,
   useToggleAutomation,
@@ -37,6 +38,7 @@ vi.mock("#/api/automation-service/automation-service.api", () => ({
     getAutomation: vi.fn(),
     getAutomationRuns: vi.fn(),
     dispatchAutomation: vi.fn(),
+    cancelAutomationRun: vi.fn(),
     deleteAutomation: vi.fn(),
     updateAutomation: vi.fn(),
     toggleAutomation: vi.fn(),
@@ -114,6 +116,10 @@ beforeEach(() => {
   vi.mocked(AutomationService.getAutomationRuns).mockReset();
   vi.mocked(AutomationService.dispatchAutomation).mockReset();
   vi.mocked(AutomationService.dispatchAutomation).mockResolvedValue(
+    automationRun,
+  );
+  vi.mocked(AutomationService.cancelAutomationRun).mockReset();
+  vi.mocked(AutomationService.cancelAutomationRun).mockResolvedValue(
     automationRun,
   );
   vi.mocked(AutomationService.deleteAutomation).mockReset();
@@ -250,6 +256,74 @@ describe("useAutomationRuns — polling", () => {
     },
     15000,
   );
+});
+
+describe("run mutations — sidebar conversation refresh", () => {
+  // The sidebar's conversation poll is paused on automation routes, so these
+  // mutations are what keep the sidebar list current for a run's conversation.
+  function makeClientWrapper() {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <ActiveBackendProvider>{children}</ActiveBackendProvider>
+        </QueryClientProvider>
+      );
+    }
+    return { queryClient, Wrapper };
+  }
+
+  const conversationsKey = [
+    "user",
+    "conversations",
+    "paginated",
+    20,
+    "local-1",
+    null,
+  ];
+
+  it("invalidates the cached conversation list after a successful dispatch", async () => {
+    // Arrange — a sidebar list already sits in the cache.
+    const { queryClient, Wrapper } = makeClientWrapper();
+    queryClient.setQueryData(conversationsKey, { pages: [], pageParams: [] });
+    const { result } = renderHook(() => useDispatchAutomation(), {
+      wrapper: Wrapper,
+    });
+
+    // Act
+    await act(async () => {
+      await result.current.mutateAsync("auto-1");
+    });
+
+    // Assert
+    expect(queryClient.getQueryState(conversationsKey)?.isInvalidated).toBe(
+      true,
+    );
+  });
+
+  it("invalidates the cached conversation list after a successful cancel", async () => {
+    // Arrange
+    const { queryClient, Wrapper } = makeClientWrapper();
+    queryClient.setQueryData(conversationsKey, { pages: [], pageParams: [] });
+    const { result } = renderHook(() => useCancelAutomationRun(), {
+      wrapper: Wrapper,
+    });
+
+    // Act
+    await act(async () => {
+      await result.current.mutateAsync({
+        automationId: "auto-1",
+        runId: "run-1",
+      });
+    });
+
+    // Assert
+    expect(queryClient.getQueryState(conversationsKey)?.isInvalidated).toBe(
+      true,
+    );
+  });
 });
 
 describe("automation mutation hooks — analytics tracking", () => {

--- a/__tests__/hooks/query/use-latest-automation-runs.test.tsx
+++ b/__tests__/hooks/query/use-latest-automation-runs.test.tsx
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AutomationService from "#/api/automation-service/automation-service.api";
+import { useLatestAutomationRuns } from "#/hooks/query/use-latest-automation-runs";
+import type { Automation, AutomationRunsResponse } from "#/types/automation";
+
+vi.mock("#/api/automation-service/automation-service.api", () => ({
+  default: {
+    getAutomationRuns: vi.fn(),
+  },
+}));
+
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => ({
+    backend: { id: "test-backend", kind: "local" },
+    orgId: null,
+  }),
+}));
+
+function makeAutomation(id: string): Automation {
+  return {
+    id,
+    name: `Automation ${id}`,
+    prompt: "p",
+    trigger: { type: "schedule", schedule_human: "Daily" },
+    enabled: true,
+    repository: "acme/repo",
+    model: "daily-profile",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+const emptyRuns: AutomationRunsResponse = { runs: [], total: 0 };
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useLatestAutomationRuns", () => {
+  beforeEach(() => {
+    vi.mocked(AutomationService.getAutomationRuns).mockReset();
+  });
+
+  it("keeps at most three runs requests in flight across the home fan-out", async () => {
+    // Arrange — five automations, each runs request held open by the test.
+    const pending: Array<(response: AutomationRunsResponse) => void> = [];
+    vi.mocked(AutomationService.getAutomationRuns).mockImplementation(
+      () =>
+        new Promise<AutomationRunsResponse>((resolve) => {
+          pending.push(resolve);
+        }),
+    );
+    const automations = ["a-1", "a-2", "a-3", "a-4", "a-5"].map(makeAutomation);
+
+    // Act
+    const { result } = renderHook(() => useLatestAutomationRuns(automations), {
+      wrapper: createWrapper(),
+    });
+
+    // Assert — only three requests start; the rest follow as responses free
+    // slots, until every automation's state settles.
+    await waitFor(() => {
+      expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(3);
+    });
+    expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      pending.splice(0).forEach((resolve) => resolve(emptyRuns));
+    });
+    await waitFor(() => {
+      expect(AutomationService.getAutomationRuns).toHaveBeenCalledTimes(5);
+    });
+    await act(async () => {
+      pending.splice(0).forEach((resolve) => resolve(emptyRuns));
+    });
+    await waitFor(() => {
+      automations.forEach((automation) => {
+        expect(result.current.get(automation.id)?.isLoading).toBe(false);
+      });
+    });
+  });
+});

--- a/__tests__/hooks/query/use-paginated-conversations.test.tsx
+++ b/__tests__/hooks/query/use-paginated-conversations.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import { NavigationProvider } from "#/context/navigation-context";
+import { usePaginatedConversations } from "#/hooks/query/use-paginated-conversations";
+import type { AppConversationPage } from "#/api/conversation-service/agent-server-conversation-service.types";
+
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: {
+      searchConversations: vi.fn(),
+    },
+  }),
+);
+
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => ({
+    backend: { id: "test-backend", kind: "local" },
+    orgId: null,
+  }),
+}));
+
+const emptyPage: AppConversationPage = { items: [], next_page_id: null };
+
+function createWrapper(currentPath: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const navigation = {
+    currentPath,
+    conversationId: null,
+    isNavigating: false,
+    navigate: () => {},
+  };
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <NavigationProvider value={navigation}>{children}</NavigationProvider>
+    </QueryClientProvider>
+  );
+}
+
+/** Flush timers and the promise work they unblock inside act. */
+async function flushAsync(ms = 0) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("usePaginatedConversations — interval polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(AgentServerConversationService.searchConversations).mockReset();
+    vi.mocked(
+      AgentServerConversationService.searchConversations,
+    ).mockResolvedValue(emptyPage);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fetches once but does not interval-poll while an automations route is open", async () => {
+    // Arrange & Act — mount the sidebar list on the automations route.
+    renderHook(() => usePaginatedConversations(), {
+      wrapper: createWrapper("/automations"),
+    });
+    await flushAsync();
+    await flushAsync();
+
+    // Assert — the initial fetch happened, and a full poll window later no
+    // further request has fired.
+    expect(
+      AgentServerConversationService.searchConversations,
+    ).toHaveBeenCalledTimes(1);
+    await flushAsync(31_000);
+    expect(
+      AgentServerConversationService.searchConversations,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the 30s poll on routes outside the automation surface", async () => {
+    // Arrange & Act
+    renderHook(() => usePaginatedConversations(), {
+      wrapper: createWrapper("/"),
+    });
+    await flushAsync();
+    await flushAsync();
+    expect(
+      AgentServerConversationService.searchConversations,
+    ).toHaveBeenCalledTimes(1);
+
+    // Assert — one poll window later the list refreshed.
+    await flushAsync(31_000);
+    expect(
+      AgentServerConversationService.searchConversations,
+    ).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/manifests/automation-interface.test.ts
+++ b/__tests__/manifests/automation-interface.test.ts
@@ -48,6 +48,29 @@ describe("the automation interface seam", () => {
     });
   });
 
+  it("classifies pathnames inside and outside the automation surface", async () => {
+    // Arrange — routes are the host's own registrations, so the matcher
+    // answers with or without an admitted manifest.
+    const seam = await loadSeam(undefined);
+
+    // Act & Assert
+    expect({
+      list: seam.isAutomationsRoute("/automations"),
+      detail: seam.isAutomationsRoute("/automations/abc-123"),
+      templates: seam.isAutomationsRoute("/automations/templates"),
+      home: seam.isAutomationsRoute("/"),
+      conversation: seam.isAutomationsRoute("/conversations/abc-123"),
+      lookalike: seam.isAutomationsRoute("/automations-foo"),
+    }).toEqual({
+      list: true,
+      detail: true,
+      templates: true,
+      home: false,
+      conversation: false,
+      lookalike: false,
+    });
+  });
+
   it("serves an admitted manifest's data", async () => {
     // Arrange
     const seam = await loadSeam(createInterfaceManifest());

--- a/src/hooks/query/concurrency-limiter.ts
+++ b/src/hooks/query/concurrency-limiter.ts
@@ -1,0 +1,55 @@
+/**
+ * A FIFO promise semaphore: at most `limit` wrapped tasks run at once; the
+ * rest wait in arrival order. Wrap a queryFn's work in `run` to bound how many
+ * of a query family's requests are in flight simultaneously.
+ */
+export class ConcurrencyLimiter {
+  private active = 0;
+
+  private readonly queue: Array<() => void> = [];
+
+  constructor(private readonly limit: number) {}
+
+  async run<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    await this.acquire();
+    try {
+      // A query cancelled while queued (e.g. its last observer unmounted)
+      // frees its slot without ever hitting the network.
+      if (signal?.aborted) {
+        throw signal.reason ?? new DOMException("Aborted", "AbortError");
+      }
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.limit) {
+      this.active += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.queue.push(resolve);
+    });
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      // The waiter inherits the released slot directly, so `active` stays put.
+      next();
+    } else {
+      this.active -= 1;
+    }
+  }
+}
+
+/**
+ * Shared by every per-automation runs query: the dashboard and home page each
+ * fan out one GET .../runs request per automation, which can exhaust the
+ * automation service's DB connection pool (~15 connections) and stall every
+ * request for the pool's 30s acquisition timeout. Three in flight keeps the
+ * surfaces responsive without saturating the pool.
+ */
+export const automationRunRequestsLimiter = new ConcurrencyLimiter(3);

--- a/src/hooks/query/use-automation-run-summaries.ts
+++ b/src/hooks/query/use-automation-run-summaries.ts
@@ -1,6 +1,7 @@
 import { useQueries } from "@tanstack/react-query";
 import AutomationService from "#/api/automation-service/automation-service.api";
 import { useActiveBackend } from "#/contexts/active-backend-context";
+import { automationRunRequestsLimiter } from "#/hooks/query/concurrency-limiter";
 import { AUTOMATION_RUNS_QUERY_KEY } from "#/hooks/query/use-automation-detail";
 import {
   summarizeAutomationRuns,
@@ -58,13 +59,25 @@ export function useAutomationRunSummaries(
         active.backend.id,
         active.orgId,
       ],
-      queryFn: () =>
-        AutomationService.getAutomationRuns(
-          automation.id,
-          RECENT_RUN_SAMPLE_SIZE,
-          0,
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        automationRunRequestsLimiter.run(
+          () =>
+            AutomationService.getAutomationRuns(
+              automation.id,
+              RECENT_RUN_SAMPLE_SIZE,
+              0,
+            ),
+          signal,
         ),
       staleTime: 60 * 1000,
+      // No retries and no focus refetch: a failed summary settles into the
+      // dashboard's degraded "unknown" health state instead of hammering an
+      // unhealthy automation service (mirrors useLatestAutomationRuns).
+      retry: false,
+      refetchOnWindowFocus: false,
+      // isError already renders as the degraded indicator; a failing fan-out
+      // must not raise one global error toast per automation.
+      meta: { disableToast: true },
       enabled: enabled && !!automation.id,
       refetchInterval: (query: {
         state: { data?: AutomationRunsResponse };

--- a/src/hooks/query/use-automations.ts
+++ b/src/hooks/query/use-automations.ts
@@ -103,6 +103,10 @@ export function useDispatchAutomation() {
       queryClient.invalidateQueries({
         queryKey: [...AUTOMATION_RUNS_QUERY_KEY, id],
       });
+      // Runs carry a conversation_id surfaced in the sidebar, and the
+      // conversation poll is paused on automation routes, so refresh the list
+      // explicitly (same prefix all conversation mutations invalidate).
+      queryClient.invalidateQueries({ queryKey: ["user", "conversations"] });
       trackAutomationExecuted({ backendKind: active.backend.kind });
     },
   });
@@ -119,6 +123,9 @@ export function useCancelAutomationRun() {
       queryClient.invalidateQueries({
         queryKey: [...AUTOMATION_RUNS_QUERY_KEY, automationId],
       });
+      // Same staleness hole as dispatch: the cancelled run's conversation
+      // shows in the sidebar while the poll is paused on automation routes.
+      queryClient.invalidateQueries({ queryKey: ["user", "conversations"] });
     },
   });
 }

--- a/src/hooks/query/use-latest-automation-runs.ts
+++ b/src/hooks/query/use-latest-automation-runs.ts
@@ -1,6 +1,7 @@
 import { useQueries } from "@tanstack/react-query";
 import AutomationService from "#/api/automation-service/automation-service.api";
 import { useActiveBackend } from "#/contexts/active-backend-context";
+import { automationRunRequestsLimiter } from "#/hooks/query/concurrency-limiter";
 import {
   AutomationRunStatus,
   type Automation,
@@ -53,11 +54,15 @@ export function useLatestAutomationRuns(
         active.backend.id,
         active.orgId,
       ],
-      queryFn: () =>
-        AutomationService.getAutomationRuns(
-          automation.id,
-          AUTOMATION_RUN_ACTIVITY_LIMIT,
-          0,
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        automationRunRequestsLimiter.run(
+          () =>
+            AutomationService.getAutomationRuns(
+              automation.id,
+              AUTOMATION_RUN_ACTIVITY_LIMIT,
+              0,
+            ),
+          signal,
         ),
       staleTime: 60 * 1000,
       // No retries: the home section settles into its degraded "unknown"

--- a/src/hooks/query/use-paginated-conversations.ts
+++ b/src/hooks/query/use-paginated-conversations.ts
@@ -2,12 +2,15 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { useIsAuthed } from "./use-is-authed";
 import { isNoBackend } from "#/api/backend-registry/active-store";
+import { useNavigation } from "#/context/navigation-context";
 import { useActiveBackend } from "#/contexts/active-backend-context";
+import { isAutomationsRoute } from "#/manifests/automation-interface";
 import { AppConversationPage } from "#/api/conversation-service/agent-server-conversation-service.types";
 
 export const usePaginatedConversations = (limit: number = 20) => {
   const { data: userIsAuthenticated } = useIsAuthed();
   const active = useActiveBackend();
+  const { currentPath } = useNavigation();
   const hasBackend = !isNoBackend(active.backend);
 
   return useInfiniteQuery({
@@ -42,7 +45,14 @@ export const usePaginatedConversations = (limit: number = 20) => {
     // skeletons) on `isLoading`, not `isFetching` — `isFetching` flips back to
     // true on every background refetch, which would cause the skeleton to
     // flicker on each poll when the list is empty.
-    refetchInterval: 30_000,
+    //
+    // The interval is paused on automation routes: the dashboard there already
+    // fans out one runs request per automation, and the sidebar list is not
+    // the focus. Only the poll pauses — the initial fetch still happens — and
+    // mutations that create or cancel runs invalidate ["user", "conversations"]
+    // so the sidebar stays correct while paused.
+    refetchInterval: isAutomationsRoute(currentPath) ? false : 30_000,
+    refetchIntervalInBackground: false,
     // A successful fetch proves the backend is reachable. The global
     // QueryCache onSuccess handler reads this to clear any persisted
     // failure state, re-arming the status dot without user intervention.

--- a/src/manifests/automation-interface.ts
+++ b/src/manifests/automation-interface.ts
@@ -126,6 +126,17 @@ export function automationTemplatesPath(): string {
 }
 
 /**
+ * Whether `path` (a location pathname) is inside the automation surface: the
+ * list route itself or anything nested under it (detail, setup, templates,
+ * git-sync). Prefix-safe: "/automations-foo" does not match.
+ */
+export function isAutomationsRoute(path: string): boolean {
+  return (
+    path === MOUNTED_ROUTES.list || path.startsWith(`${MOUNTED_ROUTES.list}/`)
+  );
+}
+
+/**
  * A declared endpoint path. Empty for one the manifest may omit - the two a
  * bundle needs were added after the block shipped - so a caller that needs one
  * says so rather than reading a host-held default that does not exist.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes.

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

---

## Why

<!-- Describe problem, motivation, etc. -->

Opening the Automation view fired one `GET /api/automation/v1/{id}/runs?limit=20` request per listed automation, all in parallel and with default React Query retries. In the reporter's capture (21 automations), the burst exhausted the automation service's DB connection pool (~15 effective connections, 30s acquisition timeout): all 21 requests stalled ~30s, six returned HTTP 500, and immediate retries succeeded in ~300–450ms. The service has no batch run-summaries endpoint yet, so the fan-out must be bounded client-side. Separately, the sidebar's conversation list kept interval-polling `/api/conversations/search` (~365 KiB per response) while the automations route was open.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add `ConcurrencyLimiter` (FIFO promise semaphore) and bound both per-automation runs fan-outs — dashboard summaries and home latest-runs — to 3 concurrent requests via a shared instance; the summaries hook also gains `retry: false`, `refetchOnWindowFocus: false`, and `meta.disableToast` so failures settle into the existing "unknown" health state without retry storms or per-automation error toasts.
- Pause the sidebar conversation list's 30s poll while any `/automations*` route is open (new `isAutomationsRoute` helper; the initial fetch is unchanged), and invalidate `["user", "conversations"]` when a run is dispatched or cancelled so its conversation still appears in the sidebar while the poll is paused.
- Add regression tests: limiter semantics, bounded fan-out for both hooks, no-retry failure degradation, route-based poll pause/resume, and dispatch/cancel conversation-cache invalidation.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #16559

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm install`, then `npm run dev` with an automation backend holding 20+ automations (the original report used a local SQLite-backed service).
2. Open `/automations` with the browser Network tab recording:

- the automation cards render as soon as the list response arrives;
- `.../runs?limit=20` requests proceed in a staircase of at most 3 concurrent, instead of 20+ simultaneous requests stalling for ~30s;
- `/api/conversations/search` fires once and does not repeat every 30s while on any `/automations*` route; navigate to `/` and confirm the poll resumes.

3. Dispatch (or cancel) a run from the dashboard and confirm an immediate `/api/conversations/search` refetch so the run's conversation appears in the sidebar.
4. Stop the automation service and reload `/automations`: cards show the "unknown" health indicator, each runs request is attempted once (no retry storm), and no per-automation error toast spam appears.
5. Unit tests: `npx vitest run __tests__/hooks/query __tests__/manifests`.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

N/A.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `ee6bf2fc1e31ca6f5c32349ac020454ff75351e7` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-ee6bf2f
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-ee6bf2f
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-ee6bf2f-amd64
ghcr.io/openhands/agent-canvas:hieptl-oss-9506-amd64
ghcr.io/openhands/agent-canvas:pr-16867-amd64
ghcr.io/openhands/agent-canvas:sha-ee6bf2f-arm64
ghcr.io/openhands/agent-canvas:hieptl-oss-9506-arm64
ghcr.io/openhands/agent-canvas:pr-16867-arm64
ghcr.io/openhands/agent-canvas:sha-ee6bf2f
ghcr.io/openhands/agent-canvas:hieptl-oss-9506
ghcr.io/openhands/agent-canvas:pr-16867
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-ee6bf2f`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-ee6bf2f-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->