### PR TITLE
feat: sync pinned conversations across devices via conversation tags

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -27,6 +27,7 @@ import { ConversationPanel } from "#/components/features/conversation-panel/conv
 import { useConversationPanelPreferencesStore } from "#/stores/conversation-panel-preferences-store";
 import { useArchivedConversationsStore } from "#/stores/archived-conversations-store";
 import { usePinnedConversationsStore } from "#/stores/pinned-conversations-store";
+import { PINNED_TAG_KEY } from "#/api/agent-server-adapter";
 import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
 import { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
 import { ExecutionStatus } from "#/types/agent-server/core";
@@ -122,6 +123,68 @@ describe("ConversationPanel", () => {
     createMockConversation({ id: "2", title: "Conversation 2" }),
     createMockConversation({ id: "3", title: "Conversation 3" }),
   ];
+
+  /**
+   * Serves conversations the way an agent-server backend does: a pin is a
+   * `pinned` tag on the conversation, and a tag PATCH is read-merge-write.
+   * `pinnedIds` are stamped in ascending order, so the last one pinned sorts
+   * to the top of the pinned section.
+   */
+  const seedConversationsWithPins = (
+    conversations: AppConversation[],
+    pinnedIds: readonly string[],
+  ) => {
+    let items: AppConversation[] = conversations.map((conversation) => {
+      const pinIndex = pinnedIds.indexOf(conversation.id);
+      if (pinIndex === -1) {
+        return conversation;
+      }
+      return {
+        ...conversation,
+        tags: {
+          ...(conversation.tags ?? {}),
+          [PINNED_TAG_KEY]: new Date(
+            Date.UTC(2026, 0, 1, 0, 0, pinIndex),
+          ).toISOString(),
+        },
+      };
+    });
+
+    vi.spyOn(
+      AgentServerConversationService,
+      "searchConversations",
+    ).mockImplementation(async () => ({
+      items: [...items],
+      next_page_id: null,
+    }));
+
+    vi.spyOn(
+      AgentServerConversationService,
+      "mergeConversationTags",
+    ).mockImplementation(async (conversationId, patch) => {
+      items = items.map((conversation) => {
+        if (conversation.id !== conversationId) {
+          return conversation;
+        }
+        const tags: Record<string, string> = { ...(conversation.tags ?? {}) };
+        Object.entries(patch).forEach(([key, value]) => {
+          if (value === null) {
+            delete tags[key];
+          } else {
+            tags[key] = value;
+          }
+        });
+        return { ...conversation, tags };
+      });
+      const updated = items.find(
+        (conversation) => conversation.id === conversationId,
+      );
+      if (!updated) {
+        throw new Error(`unknown conversation ${conversationId}`);
+      }
+      return updated;
+    });
+  };
 
   const cloudBackend: Backend = {
     id: "cloud-prod",
@@ -2400,9 +2463,7 @@ describe("ConversationPanel", () => {
   });
 
   it("shows a pinned section above the conversations list when pins exist", async () => {
-    usePinnedConversationsStore
-      .getState()
-      .pinConversation("default-local", "2");
+    seedConversationsWithPins(mockConversations, ["2"]);
 
     renderConversationPanel();
 
@@ -2421,9 +2482,7 @@ describe("ConversationPanel", () => {
   });
 
   it("renders pinned conversations only in the pinned section in chronological mode", async () => {
-    usePinnedConversationsStore
-      .getState()
-      .pinConversation("default-local", "2");
+    seedConversationsWithPins(mockConversations, ["2"]);
 
     renderConversationPanel();
 
@@ -2439,9 +2498,7 @@ describe("ConversationPanel", () => {
 
   it("renders pinned conversations only in the pinned section in grouped mode", async () => {
     useConversationPanelPreferencesStore.setState({ organizeMode: "grouped" });
-    usePinnedConversationsStore
-      .getState()
-      .pinConversation("default-local", "2");
+    seedConversationsWithPins(mockConversations, ["2"]);
 
     renderConversationPanel();
 
@@ -2456,9 +2513,7 @@ describe("ConversationPanel", () => {
   });
 
   it("hides the pinned section after the last pin is removed", async () => {
-    usePinnedConversationsStore
-      .getState()
-      .pinConversation("default-local", "2");
+    seedConversationsWithPins(mockConversations, ["2"]);
 
     const user = userEvent.setup();
     renderConversationPanel();
@@ -2486,18 +2541,10 @@ describe("ConversationPanel", () => {
         title: `Conversation ${index + 1}`,
       }),
     );
-    vi.spyOn(
-      AgentServerConversationService,
-      "searchConversations",
-    ).mockResolvedValue({
-      items: manyConversations,
-      next_page_id: null,
-    });
-    for (const conversation of manyConversations) {
-      usePinnedConversationsStore
-        .getState()
-        .pinConversation("default-local", conversation.id);
-    }
+    seedConversationsWithPins(
+      manyConversations,
+      manyConversations.map((conversation) => conversation.id),
+    );
 
     renderConversationPanel();
 

--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -124,12 +124,7 @@ describe("ConversationPanel", () => {
     createMockConversation({ id: "3", title: "Conversation 3" }),
   ];
 
-  /**
-   * Serves conversations the way an agent-server backend does: a pin is a
-   * `pinned` tag on the conversation, and a tag PATCH is read-merge-write.
-   * `pinnedIds` are stamped in ascending order, so the last one pinned sorts
-   * to the top of the pinned section.
-   */
+  /** Pins as the backend stores them: a `pinned` tag, PATCHed read-merge-write. */
   const seedConversationsWithPins = (
     conversations: AppConversation[],
     pinnedIds: readonly string[],
@@ -176,13 +171,6 @@ describe("ConversationPanel", () => {
         });
         return { ...conversation, tags };
       });
-      const updated = items.find(
-        (conversation) => conversation.id === conversationId,
-      );
-      if (!updated) {
-        throw new Error(`unknown conversation ${conversationId}`);
-      }
-      return updated;
     });
   };
 

--- a/__tests__/hooks/use-pinned-conversations.test.tsx
+++ b/__tests__/hooks/use-pinned-conversations.test.tsx
@@ -29,8 +29,11 @@ vi.mock("@tanstack/react-query", async (importOriginal) => ({
   }: {
     mutationFn: (variables: unknown) => Promise<unknown>;
   }) => ({
-    mutate: (variables: unknown) => {
-      void mutationFn(variables);
+    mutate: (variables: unknown, options?: { onSuccess?: () => void }) => {
+      mutationFn(variables).then(
+        () => options?.onSuccess?.(),
+        () => {},
+      );
     },
   }),
 }));
@@ -128,9 +131,9 @@ describe("usePinnedConversations", () => {
     );
   });
 
-  it("does not replay local pins for conversations the backend no longer has", async () => {
+  it("keeps a local pin whose conversation pagination has not reached yet", async () => {
     usePinnedConversationsStore.setState({
-      pinsByBackendId: { [BACKEND_ID]: ["gone", "a"] },
+      pinsByBackendId: { [BACKEND_ID]: ["on-a-later-page", "a"] },
     });
 
     renderHook(() => usePinnedConversations([conversation("a")]));
@@ -139,6 +142,28 @@ describe("usePinnedConversations", () => {
       expect(mergeConversationTagsMock).toHaveBeenCalledTimes(1),
     );
     expect(mergeConversationTagsMock.mock.calls[0][0]).toBe("a");
+    // Dropping it here would lose the pin before it ever reached the backend.
+    await waitFor(() =>
+      expect(
+        usePinnedConversationsStore.getState().pinsByBackendId[BACKEND_ID],
+      ).toEqual(["on-a-later-page"]),
+    );
+  });
+
+  it("keeps the local pin when the tag write fails", async () => {
+    mergeConversationTagsMock.mockRejectedValue(new Error("patch failed"));
+    usePinnedConversationsStore.setState({
+      pinsByBackendId: { [BACKEND_ID]: ["a"] },
+    });
+
+    renderHook(() => usePinnedConversations([conversation("a")]));
+
+    await waitFor(() =>
+      expect(mergeConversationTagsMock).toHaveBeenCalledTimes(1),
+    );
+    expect(
+      usePinnedConversationsStore.getState().pinsByBackendId[BACKEND_ID],
+    ).toEqual(["a"]);
   });
 
   it("waits for the conversation list before migrating, so no pin is discarded", () => {

--- a/__tests__/hooks/use-pinned-conversations.test.tsx
+++ b/__tests__/hooks/use-pinned-conversations.test.tsx
@@ -1,0 +1,173 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PINNED_TAG_KEY } from "#/api/agent-server-adapter";
+import { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+import { usePinnedConversations } from "#/hooks/use-pinned-conversations";
+import { usePinnedConversationsStore } from "#/stores/pinned-conversations-store";
+
+const useActiveBackendMock = vi.fn();
+const mergeConversationTagsMock = vi.fn();
+
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => useActiveBackendMock(),
+}));
+vi.mock(
+  "#/api/conversation-service/agent-server-conversation-service.api",
+  () => ({
+    default: {
+      mergeConversationTags: (
+        ...args: Parameters<typeof mergeConversationTagsMock>
+      ) => mergeConversationTagsMock(...args),
+    },
+  }),
+);
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useMutation: ({
+    mutationFn,
+  }: {
+    mutationFn: (variables: unknown) => Promise<unknown>;
+  }) => ({
+    mutate: (variables: unknown) => {
+      void mutationFn(variables);
+    },
+  }),
+}));
+
+const BACKEND_ID = "default-local";
+
+function conversation(
+  id: string,
+  tags: Record<string, string> | null = null,
+): AppConversation {
+  return { id, tags } as AppConversation;
+}
+
+describe("usePinnedConversations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    usePinnedConversationsStore.setState({ pinsByBackendId: {} });
+    mergeConversationTagsMock.mockResolvedValue(undefined);
+    useActiveBackendMock.mockReturnValue({
+      backend: { kind: "local", id: BACKEND_ID },
+    });
+  });
+
+  it("orders pinned conversations most recently pinned first", () => {
+    const conversations = [
+      conversation("a", { [PINNED_TAG_KEY]: "2026-01-01T00:00:00.000Z" }),
+      conversation("b"),
+      conversation("c", { [PINNED_TAG_KEY]: "2026-03-01T00:00:00.000Z" }),
+      conversation("d", { [PINNED_TAG_KEY]: "2026-02-01T00:00:00.000Z" }),
+    ];
+
+    const { result } = renderHook(() => usePinnedConversations(conversations));
+
+    expect(result.current.pinnedIds).toEqual(["c", "d", "a"]);
+  });
+
+  it("writes a pinned tag when pinning and clears it when unpinning", () => {
+    const conversations = [
+      conversation("a"),
+      conversation("b", { [PINNED_TAG_KEY]: "2026-01-01T00:00:00.000Z" }),
+    ];
+
+    const { result } = renderHook(() => usePinnedConversations(conversations));
+
+    result.current.togglePin("a");
+    expect(mergeConversationTagsMock).toHaveBeenCalledWith("a", {
+      [PINNED_TAG_KEY]: expect.any(String),
+    });
+
+    result.current.togglePin("b");
+    expect(mergeConversationTagsMock).toHaveBeenCalledWith("b", {
+      [PINNED_TAG_KEY]: null,
+    });
+  });
+
+  it("sends only the pin key, leaving the tag merge to the service", () => {
+    const conversations = [conversation("a", { acpserver: "gemini-cli" })];
+
+    const { result } = renderHook(() => usePinnedConversations(conversations));
+    result.current.togglePin("a");
+
+    expect(mergeConversationTagsMock).toHaveBeenCalledTimes(1);
+    expect(Object.keys(mergeConversationTagsMock.mock.calls[0][1])).toEqual([
+      PINNED_TAG_KEY,
+    ]);
+  });
+
+  it("replays pins made before the migration onto the backend, then drops them locally", async () => {
+    usePinnedConversationsStore.setState({
+      pinsByBackendId: { [BACKEND_ID]: ["b", "a"] },
+    });
+
+    renderHook(() =>
+      usePinnedConversations([conversation("a"), conversation("b")]),
+    );
+
+    await waitFor(() =>
+      expect(mergeConversationTagsMock).toHaveBeenCalledTimes(2),
+    );
+    // "b" was pinned most recently locally, so it must end up with the newest
+    // timestamp and stay at the top of the pinned section.
+    const stamped = Object.fromEntries(
+      mergeConversationTagsMock.mock.calls.map(([id, patch]) => [
+        id,
+        patch[PINNED_TAG_KEY],
+      ]),
+    );
+    expect(stamped.b > stamped.a).toBe(true);
+
+    await waitFor(() =>
+      expect(
+        usePinnedConversationsStore.getState().pinsByBackendId[BACKEND_ID],
+      ).toEqual([]),
+    );
+  });
+
+  it("does not replay local pins for conversations the backend no longer has", async () => {
+    usePinnedConversationsStore.setState({
+      pinsByBackendId: { [BACKEND_ID]: ["gone", "a"] },
+    });
+
+    renderHook(() => usePinnedConversations([conversation("a")]));
+
+    await waitFor(() =>
+      expect(mergeConversationTagsMock).toHaveBeenCalledTimes(1),
+    );
+    expect(mergeConversationTagsMock.mock.calls[0][0]).toBe("a");
+  });
+
+  it("waits for the conversation list before migrating, so no pin is discarded", () => {
+    usePinnedConversationsStore.setState({
+      pinsByBackendId: { [BACKEND_ID]: ["a"] },
+    });
+
+    renderHook(() => usePinnedConversations([]));
+
+    expect(mergeConversationTagsMock).not.toHaveBeenCalled();
+    expect(
+      usePinnedConversationsStore.getState().pinsByBackendId[BACKEND_ID],
+    ).toEqual(["a"]);
+  });
+
+  it("keeps cloud backends on the browser-local store", () => {
+    useActiveBackendMock.mockReturnValue({
+      backend: { kind: "cloud", id: "cloud-prod" },
+    });
+
+    const { result } = renderHook(() =>
+      usePinnedConversations([conversation("a")]),
+    );
+
+    result.current.togglePin("a");
+
+    expect(mergeConversationTagsMock).not.toHaveBeenCalled();
+    expect(
+      usePinnedConversationsStore.getState().pinsByBackendId["cloud-prod"],
+    ).toEqual(["a"]);
+  });
+});

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -450,13 +450,7 @@ export const ACP_SERVER_TAG_KEY = "acpserver";
 export const CLIENT_SOURCE_TAG_KEY = "clientsource";
 export const AGENT_CANVAS_SOURCE = "agentcanvas";
 
-/**
- * Marks a conversation as pinned in the sidebar. The value is the ISO-8601
- * instant the pin was made, so the pinned list can keep "most recently pinned
- * first" ordering without a second key. Server-side so pins follow the user
- * across devices (agent-server backends only — the cloud app-server does not
- * round-trip tags yet).
- */
+/** Sidebar pin marker; the value is the ISO-8601 instant that orders the list. */
 export const PINNED_TAG_KEY = "pinned";
 
 export const AUTOMATION_TRIGGER_TAG_KEY = "automationtrigger";

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -450,6 +450,15 @@ export const ACP_SERVER_TAG_KEY = "acpserver";
 export const CLIENT_SOURCE_TAG_KEY = "clientsource";
 export const AGENT_CANVAS_SOURCE = "agentcanvas";
 
+/**
+ * Marks a conversation as pinned in the sidebar. The value is the ISO-8601
+ * instant the pin was made, so the pinned list can keep "most recently pinned
+ * first" ordering without a second key. Server-side so pins follow the user
+ * across devices (agent-server backends only — the cloud app-server does not
+ * round-trip tags yet).
+ */
+export const PINNED_TAG_KEY = "pinned";
+
 export const AUTOMATION_TRIGGER_TAG_KEY = "automationtrigger";
 export const AUTOMATION_ID_TAG_KEY = "automationid";
 export const AUTOMATION_NAME_TAG_KEY = "automationname";
@@ -480,12 +489,14 @@ export const AUTOMATION_TAG_KEYS: readonly string[] = [
  * - ``automationid`` / ``automationrunid`` → raw UUIDs consumed by the
  *   conversation panel's automation filter (chip noise), while
  *   ``automationname`` / ``automationtrigger`` stay visible
+ * - ``pinned`` → drives the sidebar's pinned section, not a user-authored tag
  */
 export const RESERVED_CONVERSATION_TAG_KEYS: ReadonlySet<string> = new Set([
   ACP_SERVER_TAG_KEY,
   CLIENT_SOURCE_TAG_KEY,
   AUTOMATION_ID_TAG_KEY,
   AUTOMATION_RUN_ID_TAG_KEY,
+  PINNED_TAG_KEY,
   "title",
   "git_provider",
   "repo_name",

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -814,6 +814,43 @@ class AgentServerConversationService {
   }
 
   /**
+   * Merges `patch` into a conversation's server-side tags; a `null` value
+   * removes that key.
+   *
+   * The agent-server's `PATCH /api/conversations/{id}` replaces the
+   * **complete** tags map, so this reads the current tags and writes the
+   * merged result. Two concurrent tag writes on the same conversation can
+   * still clobber each other — acceptable for user-driven toggles, but a
+   * merge-style PATCH server-side would remove the race.
+   *
+   * Agent-server backends only: the cloud app-server does not round-trip
+   * `tags`, so callers must not route cloud conversations here.
+   */
+  static async mergeConversationTags(
+    conversationId: string,
+    patch: Record<string, string | null>,
+  ): Promise<AppConversation> {
+    const [current] = await this.batchGetAppConversations([conversationId]);
+    const merged: Record<string, string> = {
+      ...(requireAppConversation(current, conversationId).tags ?? {}),
+    };
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === null) {
+        delete merged[key];
+      } else {
+        merged[key] = value;
+      }
+    }
+
+    await new ConversationClient(
+      getAgentServerClientOptions(),
+    ).updateConversation(conversationId, { tags: merged });
+
+    const [updated] = await this.batchGetAppConversations([conversationId]);
+    return requireAppConversation(updated, conversationId);
+  }
+
+  /**
    * Forks a conversation, copying event history up to and including
    * `fromEventId`. Local agent-server only; needs agent-server >= 1.31.0 for
    * `from_event_id` (older backends copy the whole conversation).

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -814,40 +814,30 @@ class AgentServerConversationService {
   }
 
   /**
-   * Merges `patch` into a conversation's server-side tags; a `null` value
-   * removes that key.
-   *
-   * The agent-server's `PATCH /api/conversations/{id}` replaces the
-   * **complete** tags map, so this reads the current tags and writes the
-   * merged result. Two concurrent tag writes on the same conversation can
-   * still clobber each other — acceptable for user-driven toggles, but a
-   * merge-style PATCH server-side would remove the race.
-   *
-   * Agent-server backends only: the cloud app-server does not round-trip
-   * `tags`, so callers must not route cloud conversations here.
+   * Merges `patch` into a conversation's tags; a `null` value removes the key.
+   * PATCH replaces the complete tags map, so this is read-merge-write and two
+   * concurrent writes can clobber each other. Agent-server backends only — the
+   * cloud app-server does not round-trip `tags`.
    */
   static async mergeConversationTags(
     conversationId: string,
     patch: Record<string, string | null>,
-  ): Promise<AppConversation> {
+  ): Promise<void> {
     const [current] = await this.batchGetAppConversations([conversationId]);
     const merged: Record<string, string> = {
       ...(requireAppConversation(current, conversationId).tags ?? {}),
     };
-    for (const [key, value] of Object.entries(patch)) {
+    Object.entries(patch).forEach(([key, value]) => {
       if (value === null) {
         delete merged[key];
       } else {
         merged[key] = value;
       }
-    }
+    });
 
     await new ConversationClient(
       getAgentServerClientOptions(),
     ).updateConversation(conversationId, { tags: merged });
-
-    const [updated] = await this.batchGetAppConversations([conversationId]);
-    return requireAppConversation(updated, conversationId);
   }
 
   /**

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -50,7 +50,7 @@ import {
   type ConversationGroupLaunch,
 } from "./conversation-panel-list-helpers";
 import { useArchivedConversationsStore } from "#/stores/archived-conversations-store";
-import { usePinnedConversationsStore } from "#/stores/pinned-conversations-store";
+import { usePinnedConversations } from "#/hooks/use-pinned-conversations";
 
 interface ConversationPanelProps {
   onClose?: () => void;
@@ -202,17 +202,6 @@ export function ConversationPanel({
   const [expandedPinnedPreview, setExpandedPinnedPreview] =
     React.useState(false);
 
-  const pinnedIds = usePinnedConversationsStore(
-    (state) =>
-      state.pinsByBackendId[activeBackend.id] ?? EMPTY_PINNED_CONVERSATION_IDS,
-  );
-  const togglePin = usePinnedConversationsStore((state) => state.togglePin);
-  const unpinConversation = usePinnedConversationsStore(
-    (state) => state.unpinConversation,
-  );
-  const pruneMissingPinnedConversations = usePinnedConversationsStore(
-    (state) => state.pruneMissingConversations,
-  );
   const archivedIds = useArchivedConversationsStore(
     (state) =>
       state.archivesByBackendId[activeBackend.id] ??
@@ -304,6 +293,13 @@ export function ConversationPanel({
       return true;
     });
   }, [data]);
+
+  // Pins live in each conversation's server-side `pinned` tag, so they follow
+  // the user across devices. Derived from the unfiltered loaded pages so an
+  // archived-but-still-pinned row keeps its pin.
+  const { pinnedIds, togglePin, unpinConversation } = usePinnedConversations(
+    allLoadedConversations,
+  );
 
   // Grouped pagination is folder-oriented. Record the first backend page for
   // every conversation so later pages can introduce new folders without
@@ -405,19 +401,6 @@ export function ConversationPanel({
     () => resolvePinnedConversations(pinnedIds, conversations),
     [conversations, pinnedIds],
   );
-
-  React.useEffect(() => {
-    if (!isFetched) {
-      return;
-    }
-    // Prune pins against the unfiltered loaded pages so archived-but-still-
-    // pinned rows are not treated as missing. Archived IDs are intentionally
-    // not pruned here — pagination would otherwise drop archives that are not
-    // on the currently loaded pages and let them reappear in the list.
-    const loadedIds =
-      data?.pages.flatMap((page) => page.items.map((item) => item.id)) ?? [];
-    pruneMissingPinnedConversations(activeBackend.id, loadedIds);
-  }, [activeBackend.id, data, isFetched, pruneMissingPinnedConversations]);
 
   React.useEffect(() => {
     if (pinnedIds.length === 0) {
@@ -780,7 +763,7 @@ export function ConversationPanel({
       return;
     }
     archiveConversation(activeBackend.id, selectedConversationId);
-    unpinConversation(activeBackend.id, selectedConversationId);
+    unpinConversation(selectedConversationId);
     if (selectedConversationId === currentConversationId) {
       navigate("/conversations");
     }
@@ -964,7 +947,7 @@ export function ConversationPanel({
               showTags={showTagsMetadata}
               isArchived={isArchived}
               isPinned={isPinned}
-              onTogglePin={() => togglePin(activeBackend.id, conversation.id)}
+              onTogglePin={() => togglePin(conversation.id)}
               alwaysShowPinIcon={isPinned && !options?.inPinnedSection}
             />
           </NavigationLink>

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -294,9 +294,7 @@ export function ConversationPanel({
     });
   }, [data]);
 
-  // Pins live in each conversation's server-side `pinned` tag, so they follow
-  // the user across devices. Derived from the unfiltered loaded pages so an
-  // archived-but-still-pinned row keeps its pin.
+  // Unfiltered loaded pages, so an archived-but-still-pinned row keeps its pin.
   const { pinnedIds, togglePin, unpinConversation } = usePinnedConversations(
     allLoadedConversations,
   );

--- a/src/hooks/use-pinned-conversations.ts
+++ b/src/hooks/use-pinned-conversations.ts
@@ -1,0 +1,160 @@
+import React from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { PINNED_TAG_KEY } from "#/api/agent-server-adapter";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { usePinnedConversationsStore } from "#/stores/pinned-conversations-store";
+
+const EMPTY_PINNED_IDS: readonly string[] = [];
+
+export interface UsePinnedConversationsResult {
+  /** Pinned conversation ids, most recently pinned first. */
+  pinnedIds: readonly string[];
+  togglePin: (conversationId: string) => void;
+  unpinConversation: (conversationId: string) => void;
+}
+
+/**
+ * Reads the `pinned` tag off the conversations the sidebar already fetched,
+ * newest pin first (tag values are ISO-8601 instants, which sort
+ * lexicographically). Conversations the backend no longer returns simply drop
+ * out — deleting a conversation takes its tags with it, so there is nothing to
+ * prune.
+ */
+function derivePinnedIdsFromTags(
+  conversations: readonly AppConversation[],
+): readonly string[] {
+  const pinned: Array<{ id: string; pinnedAt: string }> = [];
+  for (const conversation of conversations) {
+    const pinnedAt = conversation.tags?.[PINNED_TAG_KEY];
+    if (typeof pinnedAt === "string" && pinnedAt.length > 0) {
+      pinned.push({ id: conversation.id, pinnedAt });
+    }
+  }
+  return pinned
+    .sort((a, b) => b.pinnedAt.localeCompare(a.pinnedAt))
+    .map((entry) => entry.id);
+}
+
+/**
+ * Pin state for the conversation panel.
+ *
+ * Agent-server backends keep pins in the conversation's server-side `pinned`
+ * tag, so they follow the user across devices and browsers. The cloud
+ * app-server does not round-trip `tags` yet, so cloud backends stay on the
+ * browser-local store — see OSS-10028 / the linked cloud follow-up.
+ *
+ * Callers pass the conversations they already render; no extra fetch happens.
+ */
+export function usePinnedConversations(
+  conversations: readonly AppConversation[],
+): UsePinnedConversationsResult {
+  const { backend } = useActiveBackend();
+  const backendId = backend.id;
+  const supportsTags = backend.kind !== "cloud";
+
+  const queryClient = useQueryClient();
+
+  const localPinnedIds = usePinnedConversationsStore(
+    (state) => state.pinsByBackendId[backendId] ?? EMPTY_PINNED_IDS,
+  );
+  const localTogglePin = usePinnedConversationsStore(
+    (state) => state.togglePin,
+  );
+  const localUnpin = usePinnedConversationsStore(
+    (state) => state.unpinConversation,
+  );
+
+  const { mutate: writePinnedTag } = useMutation({
+    mutationFn: (variables: {
+      conversationId: string;
+      pinnedAt: string | null;
+    }) =>
+      AgentServerConversationService.mergeConversationTags(
+        variables.conversationId,
+        { [PINNED_TAG_KEY]: variables.pinnedAt },
+      ),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["user", "conversations"] });
+    },
+  });
+
+  const taggedPinnedIds = React.useMemo(
+    () =>
+      supportsTags ? derivePinnedIdsFromTags(conversations) : EMPTY_PINNED_IDS,
+    [conversations, supportsTags],
+  );
+
+  // One-shot replay of pins made before this migration: stamp the tag on the
+  // conversations that still exist, then drop the local entries so the server
+  // stays the single source of truth. Runs per backend, and only once the
+  // conversation list has actually loaded (an empty list would look like
+  // "none of these still exist" and silently discard every pin).
+  const migratedBackendIds = React.useRef<Set<string>>(new Set());
+  React.useEffect(() => {
+    if (!supportsTags) return;
+    if (localPinnedIds.length === 0) return;
+    if (conversations.length === 0) return;
+    if (migratedBackendIds.current.has(backendId)) return;
+    migratedBackendIds.current.add(backendId);
+
+    const known = new Set(conversations.map((conversation) => conversation.id));
+    const alreadyTagged = new Set(taggedPinnedIds);
+    // Oldest local pin first, so replayed timestamps preserve the original
+    // "most recently pinned first" order.
+    const replayed = [...localPinnedIds].reverse();
+    replayed.forEach((conversationId, index) => {
+      if (known.has(conversationId) && !alreadyTagged.has(conversationId)) {
+        writePinnedTag({
+          conversationId,
+          pinnedAt: new Date(Date.now() + index).toISOString(),
+        });
+      }
+    });
+    localPinnedIds.forEach((conversationId) =>
+      localUnpin(backendId, conversationId),
+    );
+  }, [
+    backendId,
+    conversations,
+    localPinnedIds,
+    localUnpin,
+    supportsTags,
+    taggedPinnedIds,
+    writePinnedTag,
+  ]);
+
+  const togglePin = React.useCallback(
+    (conversationId: string) => {
+      if (!supportsTags) {
+        localTogglePin(backendId, conversationId);
+        return;
+      }
+      const isPinned = taggedPinnedIds.includes(conversationId);
+      writePinnedTag({
+        conversationId,
+        pinnedAt: isPinned ? null : new Date().toISOString(),
+      });
+    },
+    [backendId, localTogglePin, supportsTags, taggedPinnedIds, writePinnedTag],
+  );
+
+  const unpinConversation = React.useCallback(
+    (conversationId: string) => {
+      if (!supportsTags) {
+        localUnpin(backendId, conversationId);
+        return;
+      }
+      if (!taggedPinnedIds.includes(conversationId)) return;
+      writePinnedTag({ conversationId, pinnedAt: null });
+    },
+    [backendId, localUnpin, supportsTags, taggedPinnedIds, writePinnedTag],
+  );
+
+  return {
+    pinnedIds: supportsTags ? taggedPinnedIds : localPinnedIds,
+    togglePin,
+    unpinConversation,
+  };
+}

--- a/src/hooks/use-pinned-conversations.ts
+++ b/src/hooks/use-pinned-conversations.ts
@@ -9,43 +9,30 @@ import { usePinnedConversationsStore } from "#/stores/pinned-conversations-store
 const EMPTY_PINNED_IDS: readonly string[] = [];
 
 export interface UsePinnedConversationsResult {
-  /** Pinned conversation ids, most recently pinned first. */
   pinnedIds: readonly string[];
   togglePin: (conversationId: string) => void;
   unpinConversation: (conversationId: string) => void;
 }
 
-/**
- * Reads the `pinned` tag off the conversations the sidebar already fetched,
- * newest pin first (tag values are ISO-8601 instants, which sort
- * lexicographically). Conversations the backend no longer returns simply drop
- * out — deleting a conversation takes its tags with it, so there is nothing to
- * prune.
- */
+/** Tag values are ISO-8601 instants, so a descending sort is newest pin first. */
 function derivePinnedIdsFromTags(
   conversations: readonly AppConversation[],
 ): readonly string[] {
-  const pinned: Array<{ id: string; pinnedAt: string }> = [];
-  for (const conversation of conversations) {
-    const pinnedAt = conversation.tags?.[PINNED_TAG_KEY];
-    if (typeof pinnedAt === "string" && pinnedAt.length > 0) {
-      pinned.push({ id: conversation.id, pinnedAt });
-    }
-  }
-  return pinned
+  return conversations
+    .flatMap((conversation) => {
+      const pinnedAt = conversation.tags?.[PINNED_TAG_KEY];
+      return typeof pinnedAt === "string" && pinnedAt.length > 0
+        ? [{ id: conversation.id, pinnedAt }]
+        : [];
+    })
     .sort((a, b) => b.pinnedAt.localeCompare(a.pinnedAt))
     .map((entry) => entry.id);
 }
 
 /**
- * Pin state for the conversation panel.
- *
- * Agent-server backends keep pins in the conversation's server-side `pinned`
- * tag, so they follow the user across devices and browsers. The cloud
- * app-server does not round-trip `tags` yet, so cloud backends stay on the
- * browser-local store — see OSS-10028 / the linked cloud follow-up.
- *
- * Callers pass the conversations they already render; no extra fetch happens.
+ * Pin state derived from the `pinned` tag on `conversations` (the list the
+ * caller already renders), so pins follow the user across devices. Cloud
+ * backends stay on the local store — the app-server has no `tags` yet.
  */
 export function usePinnedConversations(
   conversations: readonly AppConversation[],
@@ -86,35 +73,32 @@ export function usePinnedConversations(
     [conversations, supportsTags],
   );
 
-  // One-shot replay of pins made before this migration: stamp the tag on the
-  // conversations that still exist, then drop the local entries so the server
-  // stays the single source of truth. Runs per backend, and only once the
-  // conversation list has actually loaded (an empty list would look like
-  // "none of these still exist" and silently discard every pin).
-  const migratedBackendIds = React.useRef<Set<string>>(new Set());
+  // Replays pins made before this migration. Only conversations on the loaded
+  // pages can be replayed, so a local pin is dropped once its write succeeds —
+  // never before, and never for one pagination has not reached yet. Stamps hang
+  // off a fixed anchor so a pin replayed from a later page keeps its old rank.
+  const attempted = React.useRef<Set<string>>(new Set());
+  const anchor = React.useRef<number | null>(null);
   React.useEffect(() => {
-    if (!supportsTags) return;
-    if (localPinnedIds.length === 0) return;
-    if (conversations.length === 0) return;
-    if (migratedBackendIds.current.has(backendId)) return;
-    migratedBackendIds.current.add(backendId);
+    if (!supportsTags || localPinnedIds.length === 0) return;
 
+    const base = (anchor.current ??= Date.now());
     const known = new Set(conversations.map((conversation) => conversation.id));
-    const alreadyTagged = new Set(taggedPinnedIds);
-    // Oldest local pin first, so replayed timestamps preserve the original
-    // "most recently pinned first" order.
-    const replayed = [...localPinnedIds].reverse();
-    replayed.forEach((conversationId, index) => {
-      if (known.has(conversationId) && !alreadyTagged.has(conversationId)) {
-        writePinnedTag({
-          conversationId,
-          pinnedAt: new Date(Date.now() + index).toISOString(),
-        });
+    const tagged = new Set(taggedPinnedIds);
+
+    localPinnedIds.forEach((conversationId, rank) => {
+      const key = `${backendId}:${conversationId}`;
+      if (!known.has(conversationId) || attempted.current.has(key)) return;
+      attempted.current.add(key);
+      if (tagged.has(conversationId)) {
+        localUnpin(backendId, conversationId);
+        return;
       }
+      writePinnedTag(
+        { conversationId, pinnedAt: new Date(base - rank).toISOString() },
+        { onSuccess: () => localUnpin(backendId, conversationId) },
+      );
     });
-    localPinnedIds.forEach((conversationId) =>
-      localUnpin(backendId, conversationId),
-    );
   }, [
     backendId,
     conversations,
@@ -131,10 +115,11 @@ export function usePinnedConversations(
         localTogglePin(backendId, conversationId);
         return;
       }
-      const isPinned = taggedPinnedIds.includes(conversationId);
       writePinnedTag({
         conversationId,
-        pinnedAt: isPinned ? null : new Date().toISOString(),
+        pinnedAt: taggedPinnedIds.includes(conversationId)
+          ? null
+          : new Date().toISOString(),
       });
     },
     [backendId, localTogglePin, supportsTags, taggedPinnedIds, writePinnedTag],


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

AGENT:

Implemented by an agent. Verification performed is listed under **How to Test**;
the browser-level cross-device walkthrough has **not** been done yet — see
**Notes**. This is why the PR is a draft.

---

## Why

Pinned conversations were stored only in browser `localStorage`
(`pinned-conversations`, shaped `{ pinsByBackendId: Record<backendId, conversationId[]> }`).
Pins therefore never followed the user to a second device, another browser, or
another browser profile, and clearing site data silently lost every pin. A pin
is a statement about the conversation, not about the machine it was made on, so
the browser is the wrong home for it.

## Summary

- Pin state moves to the conversation's server-side `pinned` tag. The value is
  the ISO-8601 instant of the pin, so one key carries both membership and the
  "most recently pinned first" ordering.
- The sidebar now derives `pinnedIds` from conversations it already fetches, so
  no extra request is made and the `pruneMissingConversations` bookkeeping is
  deleted outright — a deleted conversation takes its tags with it.
- New `usePinnedConversations` hook owns the policy, including a one-shot replay
  of pre-existing local pins onto the backend. Cloud backends keep the old
  browser-local store because the cloud app-server does not round-trip `tags`
  yet; the split is contained in the hook, so `conversation-panel.tsx` is
  unaware of it and gets net smaller.

## Issue Number

Fixes #16764

## How to Test

Run from the repo root:

```bash
npm ci
npm run lint                                                  # typecheck + eslint + prettier
npx vitest run __tests__/hooks/use-pinned-conversations.test.tsx
npx vitest run __tests__/components/features/conversation-panel/conversation-panel.test.tsx
```

What I actually ran, and the results:

- `npm run lint` → passes. 0 errors; the 3 remaining warnings
  (`conversation-card-context-menu.tsx`, `use-local-git-info.ts`) are
  pre-existing on `main` and in files this PR does not touch.
- `npx vitest run __tests__/hooks/use-pinned-conversations.test.tsx` → 8 passed.
  Covers ordering, pin/unpin tag writes, the localStorage→tag replay, and the
  cloud fallback. Two of them (a pin whose conversation pagination has not
  reached yet, and a failed tag write) were added after review found the
  migration bug described in Notes; both fail against the previous commit and
  pass against the fix.
- `npx vitest run __tests__/components/features/conversation-panel/conversation-panel.test.tsx`
  → 59 passed. The five pre-existing pin tests were rewritten to seed pins the
  way the backend does (a `pinned` tag) and to model `PATCH` as read-merge-write.
  "hides the pinned section after the last pin is removed" now drives the whole
  new path: derive → PATCH → invalidate → refetch → section disappears.
- Full suite: `npx vitest run` → **5224 passed, 1 failed**. The one failure is
  `__tests__/scripts/dev-with-automation.test.ts > cleans up detached services
  when the launcher receives SIGHUP`. It is unrelated to this change (this PR
  touches no files under `scripts/`) and I confirmed it fails identically on a
  clean `origin/main` worktree, so it is pre-existing and environment-dependent.
  (`delete-profile-modal` flaked once under full-suite parallelism and passed on
  re-run and in isolation; it is unrelated to this change.)

## Video/Screenshots

Not captured. I verified this at the unit/integration level only — including a
test that exercises the full pin→PATCH→refetch→re-render path — but I did not
stand up Canvas against a live agent-server and pin a conversation in two
browsers. That walkthrough is the remaining work before this leaves draft, and
it is the check that actually demonstrates the cross-device behaviour this PR
exists for.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Cloud is intentionally not migrated.** The cloud app-server does not return
  `tags` on conversations, so routing cloud pins through tags would make pinning
  a silent no-op there. Cloud keeps the existing `pinned-conversations` store
  until the app-server grows equivalent support; that follow-up is called out in
  the linked issue.
- **Tag PATCH is read-merge-write.** `PATCH /api/conversations/{id}` replaces the
  complete tags map, so `mergeConversationTags` reads current tags first. Two
  concurrent tag writes to the same conversation can still clobber each other; a
  merge-style PATCH in `software-agent-sdk` would remove that race. Acceptable
  for a user-driven toggle, but worth knowing.
- **`pinned` is registered in `RESERVED_CONVERSATION_TAG_KEYS`** so it drives the
  pinned section without also rendering as a user-facing tag chip.
- **Migration drops a local pin only when that pin's own write succeeds.** The
  first cut of this PR replayed just the pins on the loaded pages but cleared
  the whole local list; with the sidebar paginating 20 at a time, a pin on an
  older conversation was destroyed before it ever reached the backend. A pin
  that is not yet paginated in, or whose PATCH fails, is now left alone for a
  later pass. Replay stamps hang off a fixed anchor so a pin migrated from a
  later page keeps its original rank rather than jumping to the top.
- **Process note:** #16764 currently carries only the `localstorage` label. The
  `pr-description-check` workflow requires a linked issue labelled
  `ready-for-dev`, and requires a `Feature` PR to link an issue labelled
  `enhancement`. I have deliberately not added labels to the issue myself —
  please apply them if you agree this is ready for dev, otherwise that check
  will stay red.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `89c7daaa6f624851010eca33c508fafe583360b6` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-89c7daa
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-89c7daa
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-89c7daa-amd64
ghcr.io/openhands/agent-canvas:vasco-oss-10028-pinned-conversations-tags-amd64
ghcr.io/openhands/agent-canvas:pr-16902-amd64
ghcr.io/openhands/agent-canvas:sha-89c7daa-arm64
ghcr.io/openhands/agent-canvas:vasco-oss-10028-pinned-conversations-tags-arm64
ghcr.io/openhands/agent-canvas:pr-16902-arm64
ghcr.io/openhands/agent-canvas:sha-89c7daa
ghcr.io/openhands/agent-canvas:vasco-oss-10028-pinned-conversations-tags
ghcr.io/openhands/agent-canvas:pr-16902
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-89c7daa`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-89c7daa-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->