### PR TITLE
fix(automations): flip the kebab menu above the trigger when it would clip

### DIFF
--- a/__tests__/components/automations/kebab-menu.test.tsx
+++ b/__tests__/components/automations/kebab-menu.test.tsx
@@ -2,6 +2,30 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { KebabMenu } from "#/components/features/automations/kebab-menu";
 
+const ITEMS = ["Run now", "View", "Export", "Edit", "Turn on", "Delete"].map(
+  (label) => ({ label, icon: <span />, onClick: vi.fn() }),
+);
+
+/** Place the trigger at a fixed viewport position before the menu opens. */
+function openMenuWithTriggerAt(top: number, bottom: number) {
+  const trigger = screen.getByRole("button", {
+    name: "AUTOMATIONS$ACTIONS_MENU",
+  });
+  vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+    top,
+    bottom,
+    left: 900,
+    right: 1000,
+    width: 100,
+    height: bottom - top,
+    x: 900,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect);
+  fireEvent.click(trigger);
+  return document.querySelector<HTMLElement>('div[style*="position: fixed"]');
+}
+
 describe("KebabMenu", () => {
   it("opens the menu and invokes an item's onClick when selected", async () => {
     const onClick = vi.fn();
@@ -16,5 +40,24 @@ describe("KebabMenu", () => {
     fireEvent.click(await screen.findByText("Delete"));
 
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("anchors below the trigger when the menu fits in the viewport", () => {
+    render(<KebabMenu items={ITEMS} />);
+
+    const portal = openMenuWithTriggerAt(68, 100);
+
+    expect(portal?.style.top).toBe("104px");
+    expect(portal?.style.bottom).toBe("");
+  });
+
+  it("flips above the trigger when the menu would clip at the viewport bottom", () => {
+    render(<KebabMenu items={ITEMS} />);
+
+    // window.innerHeight is 768 in jsdom; 700 + 4 + (6 * 36) overflows it.
+    const portal = openMenuWithTriggerAt(668, 700);
+
+    expect(portal?.style.bottom).toBe("104px");
+    expect(portal?.style.top).toBe("");
   });
 });

--- a/src/components/features/automations/kebab-menu.tsx
+++ b/src/components/features/automations/kebab-menu.tsx
@@ -36,22 +36,35 @@ export function KebabMenu({ items, triggerClassName }: KebabMenuProps) {
       if (!rect) return;
 
       const gap = 4;
+      // The real height is only measurable once the portal has painted; the
+      // first pass falls back to an items-derived estimate (~36px per row).
+      const measured = menuRef.current?.getBoundingClientRect().height ?? 0;
+      const menuHeight = measured || items.length * 36;
+      const overflowsBelow =
+        rect.bottom + gap + menuHeight > window.innerHeight;
+
       setPortalStyle({
         position: "fixed",
         zIndex: 9999,
-        top: rect.bottom + gap,
+        // Flip above the trigger when the menu would clip at the viewport
+        // bottom. Bottom-anchoring keeps it hugging the trigger at any height.
+        ...(overflowsBelow
+          ? { bottom: window.innerHeight - rect.top + gap }
+          : { top: rect.bottom + gap }),
         right: window.innerWidth - rect.right,
       });
     };
 
     updatePosition();
+    const frame = window.requestAnimationFrame(updatePosition);
     window.addEventListener("resize", updatePosition);
     window.addEventListener("scroll", updatePosition, true);
     return () => {
+      window.cancelAnimationFrame(frame);
       window.removeEventListener("resize", updatePosition);
       window.removeEventListener("scroll", updatePosition, true);
     };
-  }, [open]);
+  }, [open, items.length]);
 
   useEffect(() => {
     if (!open) return undefined;


### PR DESCRIPTION
HUMAN:

Small fix for a problem I had with deleting automations.

AGENT:

Verified end-to-end in a browser against the mock stack, not just unit tests. Commands, measurements and before/after screenshots are under **How to Test** and **Video/Screenshots**.

---

## Why

The automations overflow (`⋮`) menu is always anchored below its trigger, with no viewport collision handling. For rows near the bottom of the window the menu renders past the bottom edge and its lower items cannot be reached.

The **Inactive** group renders last on the Automate page, so its rows are the ones that collide with the viewport bottom — and `Turn on` (item 5 of 6) is both the first thing an inactive automation needs and among the first items clipped. `Run now` stays visible but is disabled for a disabled automation, so every action in the row ends up either disabled or off-screen.

## Summary

- `KebabMenu` now measures the menu and bottom-anchors it above the trigger when it would not fit below, instead of always using `top: rect.bottom + gap`.
- Falls back to an items-derived height estimate for the first paint, then re-measures on the next frame once the portal has painted.
- Added regression coverage for the flip / no-flip cases.

## Issue Number

Fixes #16924

## How to Test

```bash
npm ci
npm run dev:mock
```

1. Open `/automations` in a window ~700px tall and switch to **list view** (toggle, top right).
2. Scroll to the bottom and click `⋮` on the last row of the **Inactive** group.
3. All six items (`Run now`, `View`, `Export`, `Edit`, `Turn on`, `Delete`) are on screen; before this change only `Run now` was.

Unit tests: `npx vitest run __tests__/components/automations/kebab-menu.test.tsx` — 3 passed. The new flip test fails on `main` and passes here.

Also ran `npm run typecheck` (clean) and `npx vitest run __tests__/components/automations __tests__/routes/automations-list.test.tsx` — 27 files, 204 tests passed.

## Video/Screenshots

Measured with Playwright at a 1280×700 viewport, same page and same row in both runs.

**Before** — menu overflows the viewport bottom by 186px; 5 of 6 items unreachable:

```
menu box: y=650, height=236, bottom=886   ->  overflow +186px
VISIBLE  Run now   (disabled)
CLIPPED  View / Export / Edit / Turn on / Delete
```

![Before: kebab menu clipped at the viewport bottom](https://raw.githubusercontent.com/VascoSch92/OpenHands/issue-assets/automations-kebab-clipping/assets/repro-clipped-700.png)

**After** — menu flips above the trigger; all 6 items visible:

```
menu box: y=366, height=236, bottom=602   ->  fits (-98px)
VISIBLE  Run now / View / Export / Edit / Turn on / Delete
```

![After: kebab menu flipped above the trigger with all six items visible](https://raw.githubusercontent.com/VascoSch92/OpenHands/issue-assets/automations-kebab-clipping/assets/fix-after-700.png)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `KebabMenu` is shared, so this also fixes the grid view (`automation-card.tsx`) and the detail header (`detail-header.tsx`).
- The same "anchor below, never flip" pattern exists in 10 other menus (conversation panel, settings profile menus, `add-automation-menu`, `automation-view-toggle`). `usePopoverFixedPlacement` clamps horizontally only and shares the bug. Deliberately left out of scope here; worth a follow-up to extract a shared helper — `home-automation-menu.tsx` and `conversation-name-context-menu.tsx` already hand-roll their own flip.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.42.1-python` |
| **Automation** | `openhands-automation==1.8.0` |
| **Commit** | `d2eafbfd3addf4d933e09d184481718cfc0c9f95` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-d2eafbf
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-d2eafbf
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-d2eafbf-amd64
ghcr.io/openhands/agent-canvas:vasco-fix-automations-kebab-menu-flip-amd64
ghcr.io/openhands/agent-canvas:pr-16926-amd64
ghcr.io/openhands/agent-canvas:sha-d2eafbf-arm64
ghcr.io/openhands/agent-canvas:vasco-fix-automations-kebab-menu-flip-arm64
ghcr.io/openhands/agent-canvas:pr-16926-arm64
ghcr.io/openhands/agent-canvas:sha-d2eafbf
ghcr.io/openhands/agent-canvas:vasco-fix-automations-kebab-menu-flip
ghcr.io/openhands/agent-canvas:pr-16926
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-d2eafbf`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-d2eafbf-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->