### PR TITLE
fix: consume consent-aware website PostHog handoff

### DIFF
--- a/__tests__/components/providers/telemetry-provider.test.tsx
+++ b/__tests__/components/providers/telemetry-provider.test.tsx
@@ -16,10 +16,21 @@ const runtimeConfig = {
   uiHost: "https://posthog.example.com",
 };
 
+function encodeHandoff(value: unknown): string {
+  const encoded = btoa(
+    encodeURIComponent(JSON.stringify(value)).replace(
+      /%([0-9A-F]{2})/g,
+      (_, hex: string) => String.fromCharCode(Number.parseInt(hex, 16)),
+    ),
+  );
+  return encoded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
 describe("TelemetryProvider", () => {
   let configureBootstrapMock: ReturnType<typeof vi.spyOn>;
   let configureTelemetryMock: ReturnType<typeof vi.spyOn>;
   let initializeClientMock: ReturnType<typeof vi.spyOn>;
+  let setWebsiteAttributionMock: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     configureBootstrapMock = vi
@@ -31,8 +42,12 @@ describe("TelemetryProvider", () => {
     initializeClientMock = vi
       .spyOn(telemetry, "initializePostHogClient")
       .mockResolvedValue(null);
+    setWebsiteAttributionMock = vi
+      .spyOn(telemetry, "setTelemetryWebsiteAttribution")
+      .mockImplementation(() => undefined);
     useTelemetryMock.mockClear();
     window.location.hash = "";
+    localStorage.clear();
     sessionStorage.clear();
   });
 
@@ -83,6 +98,102 @@ describe("TelemetryProvider", () => {
       distinctID: "user-123",
       sessionID: "session-456",
     });
+  });
+
+  it("consumes structured website handoff IDs and attribution from the URL", () => {
+    window.location.hash = `oh_ph_handoff=${encodeHandoff({
+      v: 1,
+      exp: Date.now() + 60_000,
+      nonce: "nonce-structured",
+      distinct_id: "website-anon-id",
+      session_id: "website-session-id",
+      attribution: {
+        utm_source: "newsletter",
+        utm_medium: "email",
+        utm_campaign: "launch",
+        landing_page_category: "home",
+        cta_id: "hero-cloud",
+        cta_surface: "homepage_hero",
+        referring_domain_category: "search",
+        full_url: "https://www.openhands.dev/?secret=value",
+      },
+    })}`;
+
+    render(
+      <TelemetryProvider config={runtimeConfig}>
+        <div data-testid="child" />
+      </TelemetryProvider>,
+    );
+
+    expect(configureBootstrapMock).toHaveBeenCalledWith({
+      distinctID: "website-anon-id",
+      sessionID: "website-session-id",
+    });
+    expect(setWebsiteAttributionMock).toHaveBeenCalledWith({
+      utm_source: "newsletter",
+      utm_medium: "email",
+      utm_campaign: "launch",
+      landing_page_category: "home",
+      cta_id: "hero-cloud",
+      cta_surface: "homepage_hero",
+      referring_domain_category: "search",
+    });
+    expect(window.location.hash).toBe("");
+  });
+
+  it("drops malformed or expired handoffs and removes them from the URL", () => {
+    window.location.hash = `oh_ph_handoff=${encodeHandoff({
+      v: 1,
+      exp: Date.now() - 1,
+      nonce: "nonce-expired",
+      distinct_id: "website-anon-id",
+      session_id: "website-session-id",
+    })}`;
+
+    render(
+      <TelemetryProvider config={runtimeConfig}>
+        <div />
+      </TelemetryProvider>,
+    );
+
+    expect(configureBootstrapMock).toHaveBeenCalledWith(undefined);
+    expect(setWebsiteAttributionMock).toHaveBeenCalledWith(undefined);
+    expect(window.location.hash).toBe("");
+  });
+
+  it("prevents replay of a consumed structured handoff URL", () => {
+    const encoded = encodeHandoff({
+      v: 1,
+      exp: Date.now() + 60_000,
+      nonce: "nonce-replay",
+      distinct_id: "website-anon-id",
+      session_id: "website-session-id",
+    });
+
+    window.location.hash = `oh_ph_handoff=${encoded}`;
+    const firstView = render(
+      <TelemetryProvider config={runtimeConfig}>
+        <div />
+      </TelemetryProvider>,
+    );
+    expect(configureBootstrapMock).toHaveBeenLastCalledWith({
+      distinctID: "website-anon-id",
+      sessionID: "website-session-id",
+    });
+
+    firstView.unmount();
+    configureBootstrapMock.mockClear();
+    setWebsiteAttributionMock.mockClear();
+    window.location.hash = `oh_ph_handoff=${encoded}`;
+
+    render(
+      <TelemetryProvider config={runtimeConfig}>
+        <div />
+      </TelemetryProvider>,
+    );
+
+    expect(configureBootstrapMock).toHaveBeenCalledWith(undefined);
+    expect(setWebsiteAttributionMock).toHaveBeenCalledWith(undefined);
   });
 
   it("mounts telemetry lifecycle when analytics are enabled", () => {

--- a/__tests__/services/telemetry.test.ts
+++ b/__tests__/services/telemetry.test.ts
@@ -51,6 +51,7 @@ import {
   setTelemetryBackendContext,
   setTelemetryCloudContext,
   setTelemetryConsent,
+  setTelemetryWebsiteAttribution,
   setTelemetryIdentity,
   subscribeTelemetryConsent,
   trackEvent,
@@ -84,6 +85,7 @@ describe("Telemetry Service", () => {
     );
     await setTelemetryIdentity(null);
     setTelemetryBackendContext({});
+    setTelemetryWebsiteAttribution(undefined);
   });
 
   afterEach(() => {
@@ -151,6 +153,15 @@ describe("Telemetry Service", () => {
         agentServerVersion: "1.36.2",
         automationSdkVersion: "1.36.3",
       });
+      setTelemetryWebsiteAttribution({
+        utm_source: "newsletter",
+        utm_medium: "email",
+        utm_campaign: "launch",
+        landing_page_category: "home",
+        cta_id: "hero-cloud",
+        cta_surface: "homepage_hero",
+        referring_domain_category: "search",
+      });
       expect(
         config.before_send({
           event: "backend_context_event",
@@ -163,6 +174,13 @@ describe("Telemetry Service", () => {
           agent_server_version: "1.36.2",
           automation_sdk_version: "1.36.3",
           backend_version: "1.36.2",
+          utm_source: "newsletter",
+          utm_medium: "email",
+          utm_campaign: "launch",
+          landing_page_category: "home",
+          cta_id: "hero-cloud",
+          cta_surface: "homepage_hero",
+          referring_domain_category: "search",
           custom: "value",
         }),
       });

--- a/src/components/providers/telemetry-provider.tsx
+++ b/src/components/providers/telemetry-provider.tsx
@@ -5,10 +5,34 @@ import {
   configurePostHogBootstrap,
   configureTelemetry,
   initializePostHogClient,
+  setTelemetryWebsiteAttribution,
   type TelemetryConfiguration,
+  type WebsiteHandoffAttribution,
 } from "#/services/telemetry";
 
 const POSTHOG_BOOTSTRAP_KEY = "posthog_bootstrap";
+const POSTHOG_HANDOFF_PARAM = "oh_ph_handoff";
+const consumedHandoffNonces = new Set<string>();
+
+type PostHogHandoff = {
+  bootstrap: BootstrapConfig;
+  attribution?: WebsiteHandoffAttribution;
+};
+
+type StoredHandoff = PostHogHandoff & {
+  exp?: number;
+  nonce?: string;
+};
+
+const ATTRIBUTION_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "landing_page_category",
+  "cta_id",
+  "cta_surface",
+  "referring_domain_category",
+] as const;
 
 function isBootstrapConfig(value: unknown): value is BootstrapConfig {
   if (typeof value !== "object" || value === null) return false;
@@ -19,48 +43,199 @@ function isBootstrapConfig(value: unknown): value is BootstrapConfig {
   );
 }
 
-function readBootstrapIds(): BootstrapConfig | undefined {
-  if (typeof window === "undefined" || typeof sessionStorage === "undefined") {
-    return undefined;
+function safeSessionStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function safeLocalStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function base64UrlDecode(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  const decoded = atob(padded);
+  const encoded = Array.from(
+    decoded,
+    (char) => `%${char.charCodeAt(0).toString(16).padStart(2, "0")}`,
+  ).join("");
+  return decodeURIComponent(encoded);
+}
+
+function sanitizeAttribution(
+  value: unknown,
+): WebsiteHandoffAttribution | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const source = value as Record<string, unknown>;
+  const attribution: WebsiteHandoffAttribution = {};
+
+  for (const key of ATTRIBUTION_KEYS) {
+    const candidate = source[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      attribution[key] = candidate.trim().slice(0, 80);
+    }
   }
 
+  return Object.keys(attribution).length > 0 ? attribution : undefined;
+}
+
+function isHandoffNonceConsumed(nonce: string): boolean {
+  if (consumedHandoffNonces.has(nonce)) return true;
+
+  try {
+    return (
+      safeLocalStorage()?.getItem(`${POSTHOG_BOOTSTRAP_KEY}:${nonce}`) ===
+      "consumed"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function markHandoffNonceConsumed(nonce: string): void {
+  consumedHandoffNonces.add(nonce);
+  try {
+    safeLocalStorage()?.setItem(
+      `${POSTHOG_BOOTSTRAP_KEY}:${nonce}`,
+      "consumed",
+    );
+  } catch {
+    // In-memory replay protection still applies for this page lifetime.
+  }
+}
+
+function removeHandoffFromUrl(params: URLSearchParams): void {
+  params.delete(POSTHOG_HANDOFF_PARAM);
+  params.delete("distinct_id");
+  params.delete("session_id");
+  const nextHash = params.toString();
+
+  try {
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${window.location.search}${nextHash ? `#${nextHash}` : ""}`,
+    );
+  } catch {
+    // Telemetry must never prevent the application from rendering.
+  }
+}
+
+function parseStructuredHandoff(encoded: string): StoredHandoff | undefined {
+  try {
+    const parsed: unknown = JSON.parse(base64UrlDecode(encoded));
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+
+    const candidate = parsed as Record<string, unknown>;
+    if (candidate.v !== 1) return undefined;
+    if (typeof candidate.exp !== "number" || candidate.exp < Date.now())
+      return undefined;
+    if (typeof candidate.nonce !== "string" || !candidate.nonce)
+      return undefined;
+    if (isHandoffNonceConsumed(candidate.nonce)) return undefined;
+    if (typeof candidate.distinct_id !== "string" || !candidate.distinct_id)
+      return undefined;
+    if (typeof candidate.session_id !== "string" || !candidate.session_id)
+      return undefined;
+
+    const handoff = {
+      bootstrap: {
+        distinctID: candidate.distinct_id.slice(0, 256),
+        sessionID: candidate.session_id.slice(0, 256),
+      },
+      attribution: sanitizeAttribution(candidate.attribution),
+      exp: candidate.exp,
+      nonce: candidate.nonce,
+    };
+    markHandoffNonceConsumed(candidate.nonce);
+    return handoff;
+  } catch {
+    return undefined;
+  }
+}
+
+function readHandoffFromUrl(): PostHogHandoff | null | undefined {
   const params = new URLSearchParams(window.location.hash.slice(1));
+  const structured = params.get(POSTHOG_HANDOFF_PARAM);
   const distinctID = params.get("distinct_id");
   const sessionID = params.get("session_id");
-  if (distinctID && sessionID) {
-    const bootstrap = { distinctID, sessionID };
+  if (!structured && !(distinctID && sessionID)) return undefined;
+
+  const handoff = structured
+    ? parseStructuredHandoff(structured)
+    : {
+        bootstrap: { distinctID: distinctID ?? "", sessionID: sessionID ?? "" },
+      };
+
+  if (handoff) {
     try {
-      sessionStorage.setItem(POSTHOG_BOOTSTRAP_KEY, JSON.stringify(bootstrap));
+      safeSessionStorage()?.setItem(
+        POSTHOG_BOOTSTRAP_KEY,
+        JSON.stringify(handoff),
+      );
     } catch {
       // OAuth continuity is best effort when browser storage is unavailable.
     }
-    try {
-      window.history.replaceState(
-        null,
-        "",
-        window.location.pathname + window.location.search,
-      );
-    } catch {
-      // Telemetry must never prevent the application from rendering.
-    }
-    return bootstrap;
   }
 
+  removeHandoffFromUrl(params);
+  return handoff ?? null;
+}
+
+function isStoredHandoff(value: unknown): value is StoredHandoff {
+  if (isBootstrapConfig(value)) return true;
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return isBootstrapConfig(candidate.bootstrap);
+}
+
+function readStoredHandoff(): PostHogHandoff | undefined {
+  const storage = safeSessionStorage();
+  if (!storage) return undefined;
+
   try {
-    const stored = sessionStorage.getItem(POSTHOG_BOOTSTRAP_KEY);
+    const stored = storage.getItem(POSTHOG_BOOTSTRAP_KEY);
     if (!stored) return undefined;
 
-    sessionStorage.removeItem(POSTHOG_BOOTSTRAP_KEY);
+    storage.removeItem(POSTHOG_BOOTSTRAP_KEY);
     const parsed: unknown = JSON.parse(stored);
-    return isBootstrapConfig(parsed) ? parsed : undefined;
+    if (!isStoredHandoff(parsed)) return undefined;
+
+    if (isBootstrapConfig(parsed)) return { bootstrap: parsed };
+    if (typeof parsed.exp === "number" && parsed.exp < Date.now())
+      return undefined;
+    return {
+      bootstrap: parsed.bootstrap,
+      attribution: sanitizeAttribution(parsed.attribution),
+    };
   } catch {
     try {
-      sessionStorage.removeItem(POSTHOG_BOOTSTRAP_KEY);
+      storage.removeItem(POSTHOG_BOOTSTRAP_KEY);
     } catch {
       // Ignore unavailable storage.
     }
     return undefined;
   }
+}
+
+function readPostHogHandoff(): PostHogHandoff | undefined {
+  if (typeof window === "undefined") return undefined;
+  const urlHandoff = readHandoffFromUrl();
+  return urlHandoff === undefined
+    ? readStoredHandoff()
+    : (urlHandoff ?? undefined);
 }
 
 function TelemetryLifecycle() {
@@ -84,7 +259,9 @@ export function TelemetryProvider({
   React.useLayoutEffect(() => {
     configureTelemetry(analyticsEnabled ? { apiKey, apiHost, uiHost } : false);
     if (!configuredBootstrap.current) {
-      configurePostHogBootstrap(readBootstrapIds());
+      const handoff = readPostHogHandoff();
+      configurePostHogBootstrap(handoff?.bootstrap);
+      setTelemetryWebsiteAttribution(handoff?.attribution);
       configuredBootstrap.current = true;
     }
   }, [analyticsEnabled, apiHost, apiKey, uiHost]);

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -79,6 +79,19 @@ export interface TelemetryConfig {
   uiHost?: string;
 }
 
+export type WebsiteHandoffAttribution = Partial<
+  Record<
+    | "utm_source"
+    | "utm_medium"
+    | "utm_campaign"
+    | "landing_page_category"
+    | "cta_id"
+    | "cta_surface"
+    | "referring_domain_category",
+    string
+  >
+>;
+
 export type TelemetryConfiguration = TelemetryConfig | false;
 
 export type TelemetryConsent = "granted" | "denied" | "pending";
@@ -116,6 +129,13 @@ const CANVAS_EVENT_PROPERTIES = Object.freeze({
 
 let telemetryBackendContext = getBackendTelemetryProperties({});
 let telemetryCloudContext = getCloudTelemetryProperties();
+let telemetryWebsiteAttribution: WebsiteHandoffAttribution = {};
+
+export function setTelemetryWebsiteAttribution(
+  attribution: WebsiteHandoffAttribution | undefined,
+): void {
+  telemetryWebsiteAttribution = attribution ?? {};
+}
 
 export function setTelemetryBackendContext(
   context: BackendTelemetryContextInput,
@@ -139,6 +159,7 @@ function addCanvasEventProperties(
     properties: {
       ...telemetryBackendContext,
       ...telemetryCloudContext,
+      ...telemetryWebsiteAttribution,
       ...event.properties,
       ...CANVAS_EVENT_PROPERTIES,
     },
@@ -853,6 +874,7 @@ export async function clearTelemetryData(): Promise<void> {
 
   telemetryBackendContext = getBackendTelemetryProperties({});
   telemetryCloudContext = getCloudTelemetryProperties();
+  telemetryWebsiteAttribution = {};
   desiredTelemetryIdentity = null;
   desiredIdentityRevision += 1;
   appliedIdentityRevision = -1;


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

## Why

Live PostHog data shows weak person/session continuity from `www.openhands.dev` to Canvas. The website now produces a consent-aware structured handoff, so Canvas needs to consume it once, remove it from the visible URL, and bootstrap PostHog with the incoming anonymous identity/session.

Linear issue: https://linear.app/all-hands-ai/issue/OSS-10250/restore-consent-aware-website-to-canvas-posthog-identity-handoff

## Summary

- Adds structured `oh_ph_handoff` parsing with expiry, malformed payload handling, and replay prevention.
- Preserves legacy `distinct_id` / `session_id` hash bootstrap compatibility and session-storage continuity.
- Registers allow-listed website attribution on Canvas telemetry events and clears it on telemetry reset.

## Issue Number

Refs OSS-10250: https://linear.app/all-hands-ai/issue/OSS-10250/restore-consent-aware-website-to-canvas-posthog-identity-handoff

## How to Test

Commands run:

```bash
npm test -- --run __tests__/components/providers/telemetry-provider.test.tsx __tests__/services/telemetry.test.ts
npm run typecheck
```

Results:

- Targeted telemetry tests passed: 49 tests.
- Typecheck passed.

End-to-end browser verification against production PostHog/dashboard has not been run yet; this remains draft pending the companion website/enterprise PRs and dashboard verification.

## Video/Screenshots

Not included. This is telemetry/bootstrap plumbing with unit and typecheck validation; browser-level handoff verification is still pending while the cross-repo draft stack is reviewed.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Companion draft PRs are required in:

- `OpenHands/company-website` for handoff production from website CTAs.
- `OpenHands/enterprise` because Canvas is deployed under the Enterprise app subpath.

No raw emails, full URLs, query strings, device codes, API keys, or form content are consumed from the handoff; attribution is restricted to controlled categories and UTM source/medium/campaign.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c024ba72-040d-4774-8a68-a73184ed8db8)


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.49.1-python` |
| **Automation** | `openhands-automation==1.13.1` |
| **Commit** | `d211a07f70d5e02b91913c38bf00a1e817076373` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-d211a07
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-d211a07
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-d211a07-amd64
ghcr.io/openhands/agent-canvas:oss-10250-posthog-handoff-amd64
ghcr.io/openhands/agent-canvas:pr-16976-amd64
ghcr.io/openhands/agent-canvas:sha-d211a07-arm64
ghcr.io/openhands/agent-canvas:oss-10250-posthog-handoff-arm64
ghcr.io/openhands/agent-canvas:pr-16976-arm64
ghcr.io/openhands/agent-canvas:sha-d211a07
ghcr.io/openhands/agent-canvas:oss-10250-posthog-handoff
ghcr.io/openhands/agent-canvas:pr-16976
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-d211a07`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-d211a07-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->