### PR TITLE
fix: scope plugin queries to the active backend

### DIFF
--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -261,7 +261,9 @@ export const useCreateConversation = () => {
         let installed: InstalledPluginInfo[] = [];
         try {
           installed = await queryClient.ensureQueryData({
-            queryKey: PLUGINS_QUERY_KEYS.installed,
+            // Same key `usePlugins` writes. Unscoped, this served the previous
+            // backend's list and attached plugins the target server lacks.
+            queryKey: [...PLUGINS_QUERY_KEYS.installed, backend.id, orgId],
             queryFn: () => PluginsManagementService.listInstalledPlugins(),
           });
         } catch {

--- a/src/hooks/query/use-local-plugins.ts
+++ b/src/hooks/query/use-local-plugins.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import PluginsService, { type LocalPlugin } from "#/api/plugins-service";
 import { PLUGINS_QUERY_KEYS } from "./query-keys";
 
@@ -8,10 +9,13 @@ import { PLUGINS_QUERY_KEYS } from "./query-keys";
  * cloud backend yields an empty list. Rendered as the read-only "Local" group on
  * the Plugins page. Mirrors `usePlugins`.
  */
-export const useLocalPlugins = () =>
-  useQuery<LocalPlugin[]>({
-    queryKey: PLUGINS_QUERY_KEYS.local,
+export const useLocalPlugins = () => {
+  const { backend, orgId } = useActiveBackend();
+
+  return useQuery<LocalPlugin[]>({
+    queryKey: [...PLUGINS_QUERY_KEYS.local, backend.id, orgId],
     queryFn: () => PluginsService.getLocalPlugins(),
     staleTime: 1000 * 60 * 10, // 10 minutes
     refetchOnWindowFocus: false,
   });
+};

--- a/src/hooks/query/use-plugin-file-content.ts
+++ b/src/hooks/query/use-plugin-file-content.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import PluginsService, { type PluginFileContent } from "#/api/plugins-service";
 
 /**
@@ -9,9 +10,17 @@ import PluginsService, { type PluginFileContent } from "#/api/plugins-service";
 export const usePluginFileContent = (
   basePath: string | null,
   relativePath: string | null,
-) =>
-  useQuery<PluginFileContent>({
-    queryKey: ["plugin-file-content", basePath, relativePath],
+) => {
+  const { backend, orgId } = useActiveBackend();
+
+  return useQuery<PluginFileContent>({
+    queryKey: [
+      "plugin-file-content",
+      basePath,
+      relativePath,
+      backend.id,
+      orgId,
+    ],
     queryFn: () => {
       if (!basePath || !relativePath) throw new Error("No file selected");
       return PluginsService.getPluginFileContent(basePath, relativePath);
@@ -21,3 +30,4 @@ export const usePluginFileContent = (
     staleTime: 1000 * 60 * 10, // 10 minutes
     refetchOnWindowFocus: false,
   });
+};

--- a/src/hooks/query/use-plugins-marketplace.ts
+++ b/src/hooks/query/use-plugins-marketplace.ts
@@ -1,15 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import PluginsService, { type MarketplacePlugin } from "#/api/plugins-service";
+import { PLUGINS_QUERY_KEYS } from "./query-keys";
 
 /**
  * Query hook for the dynamic plugins marketplace catalog. The catalog is global
  * (not project-scoped), and currently local-backend only — a cloud backend
  * yields an empty list. Mirrors `useSkills`.
  */
-export const usePluginsMarketplace = () =>
-  useQuery<MarketplacePlugin[]>({
-    queryKey: ["plugins-marketplace"],
+export const usePluginsMarketplace = () => {
+  const { backend, orgId } = useActiveBackend();
+
+  return useQuery<MarketplacePlugin[]>({
+    queryKey: [...PLUGINS_QUERY_KEYS.marketplace, backend.id, orgId],
     queryFn: () => PluginsService.getPluginsMarketplace(),
     staleTime: 1000 * 60 * 10, // 10 minutes – catalog rarely changes
     refetchOnWindowFocus: false,
   });
+};

--- a/src/hooks/query/use-plugins.test.tsx
+++ b/src/hooks/query/use-plugins.test.tsx
@@ -1,0 +1,43 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import PluginsManagementService from "#/api/plugins-management-service";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { usePlugins } from "./use-plugins";
+import { PLUGINS_QUERY_KEYS } from "./query-keys";
+
+function renderUsePlugins() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <ActiveBackendProvider>{children}</ActiveBackendProvider>
+    </QueryClientProvider>
+  );
+  return { queryClient, ...renderHook(() => usePlugins(), { wrapper }) };
+}
+
+describe("usePlugins", () => {
+  it("scopes its cache entry to the active backend", async () => {
+    vi.spyOn(
+      PluginsManagementService,
+      "listInstalledPlugins",
+    ).mockResolvedValue([]);
+
+    const { queryClient, result } = renderUsePlugins();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [key] = queryClient
+      .getQueryCache()
+      .getAll()
+      .map((query) => query.queryKey);
+    // Unscoped, a second backend reads this same entry and shows the first
+    // backend's plugins.
+    expect(key.slice(0, PLUGINS_QUERY_KEYS.installed.length)).toEqual([
+      ...PLUGINS_QUERY_KEYS.installed,
+    ]);
+    expect(key.length).toBe(PLUGINS_QUERY_KEYS.installed.length + 2);
+  });
+});

--- a/src/hooks/query/use-plugins.ts
+++ b/src/hooks/query/use-plugins.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import PluginsManagementService, {
   type InstalledPluginInfo,
 } from "#/api/plugins-management-service";
@@ -8,10 +9,13 @@ import { PLUGINS_QUERY_KEYS } from "./query-keys";
  * Query hook for the plugins installed on the local agent-server. Local-backend
  * only — a cloud backend yields an empty list. Mirrors `useSkills`.
  */
-export const usePlugins = () =>
-  useQuery<InstalledPluginInfo[]>({
-    queryKey: PLUGINS_QUERY_KEYS.installed,
+export const usePlugins = () => {
+  const { backend, orgId } = useActiveBackend();
+
+  return useQuery<InstalledPluginInfo[]>({
+    queryKey: [...PLUGINS_QUERY_KEYS.installed, backend.id, orgId],
     queryFn: () => PluginsManagementService.listInstalledPlugins(),
     staleTime: 1000 * 60 * 10, // 10 minutes
     refetchOnWindowFocus: false,
   });
+};


### PR DESCRIPTION
HUMAN:

Ran the new test on this branch and on main with the fix reverted: fails there with one key segment, passes here with the backend and org appended.

AGENT:

Ran on a Linux dev box, Node 24, from a clean checkout of this branch.

Reproduction of the defect on the current sources (fix reverted, new test kept):

```
$ git stash push src/hooks/query/use-plugins.ts src/hooks/query/use-local-plugins.ts \
    src/hooks/query/use-plugins-marketplace.ts src/hooks/query/use-plugin-file-content.ts \
    src/hooks/mutation/use-create-conversation.ts
$ npx vitest run src/hooks/query/use-plugins.test.tsx

 × scopes its cache entry to the active backend
   AssertionError: expected 1 to be 3 // Object.is equality

 Tests  1 failed (1)
```

One key segment (`plugins-installed`) instead of the prefix plus backend id and org id — the cache slot every backend shares.

After restoring the fix:

```
$ npx vitest run src/hooks/query/use-plugins.test.tsx
 ✓ scopes its cache entry to the active backend
 Tests  1 passed (1)

$ npx vitest run __tests__/components/features/plugins src/hooks/query src/hooks/mutation \
    src/api/plugins-service.test.ts src/api/plugins-management-service.test.ts
 Test Files  10 passed (10)
      Tests  48 passed (48)

$ npx tsc --noEmit -p tsconfig.json     # clean on the five touched files
$ npx eslint <the five files>           # clean
```

---

## Why

Four plugin queries cache under keys that name no backend:

```ts
queryKey: PLUGINS_QUERY_KEYS.installed        // use-plugins
queryKey: PLUGINS_QUERY_KEYS.local            // use-local-plugins
queryKey: ["plugins-marketplace"]             // use-plugins-marketplace
queryKey: ["plugin-file-content", basePath, relativePath]
```

Switching registered backends inside the cache lifetime shows the previous server's plugins. The consequence that reaches persisted state is in `use-create-conversation`, which reads the installed list through `ensureQueryData` on that same key — so a conversation created after a switch snapshots the previous backend's enabled plugins and attaches plugins the selected server does not have installed.

## Summary

- Append the active backend id and org id to the installed, local, marketplace and file-content plugin query keys, matching `use-agent-profiles` / `use-app-installations` / `use-search-subdirs`.
- Point `use-create-conversation`'s `ensureQueryData` call at the same scoped key so conversation creation reads the active backend's list.
- Move `use-plugins-marketplace` off its inline literal onto `PLUGINS_QUERY_KEYS.marketplace`.
- Mutations are unchanged: TanStack invalidates by key prefix, so the existing keys still match every backend's scoped entry.

## Issue Number

Fixes #16843

## How to Test

```bash
npm install
npx vitest run src/hooks/query/use-plugins.test.tsx
```

Manually: register two local backends with different installed plugins, open the plugins screen on the first, switch to the second within ten minutes, and confirm the list is the second backend's. Creating a conversation right after the switch should not attach the first backend's plugins.

## Video/Screenshots

<img width="1048" height="430" alt="PR-16891" src="https://github.com/user-attachments/assets/45f7ce77-70e9-4d61-9ce1-92fc3f21a619" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

#16844 is the same defect for the workspace queries and is fixed separately in #16892; the two touch different hooks and neither depends on the other.
