### PR TITLE
fix: rename conversation title on cloud backends

### DIFF
--- a/__tests__/api/cloud/conversation-title.test.ts
+++ b/__tests__/api/cloud/conversation-title.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import {
+  getFetchCall,
+  getJsonBody,
+  mockJsonResponse,
+} from "./fetch-test-utils";
+
+vi.mock("@openhands/typescript-client/clients", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@openhands/typescript-client/clients")
+    >();
+
+  return {
+    ...actual,
+    ConversationClient: vi.fn().mockImplementation(() => ({
+      updateConversation: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("Cloud title updates must not use ConversationClient"),
+        ),
+    })),
+  };
+});
+
+const cloudBackend: Backend = {
+  id: "prod",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "bearer-token",
+  kind: "cloud",
+};
+
+const originalFetch = global.fetch;
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(
+    mockJsonResponse({ id: "conv-abc", title: "Renamed conversation" }),
+  );
+  global.fetch = fetchMock as typeof fetch;
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  fetchMock.mockReset();
+  global.fetch = originalFetch;
+});
+
+describe("AgentServerConversationService.updateConversationTitle", () => {
+  it("PATCHes the app-conversation directly on a cloud backend", async () => {
+    setRegisteredBackends([cloudBackend]);
+    setActiveSelection({ backendId: cloudBackend.id });
+
+    const result = await AgentServerConversationService.updateConversationTitle(
+      "conv-abc",
+      "Renamed conversation",
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = getFetchCall(fetchMock);
+    expect(url).toBe(`${cloudBackend.host}/api/v1/app-conversations/conv-abc`);
+    expect(init).toMatchObject({
+      method: "PATCH",
+      headers: { Authorization: "Bearer bearer-token" },
+    });
+    expect(getJsonBody(init)).toEqual({ title: "Renamed conversation" });
+    expect(result).toMatchObject({
+      id: "conv-abc",
+      title: "Renamed conversation",
+    });
+  });
+});

--- a/src/api/cloud/conversation-service.api.ts
+++ b/src/api/cloud/conversation-service.api.ts
@@ -221,6 +221,24 @@ export async function updateCloudConversationPublicFlag(
 }
 
 /**
+ * Rename a cloud v1 app-conversation. The title belongs to the Cloud
+ * app-conversation resource, so updating a runtime Agent Server would not
+ * persist it in the Cloud conversation list.
+ */
+export async function updateCloudConversationTitle(
+  conversationId: string,
+  title: string,
+): Promise<AppConversation> {
+  const backend = getActiveCloudBackend();
+  return callCloudProxy<AppConversation>({
+    backend,
+    method: "PATCH",
+    path: `/api/v1/app-conversations/${conversationId}`,
+    body: { title },
+  });
+}
+
+/**
  * Pause the cloud sandbox backing a v1 app-conversation. Mirrors
  * OpenHands' `SandboxService.pauseSandbox`:
  * `POST /api/v1/sandboxes/{sandboxId}/pause` on the cloud backend, which stops

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -34,6 +34,7 @@ import {
   readCloudConversationFile,
   searchCloudConversations,
   updateCloudConversationPublicFlag,
+  updateCloudConversationTitle,
 } from "../cloud/conversation-service.api";
 import {
   DirectConversationInfo,
@@ -802,6 +803,10 @@ class AgentServerConversationService {
     conversationId: string,
     title: string,
   ): Promise<AppConversation> {
+    if (getActiveBackend().backend.kind === "cloud") {
+      return updateCloudConversationTitle(conversationId, title);
+    }
+
     await new ConversationClient(
       getAgentServerClientOptions(),
     ).updateConversation(conversationId, {


### PR DESCRIPTION
HUMAN: 

I tested these changes

Verified fix in this video: https://www.loom.com/share/43dc69f3b62449e5bc81498edc290faa

AGENT: 

fix: rename conversation title on cloud backends

## Why

Renaming a conversation on a Cloud backend fails with `NoBackendAvailableError` because `AgentServerConversationService.updateConversationTitle` unconditionally calls `getAgentServerClientOptions()`, which throws when the active backend is Cloud. Other update methods (`deleteConversation`, `updateConversationPublicFlag`) already branch on `getActiveBackend().backend.kind === 'cloud'`; the title update did not.

## Summary

- Added `updateCloudConversationTitle` in `src/api/cloud/conversation-service.api.ts` that PATCHes `/api/v1/app-conversations/{id}` with `{ title }` via `callCloudProxy`.
- Branched `updateConversationTitle` on the cloud backend to route through the new cloud path.
- Added unit test coverage for the cloud title update path.

## Issue Number

Fixes #15830

## How to Test

1. Connect a Cloud backend.
2. Open a conversation and use the Rename option to change its title.
3. Verify the title persists (no revert) and appears on the cloud backend.

Unit tests: `npx vitest run __tests__/api/cloud/conversation-title.test.ts`

## Video/Screenshots

verified fix: https://www.loom.com/share/43dc69f3b62449e5bc81498edc290faa

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore