### PR TITLE
test(i18n): keep the onboarding LLM subtitle in sync with the default model

### DIFF
--- a/__tests__/i18n/onboarding-llm-subtitle.test.ts
+++ b/__tests__/i18n/onboarding-llm-subtitle.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+import { ONBOARDING_DEFAULT_LLM_MODEL } from "#/components/features/onboarding/steps/setup-llm-step";
+
+// Display names for models the ONBOARDING$LLM_SUBTITLE string may advertise.
+// When the onboarding default changes, add the new model here and rewrite the
+// subtitle in every locale. A missing entry is the tripwire: it means the
+// default moved without anyone deciding what the subtitle should say.
+const MODEL_DISPLAY_NAMES: Record<string, string> = {
+  "openai/gpt-5.6-sol": "OpenAI GPT-5.6 Sol",
+};
+
+// Regression coverage for #16914. The onboarding default has moved twice
+// (#16657: GLM 5.2 -> Kimi K3, #16922: Kimi K3 -> GPT-5.6 Sol), and the first
+// switch shipped without touching ONBOARDING$LLM_SUBTITLE, so the step said
+// GLM-5.2 was pre-selected while the model field showed kimi-k3. Both
+// switches synced the subtitle by hand; this test makes the sync mandatory.
+// It checks the source-of-truth (translation.json) rather than the rendered
+// subtitle, because the test environment's i18next mock returns keys instead
+// of translated strings.
+describe("ONBOARDING$LLM_SUBTITLE", () => {
+  const translationPath = path.join(
+    __dirname,
+    "../../src/i18n/translation.json",
+  );
+  const translation = JSON.parse(
+    fs.readFileSync(translationPath, "utf-8"),
+  ) as Record<string, Record<string, string>>;
+
+  it("names the pre-selected default model in every locale", () => {
+    const displayName = MODEL_DISPLAY_NAMES[ONBOARDING_DEFAULT_LLM_MODEL];
+    expect(
+      displayName,
+      `ONBOARDING_DEFAULT_LLM_MODEL is "${ONBOARDING_DEFAULT_LLM_MODEL}", ` +
+        "which has no display name registered in this test. Add it to " +
+        "MODEL_DISPLAY_NAMES and update ONBOARDING$LLM_SUBTITLE in every " +
+        "locale of src/i18n/translation.json to name the new default.",
+    ).toBeDefined();
+
+    const subtitles = translation.ONBOARDING$LLM_SUBTITLE;
+    expect(subtitles).toBeDefined();
+    Object.entries(subtitles).forEach(([locale, subtitle]) => {
+      expect(
+        subtitle,
+        `locale "${locale}" should mention ${displayName}`,
+      ).toContain(displayName);
+    });
+  });
+});


### PR DESCRIPTION
HUMAN:

I ran npx vitest run __tests__/i18n/ and saw 18 tests pass. I also broke
the Catalan subtitle on purpose and the test caught it, naming the locale.

AGENT:

## Why

#16922 moved the onboarding default to OpenAI GPT-5.6 Sol and rewrote
`ONBOARDING$LLM_SUBTITLE` in all 15 locales, which fixed the mismatch
reported in #16914. That was the second time the default moved with a
hand-synced subtitle: the first switch (#16657, GLM 5.2 to Kimi K3)
missed the subtitle entirely, which is how #16914 happened. The issue
listed two acceptance criteria. The merged fix covered the first one —
the subtitle now names the real default. What's still missing is the
second: a test so the next switch can't ship with a stale subtitle.

## Summary

- Add `__tests__/i18n/onboarding-llm-subtitle.test.ts`. It looks up the
  display name for `ONBOARDING_DEFAULT_LLM_MODEL` in a map inside the
  test and asserts that every locale's `ONBOARDING$LLM_SUBTITLE`
  contains it. If the default moves to a model the map doesn't know,
  the failure message tells the author to register the display name and
  rewrite the subtitle in every locale.
- The earlier revision of this PR renamed the subtitle to Kimi K3. That
  became obsolete when #16922 merged, so the branch was rebased onto
  main and now carries only the test, as promised in the comment above.

## Issue Number

Fixes #16914

## How to Test

1. `npx vitest run __tests__/i18n/` — 18 passed.
2. Break it on purpose: point one locale's subtitle back at Kimi K3 and
   the test fails naming that locale. Change
   `ONBOARDING_DEFAULT_LLM_MODEL` to anything unregistered and it fails
   asking for a display-name entry.
3. `npm run check-translation-completeness` — passes.

## Video/Screenshots

Tripwire in action — one locale pointed back at the old model name fails
the test naming that locale; restoring translation.json turns it green:

<img width="1337" height="938" alt="onboarding-subtitle-drift-test-red-green" src="https://github.com/user-attachments/assets/afba82af-e1b5-4af8-ac80-c92bb868fdb4" />


## Type

Docs / chore (test-only change)

## Notes

Force-pushed over the previous revision to drop the locale edits that
#16922 already took care of.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.39s · commit 7fdad26  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 1/1 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 6.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 11.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 94.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 0756f31ea90066823ce358fa0677fdcdeac81c80c46dfd9a25b89a11f62ff862 -->
<!-- jev-fast-audit:end -->
