### PR TITLE
fix(launcher): fail the stack when a required service exits

### DIFF
--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -852,6 +852,54 @@ describe("setServiceLogListener", () => {
   });
 });
 
+describe("spawnService fatal child exit", () => {
+  it.skipIf(process.platform === "win32")(
+    "exits the launcher non-zero when a fatal child dies",
+    async () => {
+      const moduleUrl = pathToFileURL(
+        path.join(repoRoot, "scripts", "dev-with-automation.mjs"),
+      ).href;
+      const supervisorSource = [
+        `import { spawnService } from ${JSON.stringify(moduleUrl)};`,
+        "setTimeout(() => { console.log('PARENT_STILL_ALIVE'); process.exit(0); }, 1500);",
+        "spawnService('static', process.execPath, ['-e', 'process.exit(7)'], { fatal: true });",
+      ].join("\n");
+
+      const supervisor = spawn(
+        process.execPath,
+        ["--input-type=module", "--eval", supervisorSource],
+        {
+          cwd: repoRoot,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      let output = "";
+      supervisor.stdout.on("data", (chunk: Buffer) => {
+        output += chunk.toString();
+      });
+      supervisor.stderr.on("data", (chunk: Buffer) => {
+        output += chunk.toString();
+      });
+
+      const [code] = await once(supervisor, "exit");
+      expect(code, output).toBe(7);
+      expect(output).not.toContain("PARENT_STILL_ALIVE");
+      expect(output).toMatch(/static exited unexpectedly with code 7/i);
+    },
+  );
+
+  it("does not exit the current process when fatal is unset", async () => {
+    const proc = spawnService(
+      "non-fatal-exit-test",
+      process.execPath,
+      ["-e", "process.exit(3);"],
+      {},
+    );
+    const [code] = await once(proc, "exit");
+    expect(code).toBe(3);
+  });
+});
+
 describe("dev-with-automation CLI", () => {
   it.skipIf(process.platform === "win32")(
     "cleans up detached services when the launcher receives SIGHUP",

--- a/__tests__/scripts/static-server.test.ts
+++ b/__tests__/scripts/static-server.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { createServer, request, type Server } from "node:http";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -793,5 +794,27 @@ describe("static-server.mjs", () => {
     expect(response.body).toContain("Bad Gateway");
     expect(response.body).toContain("Invalid URL");
     expect(server.listening).toBe(true);
+  });
+
+  it("rejects when the listen port is already in use", async () => {
+    const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+    tempDirs.push(buildDir);
+    writeFileSync(path.join(buildDir, "index.html"), "<main>app</main>");
+
+    const blocker = createServer();
+    await startHttpServer(blocker);
+    const address = blocker.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Blocker did not bind to a TCP port");
+    }
+
+    await expect(
+      startStaticServer({
+        port: address.port,
+        host: "127.0.0.1",
+        dir: buildDir,
+        routes: {},
+      }),
+    ).rejects.toMatchObject({ code: "EADDRINUSE" });
   });
 });

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -631,6 +631,18 @@ function registerShutdownHook(hook) {
   return shutdownHooks.add(hook);
 }
 
+/**
+ * Spawn a stacked service.
+ *
+ * @param {string} name
+ * @param {string} command
+ * @param {string[]} args
+ * @param {object} [options]
+ * @param {boolean} [options.fatal] If true, a non-zero child exit tears down
+ *   the rest of the stack and exits the launcher with that status. Required
+ *   services (frontend, ingress, agent-server) must set this so a bind
+ *   failure such as EADDRINUSE cannot leave a "healthy" banner on :8000.
+ */
 function spawnService(name, command, args, options = {}) {
   const proc = spawn(
     resolveWindowsCommand(command),
@@ -688,6 +700,13 @@ function spawnService(name, command, args, options = {}) {
     if (code !== 0 && code !== null && !shuttingDown) {
       logService(name, `Exited with code ${code}`, c.red);
       emitServiceLog(name, `exited with code ${code}`, "error");
+      if (options.fatal) {
+        failStack(
+          `${name} exited unexpectedly with code ${code}. ` +
+            "The Agent Canvas stack cannot continue.",
+          code,
+        );
+      }
     }
     processes.delete(name);
   });
@@ -956,6 +975,7 @@ function startAgentServer(config) {
       env: agentServerEnv,
       color: c.blue,
       parseLogLine: parseAgentServerLogLine,
+      fatal: true,
     },
   );
 }
@@ -1067,6 +1087,17 @@ function startAutomationBackend(config) {
 
 let shuttingDown = false;
 
+function failStack(message, exitCode = 1) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  logError(message);
+  for (const [, proc] of processes) {
+    signalProcessTree(proc, "SIGTERM");
+  }
+  shutdownHooks.run();
+  process.exit(exitCode || 1);
+}
+
 function shutdown() {
   if (shuttingDown) return;
   shuttingDown = true;
@@ -1122,6 +1153,7 @@ function startIngress(config) {
     {
       cwd: projectRoot,
       color: c.yellow,
+      fatal: true,
     },
   );
 }
@@ -1195,6 +1227,7 @@ function startVite(config) {
     cwd: config.canvasPath,
     env: viteEnv,
     color: c.magenta,
+    fatal: true,
   });
 }
 
@@ -1656,6 +1689,7 @@ function startStaticFrontend(config, staticDir) {
     {
       cwd: config.canvasPath,
       color: c.magenta,
+      fatal: true,
     },
   );
 }

--- a/scripts/static-server.mjs
+++ b/scripts/static-server.mjs
@@ -671,8 +671,14 @@ export function startStaticServer(config) {
   });
   server.on("close", uninstallDiagnostics);
 
-  return new Promise((resolveListen) => {
+  return new Promise((resolveListen, rejectListen) => {
+    const onListenError = (err) => {
+      server.close();
+      rejectListen(err);
+    };
+    server.once("error", onListenError);
     server.listen(config.port, config.host, () => {
+      server.off("error", onListenError);
       const displayPath = basePath === "/" ? "/" : `${basePath}/`;
       console.log("");
       console.log(


### PR DESCRIPTION
HUMAN:

Verified the launcher path locally with a parent-process repro and the focused script unit tests (163 passing). No GUI change.

AGENT:

### End-to-end verification

**Sabotage (bug still on `main`).** A parent that only logs child failure stays alive:

```js
import { spawnService } from "./scripts/dev-with-automation.mjs";
spawnService("static", process.execPath, [
  "-e",
  "console.error('Error: listen EADDRINUSE: address already in use :::3001'); process.exit(1);",
]);
setTimeout(() => { console.log("PARENT_STILL_ALIVE"); process.exit(0); }, 800);
```

```
12:53:03 [static] Error: listen EADDRINUSE: address already in use :::3001
12:53:03 [static] Exited with code 1
PARENT_STILL_ALIVE pid=3706140 child_exit=1
```

**After the fix.** The same fatal child path exits the launcher with the child's status. New regression tests:

```
npx vitest run \
  __tests__/scripts/dev-with-automation.test.ts \
  __tests__/scripts/static-server.test.ts \
  __tests__/scripts/dev-safe.test.ts
# Test Files  3 passed (3)
# Tests  163 passed (163)
```

Isolated new cases: `exits the launcher non-zero when a fatal child dies` (176ms) and `rejects when the listen port is already in use` (11ms).

---

## Why

When a required child (static frontend / Vite / ingress / agent-server) dies — the common case is `EADDRINUSE` on the frontend port — `spawnService` only logs `Exited with code N`. The parent still starts ingress and prints `Main UI: http://localhost:8000/`, so `agent-canvas` looks healthy while the UI is a blank page. `static-server.mjs` also had no `listen` error handler, so bind failures were an unhandled server error that killed the child but not the stack.

This is the launcher-side root cause of #16904.

## Summary

- Treat agent-server, Vite, static frontend, and ingress as fatal children: a non-zero exit tears down the stack and exits the launcher with that status.
- Reject `startStaticServer()` when `listen` fails (`EADDRINUSE`).
- Add a parent-process regression test for the fatal path and a static-server listen-error test.

## Issue Number

Fixes #16927
Fixes #16904

## How to Test

```bash
npm ci
npx vitest run \
  __tests__/scripts/dev-with-automation.test.ts \
  __tests__/scripts/static-server.test.ts \
  __tests__/scripts/dev-safe.test.ts
```

Manual: occupy port 3001 (`node -e "require('net').createServer().listen(3001)"`), then `npx @openhands/agent-canvas` or `npm run dev`. The launcher must exit non-zero instead of printing a healthy :8000 banner.

## Video/Screenshots

Reporter screenshot from #16904 (blank UI on :8000 while a port is occupied):

<img width="850" height="522" alt="Blank Agent Canvas page when port 3001 is occupied" src="https://github.com/user-attachments/assets/636b2b40-706c-4a47-b4cc-e7522a30f505" />

Terminal repro of the parent staying alive on current `main` (before) is quoted under AGENT. After the fix the new unit test asserts the launcher exits 7 and never prints `PARENT_STILL_ALIVE`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Automation backend is *not* marked fatal: conversations still work if it dies.
- `assertPortsFree` is unchanged. It remains a useful preflight, but a missed occupancy (race, host mismatch) must still fail the parent.
- #16927 is the detailed launcher repro of the same #16904 user report.