### PR TITLE
fix(settings): scope local settings cache by backend

### DIFF
--- a/__tests__/api/settings-service.test.ts
+++ b/__tests__/api/settings-service.test.ts
@@ -31,6 +31,30 @@ const cloudBackend: Backend = {
   kind: "cloud",
 };
 
+const localBackendA: Backend = {
+  id: "local-a",
+  name: "Local A",
+  host: "http://local-a.example",
+  apiKey: "local-a-key",
+  kind: "local",
+  connectionRevision: 0,
+};
+
+const localBackendB: Backend = {
+  id: "local-b",
+  name: "Local B",
+  host: "http://local-b.example",
+  apiKey: "local-b-key",
+  kind: "local",
+  connectionRevision: 0,
+};
+
+const settingsResponse = (model: string) => ({
+  agent_settings: { llm: { model } },
+  conversation_settings: {},
+  llm_api_key_is_set: true,
+});
+
 describe("SettingsService", () => {
   beforeEach(() => {
     // Clear localStorage and reset mock settings state
@@ -124,6 +148,134 @@ describe("SettingsService", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
 
     fetchSpy.mockRestore();
+  });
+
+  it("scopes cached settings by local backend", async () => {
+    const requestCounts = { a: 0, b: 0 };
+    server.use(
+      http.get("http://local-a.example/api/settings", () => {
+        requestCounts.a += 1;
+        return HttpResponse.json(settingsResponse("model-a"));
+      }),
+      http.get("http://local-b.example/api/settings", () => {
+        requestCounts.b += 1;
+        return HttpResponse.json(settingsResponse("model-b"));
+      }),
+    );
+    setRegisteredBackends([localBackendA, localBackendB]);
+
+    setActiveSelection({ backendId: localBackendA.id });
+    expect((await SettingsService.getSettings()).llm_model).toBe("model-a");
+
+    setActiveSelection({ backendId: localBackendB.id });
+    expect((await SettingsService.getSettings()).llm_model).toBe("model-b");
+
+    setActiveSelection({ backendId: localBackendA.id });
+    expect((await SettingsService.getSettings()).llm_model).toBe("model-a");
+    expect(requestCounts).toEqual({ a: 1, b: 1 });
+  });
+
+  it("does not reuse encrypted conversation settings across backends", async () => {
+    server.use(
+      http.get("http://local-a.example/api/settings", () =>
+        HttpResponse.json(settingsResponse("encrypted-model-a")),
+      ),
+      http.get("http://local-b.example/api/settings", () =>
+        HttpResponse.json(settingsResponse("encrypted-model-b")),
+      ),
+    );
+    setRegisteredBackends([localBackendA, localBackendB]);
+
+    setActiveSelection({ backendId: localBackendA.id });
+    const settingsA = await SettingsService.getSettingsForConversation();
+
+    setActiveSelection({ backendId: localBackendB.id });
+    const settingsB = await SettingsService.getSettingsForConversation();
+
+    expect(settingsA.agentSettings.llm).toMatchObject({
+      model: "encrypted-model-a",
+    });
+    expect(settingsB.agentSettings.llm).toMatchObject({
+      model: "encrypted-model-b",
+    });
+  });
+
+  it("invalidates cached settings when the connection revision changes", async () => {
+    let requestCount = 0;
+    server.use(
+      http.get("http://local-a.example/api/settings", () => {
+        requestCount += 1;
+        return HttpResponse.json(settingsResponse(`model-${requestCount}`));
+      }),
+    );
+    setRegisteredBackends([localBackendA]);
+    setActiveSelection({ backendId: localBackendA.id });
+
+    expect((await SettingsService.getSettings()).llm_model).toBe("model-1");
+
+    setRegisteredBackends([
+      { ...localBackendA, connectionRevision: 1, apiKey: "rotated-key" },
+    ]);
+    setActiveSelection({ backendId: localBackendA.id });
+
+    expect((await SettingsService.getSettings()).llm_model).toBe("model-2");
+    expect(requestCount).toBe(2);
+  });
+
+  it("expires redacted and encrypted settings independently", async () => {
+    const requests: Array<string | null> = [];
+    server.use(
+      http.get("http://local-a.example/api/settings", ({ request }) => {
+        const exposure = request.headers.get("X-Expose-Secrets");
+        requests.push(exposure);
+        return HttpResponse.json(
+          settingsResponse(
+            exposure === "encrypted" ? "encrypted-model" : "redacted-model",
+          ),
+        );
+      }),
+    );
+    setRegisteredBackends([localBackendA]);
+    setActiveSelection({ backendId: localBackendA.id });
+    const now = vi.spyOn(Date, "now");
+
+    now.mockReturnValue(1);
+    await SettingsService.getSettingsForConversation();
+
+    now.mockReturnValue(2);
+    await SettingsService.getSettings();
+
+    now.mockReturnValue(5 * 60 * 1000 + 2);
+    await SettingsService.getSettingsForConversation();
+
+    expect(requests).toEqual(["encrypted", null, "encrypted"]);
+    now.mockRestore();
+  });
+
+  it("pins retries to the backend that started the settings request", async () => {
+    const requestedBackends: string[] = [];
+    server.use(
+      http.get("http://local-a.example/api/settings", () => {
+        requestedBackends.push("a");
+        if (requestedBackends.length === 1) {
+          setActiveSelection({ backendId: localBackendB.id });
+          return new HttpResponse(null, { status: 503 });
+        }
+        return HttpResponse.json(settingsResponse("model-a"));
+      }),
+      http.get("http://local-b.example/api/settings", () => {
+        requestedBackends.push("b");
+        return HttpResponse.json(settingsResponse("model-b"));
+      }),
+    );
+    setRegisteredBackends([localBackendA, localBackendB]);
+    setActiveSelection({ backendId: localBackendA.id });
+
+    expect((await SettingsService.getSettings()).llm_model).toBe("model-a");
+    expect(requestedBackends).toEqual(["a", "a"]);
+
+    expect((await SettingsService.getSettings()).llm_model).toBe("model-b");
+    expect(requestedBackends).toEqual(["a", "a", "b"]);
   });
 
   it("skips API call when no diffs are provided to saveSettings", async () => {

--- a/src/api/settings-service/settings-service.api.ts
+++ b/src/api/settings-service/settings-service.api.ts
@@ -14,7 +14,10 @@ import {
   fetchCloudSettingsSchema,
   saveCloudSettings,
 } from "../cloud/settings-service.api";
-import { getAgentServerClientOptions } from "../agent-server-client-options";
+import {
+  getAgentServerClientOptions,
+  type AgentServerClientOptions,
+} from "../agent-server-client-options";
 
 /**
  * Fields the agent-server stores under `misc_settings.app_preferences` (see
@@ -157,29 +160,79 @@ async function withRetry<T>(
   throw new Error("Retry attempts exhausted");
 }
 
-/**
- * In-memory cache for settings to avoid repeated network calls.
- * The cache is invalidated on save operations.
- */
-let settingsCache: {
-  /** Settings with redacted secrets for display */
-  redacted: SettingsApiResponse | null;
-  /** Settings with encrypted secrets for conversation start */
-  encrypted: SettingsApiResponse | null;
-  /** Timestamp when the cache was last populated */
-  timestamp: number;
-} = {
-  redacted: null,
-  encrypted: null,
-  timestamp: 0,
-};
-
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
-const isCacheValid = () => Date.now() - settingsCache.timestamp < CACHE_TTL_MS;
+type SettingsExposureMode = "redacted" | "encrypted";
+
+interface SettingsCacheEntry {
+  backendId: string;
+  connectionRevision: number;
+  exposureMode: SettingsExposureMode;
+  response: SettingsApiResponse;
+  fetchedAt: number;
+}
+
+/**
+ * Local settings are owned by a specific backend connection and exposure
+ * mode. Keeping that identity in the cache prevents one backend (or its
+ * encrypted conversation payload) from being reused for another.
+ */
+const settingsCache = new Map<string, SettingsCacheEntry>();
+
+const getSettingsCacheKey = (
+  backendId: string,
+  connectionRevision: number,
+  exposureMode: SettingsExposureMode,
+) => JSON.stringify([backendId, connectionRevision, exposureMode]);
+
+const readCachedSettings = (
+  backendId: string,
+  connectionRevision: number,
+  exposureMode: SettingsExposureMode,
+): SettingsApiResponse | null => {
+  const key = getSettingsCacheKey(backendId, connectionRevision, exposureMode);
+  const entry = settingsCache.get(key);
+  if (!entry) return null;
+
+  if (Date.now() - entry.fetchedAt >= CACHE_TTL_MS) {
+    settingsCache.delete(key);
+    return null;
+  }
+
+  return entry.response;
+};
+
+const cacheSettings = (
+  backendId: string,
+  connectionRevision: number,
+  exposureMode: SettingsExposureMode,
+  response: SettingsApiResponse,
+) => {
+  // A connection revision replaces every cached representation for the prior
+  // connection, so repeated host/API-key edits do not retain old revisions.
+  settingsCache.forEach((entry, key) => {
+    if (
+      entry.backendId === backendId &&
+      entry.connectionRevision !== connectionRevision
+    ) {
+      settingsCache.delete(key);
+    }
+  });
+
+  settingsCache.set(
+    getSettingsCacheKey(backendId, connectionRevision, exposureMode),
+    {
+      backendId,
+      connectionRevision,
+      exposureMode,
+      response,
+      fetchedAt: Date.now(),
+    },
+  );
+};
 
 const clearCache = () => {
-  settingsCache = { redacted: null, encrypted: null, timestamp: 0 };
+  settingsCache.clear();
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -431,9 +484,10 @@ class SettingsService {
    */
   static async fetchSettingsFromApi(
     exposeSecrets?: ExposeSecretsMode,
+    clientOptions: AgentServerClientOptions = getAgentServerClientOptions(),
   ): Promise<SettingsApiResponse> {
     return withRetry(() =>
-      new SettingsClient(getAgentServerClientOptions()).getSettings({
+      new SettingsClient(clientOptions).getSettings({
         exposeSecrets,
       }),
     ) as Promise<SettingsApiResponse>;
@@ -460,15 +514,24 @@ class SettingsService {
       }
     }
 
-    // Check cache first
-    if (isCacheValid() && settingsCache.redacted) {
-      return syncDerivedSettings(transformApiResponse(settingsCache.redacted));
+    const backend = getActiveBackend().backend;
+    const connectionRevision = backend.connectionRevision ?? 0;
+    const clientOptions = getAgentServerClientOptions();
+    const cached = readCachedSettings(
+      backend.id,
+      connectionRevision,
+      "redacted",
+    );
+    if (cached) {
+      return syncDerivedSettings(transformApiResponse(cached));
     }
 
     try {
-      const response = await this.fetchSettingsFromApi();
-      settingsCache.redacted = response;
-      settingsCache.timestamp = Date.now();
+      const response = await this.fetchSettingsFromApi(
+        undefined,
+        clientOptions,
+      );
+      cacheSettings(backend.id, connectionRevision, "redacted", response);
       return syncDerivedSettings(transformApiResponse(response));
     } catch (error) {
       // If API fails, return defaults
@@ -490,22 +553,29 @@ class SettingsService {
     conversationSettings: Record<string, SettingsValue>;
     secretsEncrypted: boolean;
   }> {
-    // Check cache first
-    if (isCacheValid() && settingsCache.encrypted) {
+    const backend = getActiveBackend().backend;
+    const connectionRevision = backend.connectionRevision ?? 0;
+    const clientOptions = getAgentServerClientOptions();
+    const cached = readCachedSettings(
+      backend.id,
+      connectionRevision,
+      "encrypted",
+    );
+    if (cached) {
       return {
-        agentSettings: settingsCache.encrypted.agent_settings,
-        conversationSettings: settingsCache.encrypted.conversation_settings,
+        agentSettings: cached.agent_settings,
+        conversationSettings: cached.conversation_settings,
         secretsEncrypted: true,
       };
     }
 
     // Fetch encrypted settings - this MUST succeed for conversations to work.
     // Do not fall back to redacted settings as that would cause auth failures.
-    const response = await this.fetchSettingsFromApi("encrypted");
-    settingsCache.encrypted = response;
-    if (!settingsCache.timestamp) {
-      settingsCache.timestamp = Date.now();
-    }
+    const response = await this.fetchSettingsFromApi(
+      "encrypted",
+      clientOptions,
+    );
+    cacheSettings(backend.id, connectionRevision, "encrypted", response);
     return {
       agentSettings: response.agent_settings,
       conversationSettings: response.conversation_settings,


### PR DESCRIPTION
HUMAN:
This PR proposes a small refactoring for reliability, with some simplification and tests for TTL, payload, retry behavior. I’m running a few skills to nudge the agent to find code design misses or improvements, this is one of them.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

The regression suite exercises backend A → B → A cache isolation, encrypted conversation-start isolation, connection revision changes, independent exposure-mode TTLs, and a retry whose active backend changes after the first request. Focused tests, the full unit suite, lint/typecheck, and the production build were run locally with supported Node 22.23.2.

---

## Why

The local settings service kept one process-global cache beneath correctly scoped React Query entries. Switching backends inside the five-minute TTL could therefore return another backend's settings, including encrypted settings passed into conversation creation. A shared timestamp also coupled the redacted and encrypted entries, and retries re-resolved the active backend.

## Summary

- Key local settings cache entries by backend ID, connection revision, and exposure mode, with independent timestamps.
- Capture client options at operation entry so retries remain pinned to the originating backend.
- Prune obsolete connection revisions and add regression coverage for backend, revision, TTL, encrypted-payload, and retry behavior.

## Issue Number

Fixes #16945

## How to Test

Using Node 22.23.2:

- `npm test -- --run __tests__/api/settings-service.test.ts` — 35/35 passed.
- `npm test -- --run` — 618 files passed; 5,221 tests passed, 4 skipped, 7 todo.
- `npm run lint` — passed with three pre-existing warnings and no errors.
- `npm run build` — production client and SPA build passed.

## Video/Screenshots

Terminal reproduction is encoded in the new regression cases in `__tests__/api/settings-service.test.ts`. The A → B → A case verifies each backend receives its own model, the encrypted case verifies distinct conversation payloads, and the retry case switches the active backend after a 503 while asserting both attempts still target backend A.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Cloud settings continue to bypass the local cache. Cache keys contain backend identity and revision only; API keys and other secret values are not retained in keys or logs.
