### PR TITLE
fix: self-heal stale cloud org ID to prevent 403 during onboarding

### DIFF
--- a/__tests__/components/backends/backend-selector.test.tsx
+++ b/__tests__/components/backends/backend-selector.test.tsx
@@ -428,6 +428,40 @@ describe("BackendSelector", () => {
     });
   });
 
+  it("self-heals stale orgId → corrects to Cloud's current org", async () => {
+    vi.mocked(getCloudOrganizations).mockResolvedValue({
+      items: [{ id: "org-current", name: "Current Org" }],
+      currentOrgId: "org-current",
+    });
+    vi.mocked(getCloudOrganizationMe).mockResolvedValue({
+      orgId: "org-current",
+      userId: "some-user",
+      role: null,
+    });
+
+    let cloudId = "";
+    renderWithProviders(
+      <TestSeed
+        onMount={(ctx) => {
+          cloudId = ctx.addBackend(SEED_CLOUD_PRODUCTION).id;
+          // Simulate a stale orgId from an org the user has since left.
+          ctx.setActive(cloudId, "org-stale-left-org");
+        }}
+      >
+        <BackendSelector />
+      </TestSeed>,
+    );
+
+    // After orgs resolve, the stale orgId is not in the user's org list,
+    // so the selector corrects it to the cloud's current org.
+    await waitFor(() => {
+      const stored = JSON.parse(
+        window.localStorage.getItem("openhands-active-backend") ?? "null",
+      );
+      expect(stored).toEqual({ backendId: cloudId, orgId: "org-current" });
+    });
+  });
+
   it("switches the active backend when an option is selected", async () => {
     renderWithProviders(
       <TestSeed

--- a/src/api/cloud/client.ts
+++ b/src/api/cloud/client.ts
@@ -30,7 +30,10 @@ function activeOrgForBackend(backend: Backend): string | null {
   return active.backend.id === backend.id ? active.orgId : null;
 }
 
-export function createCloudClient(backend?: Backend): CloudClient {
+export function createCloudClient(
+  backend?: Backend,
+  opts?: { omitOrgId?: boolean },
+): CloudClient {
   const target = requireCloudBackend(backend);
   const proxyBaseUrl = getAgentServerBaseUrl();
   const proxyHeaders = proxyBaseUrl ? getAgentServerHeaders() : {};
@@ -38,7 +41,7 @@ export function createCloudClient(backend?: Backend): CloudClient {
   return new CloudClient({
     host: target.host,
     apiKey: target.apiKey,
-    orgId: activeOrgForBackend(target),
+    orgId: opts?.omitOrgId ? null : activeOrgForBackend(target),
     // Default request timeout in ms, matching the 30s the previous axios
     // transport used for direct and proxied calls. Per-request
     // `timeoutSeconds` still overrides it for direct calls.

--- a/src/api/cloud/organization-service.api.ts
+++ b/src/api/cloud/organization-service.api.ts
@@ -48,6 +48,11 @@ export async function getCloudOrganizations(
     backend: target,
     method: "GET",
     path: "/api/organizations",
+    // Must not send X-Org-Id: this endpoint IS the source of truth for org
+    // membership. Scoping it by a (potentially stale) stored orgId creates a
+    // chicken-and-egg where a stale org causes a 403 that prevents the
+    // self-heal from discovering the valid org.
+    omitOrgId: true,
   });
   return normalizeResult(data);
 }

--- a/src/api/cloud/proxy.ts
+++ b/src/api/cloud/proxy.ts
@@ -13,6 +13,13 @@ export interface CloudProxyRequest {
   authMode?: "bearer" | "session-api-key" | "none";
   sessionApiKey?: string | null;
   responseType?: "blob";
+  /**
+   * When true, the request is sent without an `X-Org-Id` header even if the
+   * active backend has a stored org selection. Use for endpoints that ARE the
+   * source of truth for org membership (e.g. `GET /api/organizations`) so a
+   * stale stored orgId never causes a chicken-and-egg 403.
+   */
+  omitOrgId?: boolean;
 }
 
 export async function callCloudProxy<TResponse = unknown>(
@@ -20,7 +27,7 @@ export async function callCloudProxy<TResponse = unknown>(
 ): Promise<TResponse> {
   const client = req.hostOverride
     ? createCloudClientForRuntime(req.backend)
-    : createCloudClient(req.backend);
+    : createCloudClient(req.backend, { omitOrgId: req.omitOrgId });
 
   return client.request<TResponse>({
     method: req.method,

--- a/src/components/features/backends/backend-selector.tsx
+++ b/src/components/features/backends/backend-selector.tsx
@@ -204,23 +204,29 @@ export function BackendSelector({
 
   const someCloudLoading = Object.values(cloudOrgs).some((c) => c.isLoading);
 
-  // Self-heal a malformed `(cloudBackendId, null)` selection.
+  // Self-heal a missing or stale org selection.
   //
   // Once a cloud backend's orgs resolve, the dropdown only renders
   // per-org rows for it — the `(backendId, null)` row disappears, so
   // selecting that shape would drift from what the dropdown can render
-  // (UI says "Local", APIs hit cloud). When we detect the drift, snap
-  // the selection onto Cloud's current org first, then fall back to the
+  // (UI says "Local", APIs hit cloud). Likewise, a stored orgId from an
+  // org the user has since left causes every cloud request to carry
+  // `X-Org-Id: <stale-id>`, which the cloud rejects with 403 "User is
+  // not a member of the requested organization". In both cases, snap the
+  // selection onto Cloud's current org first, then fall back to the
   // personal workspace (or, lacking a /me result, the first org). The
   // selection is recorded locally only; the cloud request scope follows
   // from the X-Org-Id header sent by `callCloudProxy`, so the cloud UI's
   // org choice is never mutated as a side effect.
   React.useEffect(() => {
-    if (noBackendSelected || active.backend.kind !== "cloud" || active.orgId)
-      return;
+    if (noBackendSelected || active.backend.kind !== "cloud") return;
     const { backend } = active;
     const entry = cloudOrgs[backend.id];
-    if (!entry || entry.orgs.length === 0) return;
+    if (!entry || entry.isLoading || entry.orgs.length === 0) return;
+
+    // Bail out only when the stored orgId is valid (still in the user's
+    // org list). A missing or stale orgId both need the same correction.
+    if (active.orgId && entry.orgs.some((o) => o.id === active.orgId)) return;
 
     const currentOrg = entry.currentOrgId
       ? entry.orgs.find((o) => o.id === entry.currentOrgId)


### PR DESCRIPTION
HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

All 23 unit tests in `__tests__/components/backends/backend-selector.test.tsx` pass, including the new test case that directly reproduces the stale-orgId scenario. I could not run a live end-to-end test against `app.all-hands.dev` from this environment.

The new test seeds a cloud backend with `orgId: "org-stale-left-org"` (an org not present in the mock org list returned by `getCloudOrganizations`) and asserts that after orgs resolve the active selection is corrected to the cloud's `currentOrgId`. This exercises the BackendSelector self-heal change directly.

Note on test coverage for the `omitOrgId` change: the mock in `backend-selector.test.tsx` already calls `getCloudOrganizations` without caring about the header, so the new option is exercised structurally but not at the HTTP layer. An integration test against the real cloud API would be needed to verify the 403-avoidance behavior end-to-end.

---

## Why

When a cloud user had a stale `orgId` persisted in `localStorage` (e.g. from an org they previously left), every cloud request included `X-Org-Id: <stale-id>`, which the cloud rejected with 403 "User is not a member of the requested organization". This surfaced most visibly during onboarding agent selection, where the first action on clicking Next is `POST /api/v1/settings` with that header, causing the modal to get stuck on "Saving…".

The `BackendSelector` already had a self-heal effect to correct a *missing* (`null`) orgId, but it bailed out early if any orgId was set — even a stale one. The fix needed two parts:

1. The self-heal couldn't fire anyway because `getCloudOrganizations` also sent `X-Org-Id: <stale>`, causing that query to 403 too — leaving `entry.orgs` empty and creating a chicken-and-egg deadlock.
2. Even if the org listing had succeeded, the BackendSelector guard `|| active.orgId` would have bailed without correcting a stale-but-non-null orgId.

## Summary

- Added `omitOrgId?: boolean` to `CloudProxyRequest` and `createCloudClient`, and set `omitOrgId: true` on the `getCloudOrganizations` call — the org listing endpoint is the source of truth for membership and must never be blocked by a stale stored orgId
- Extended the `BackendSelector` self-heal effect to validate the stored `orgId` against the fetched org list, correcting stale ids the same way as missing ones (current org → personal workspace → first org)
- Added a test covering the stale-orgId correction path

## Issue Number

Fixes #16526

## How to Test

1. Log in to `app.all-hands.dev/canvas`
2. In DevTools → Application → Local Storage, find `openhands-active-backend` and change `orgId` to any fake UUID (e.g. `"00000000-0000-0000-0000-000000000000"`)
3. Reload the page
4. **Before fix**: attempting onboarding agent selection (or any cloud action) 403s; the stored orgId stays stale
5. **After fix**: on page load, `getCloudOrganizations` now succeeds (no `X-Org-Id` sent), the BackendSelector detects the stale orgId is not in the returned org list, and corrects it automatically — no 403

## Video/Screenshots

<!-- To be added by human reviewer -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The issue does not yet carry `ready-for-dev` — the automated bot ran before the reporter filled in the required section headings. The content is all present; keeping this draft until the label is applied.
