### PR TITLE
fix: title generation uses the same LLM as the running agent profile

### DIFF
--- a/__tests__/utils/title-llm-profile.test.ts
+++ b/__tests__/utils/title-llm-profile.test.ts
@@ -40,4 +40,24 @@ describe("resolveTitleLlmProfile", () => {
       }),
     ).toBeUndefined();
   });
+
+  describe("agentLlmProfileRef priority", () => {
+    it("uses agentLlmProfileRef when no explicit preference is set", () => {
+      expect(resolveTitleLlmProfile(null, profiles, "Titles")).toBe("Titles");
+    });
+
+    it("explicit preference takes priority over agentLlmProfileRef", () => {
+      expect(resolveTitleLlmProfile("Titles", profiles, "Default")).toBe(
+        "Titles",
+      );
+    });
+
+    it("falls back to active_profile when agentLlmProfileRef is not in the list", () => {
+      expect(resolveTitleLlmProfile(null, profiles, "Deleted")).toBe("Default");
+    });
+
+    it("ignores null agentLlmProfileRef and falls back to active_profile", () => {
+      expect(resolveTitleLlmProfile(null, profiles, null)).toBe("Default");
+    });
+  });
 });

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -352,6 +352,11 @@ export interface CreateConversationOptions {
   // encrypted-settings builder; cloud sends it as a flat request field.
   agentProfileId?: string;
   agentProfileKind?: AgentKind;
+  // The LLM profile pinned to the launched agent profile (llm_profile_ref).
+  // When set and no explicit title_llm_profile preference exists, title
+  // generation uses this profile so both the agent and its title use the
+  // same model.
+  agentLlmProfileRef?: string | null;
 }
 
 class AgentServerConversationService {
@@ -416,6 +421,7 @@ class AgentServerConversationService {
       sandboxId,
       agentProfileId,
       agentProfileKind,
+      agentLlmProfileRef,
     } = options;
 
     if (getActiveBackend().backend.kind === "cloud") {
@@ -454,6 +460,7 @@ class AgentServerConversationService {
     const titleLlmProfile = resolveTitleLlmProfile(
       settings.title_llm_profile,
       profiles,
+      agentLlmProfileRef,
     );
     const conversationId = uuidv4();
     // @spec WUP-001 — Send an absolute working_dir to the agent-server.

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -237,6 +237,9 @@ export const useCreateConversation = () => {
             ? {
                 agentProfileId: effectiveAgentProfileId,
                 agentProfileKind: resolvedAgentProfile?.agent_kind,
+                // Let title generation use the same LLM as the agent profile
+                // so the title and the agent steps share a model (#16885).
+                agentLlmProfileRef: resolvedAgentProfile?.llm_profile_ref,
               }
             : {}),
         });

--- a/src/utils/title-llm-profile.ts
+++ b/src/utils/title-llm-profile.ts
@@ -1,8 +1,19 @@
 import type { ProfileListResponse } from "#/api/profiles-service/profiles-service.api";
 
+/**
+ * Resolve which LLM profile should generate the conversation title.
+ *
+ * Priority:
+ *   1. `preference` — the user's explicit `title_llm_profile` setting.
+ *   2. `agentLlmProfileRef` — the LLM pinned to the running agent profile,
+ *      so title generation uses the same model as the agent when no explicit
+ *      preference is set.
+ *   3. `profiles.active_profile` — account-wide fallback.
+ */
 export function resolveTitleLlmProfile(
   preference: string | null | undefined,
   profiles: ProfileListResponse | undefined,
+  agentLlmProfileRef?: string | null,
 ): string | undefined {
   if (!profiles) return undefined;
 
@@ -11,6 +22,9 @@ export function resolveTitleLlmProfile(
   );
   if (preference && availableProfiles.has(preference)) {
     return preference;
+  }
+  if (agentLlmProfileRef && availableProfiles.has(agentLlmProfileRef)) {
+    return agentLlmProfileRef;
   }
   if (
     profiles.active_profile &&


### PR DESCRIPTION
## Summary

Fixes #16885 — when a conversation is launched from a named agent profile whose `llm_profile_ref` differs from the account-wide active LLM profile, title generation was silently using the wrong model.

## Root Cause

`resolveTitleLlmProfile` resolved the title model with only two fallbacks:
1. `settings.title_llm_profile` — explicit user choice (defaults to `null`)
2. `profiles.active_profile` — account-wide active LLM

It never consulted the *agent profile's* pinned LLM. So when a named profile has `llm_profile_ref = "powerful"` but the account-wide active profile is `"fast"`, the agent ran with `"powerful"` while title generation used `"fast"`.

## Fix

Three small additive changes (44 lines total):

**`src/utils/title-llm-profile.ts`** — added optional `agentLlmProfileRef` parameter as a mid-priority fallback:

| Priority | Source |
|---|---|
| 1 | `settings.title_llm_profile` — explicit user override |
| 2 | **`agentLlmProfileRef`** ← new: agent profile's pinned LLM |
| 3 | `profiles.active_profile` — account-wide fallback |

**`src/api/conversation-service/agent-server-conversation-service.api.ts`** — added `agentLlmProfileRef?: string | null` to `Cr**`src/apsationOptions` and threads it into `resolveTitleLlmProfile`.

**`src/hooks/mutation/use-create-conversation.ts`** — passes `resolvedAgentProfile.llm_profile_ref` as `agentLlmProfileRef` when launching from a named profile.

## Tests

Added 4 new unit tests in `__tests__/utils/title-llm-profile.test.ts`:
- `agentLlmProfileRef` is used when no explicit preference is set
- Explicit `preference` still wins over `agentLlmProfileRef`
- Stale/missing `agentLlmProfileRef` falls through to `active_profile`
- `null` `agentLlmProfileRef` is ignored

All 8 tests pass (4 existing + 4 new).

## Backward Compatibility

Fully backward-compatible: `agentLlmProfileRef` is optional. The `agent_settings` launch path (where `Fully backward-compatible: `agentLlmProfileRef` is optional. The \es to fall back to `active_profile` as before.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `97160ee70d3ef78434b6145c0bd435e249edda72` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-97160ee
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-97160ee
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-97160ee-amd64
ghcr.io/openhands/agent-canvas:fix-title-generation-llm-mismatch-amd64
ghcr.io/openhands/agent-canvas:pr-16886-amd64
ghcr.io/openhands/agent-canvas:sha-97160ee-arm64
ghcr.io/openhands/agent-canvas:fix-title-generation-llm-mismatch-arm64
ghcr.io/openhands/agent-canvas:pr-16886-arm64
ghcr.io/openhands/agent-canvas:sha-97160ee
ghcr.io/openhands/agent-canvas:fix-title-generation-llm-mismatch
ghcr.io/openhands/agent-canvas:pr-16886
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-97160ee`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-97160ee-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->