### PR TITLE
feat: add a persistent feedback control for non-OHE installs

### DIFF
--- a/__tests__/components/features/feedback/feedback-launcher-mount.test.ts
+++ b/__tests__/components/features/feedback/feedback-launcher-mount.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Where the feedback control is mounted is load-bearing, and nothing else
+ * catches it.
+ *
+ * `useOptionalConversationId()` reads `NavigationContext`, which is created with
+ * a *default value* (`conversationId: null`). Rendering outside the provider
+ * therefore does not throw — it silently yields no conversation id, which is
+ * exactly what happened when the control was mounted in `root.tsx` as a sibling
+ * of `<Outlet />`. Every feedback event carried `conversation_id: undefined` and
+ * the component tests could not see it, because they stub the hook.
+ *
+ * `ReactRouterNavigationProvider` is mounted inside the route tree, in
+ * `root-layout.tsx`, so the control has to live there too. These assertions read
+ * the source rather than render it: the failure mode is a mount location, not a
+ * behaviour a unit test can observe once the hook is stubbed.
+ */
+
+const read = (relativePath: string) =>
+  readFileSync(join(process.cwd(), relativePath), "utf8");
+
+describe("FeedbackLauncher mount position", () => {
+  it("is mounted from root-layout, which is inside the navigation provider", () => {
+    const rootLayout = read("src/routes/root-layout.tsx");
+
+    expect(rootLayout).toContain("<FeedbackLauncher />");
+    expect(rootLayout).toContain("ReactRouterNavigationProvider");
+
+    // The launcher must sit inside the provider, not merely in the same file.
+    const providerOpens = rootLayout.indexOf("<ReactRouterNavigationProvider>");
+    const providerCloses = rootLayout.indexOf(
+      "</ReactRouterNavigationProvider>",
+    );
+    const launcher = rootLayout.indexOf("<FeedbackLauncher />");
+
+    expect(providerOpens).toBeGreaterThan(-1);
+    expect(launcher).toBeGreaterThan(providerOpens);
+    expect(launcher).toBeLessThan(providerCloses);
+  });
+
+  it("is not mounted from root, which renders outside that provider", () => {
+    expect(read("src/root.tsx")).not.toContain("FeedbackLauncher");
+  });
+
+  it("still relies on the context default that made the old mount fail quietly", () => {
+    // If NavigationContext ever starts throwing outside its provider, this
+    // guard is redundant and can go.
+    expect(read("src/context/navigation-context.tsx")).toContain(
+      "conversationId: null",
+    );
+  });
+});

--- a/__tests__/components/features/feedback/feedback-launcher.test.tsx
+++ b/__tests__/components/features/feedback/feedback-launcher.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FeedbackLauncher } from "#/components/features/feedback/feedback-launcher";
+
+const mocks = vi.hoisted(() => ({
+  trackFeedbackSubmitted: vi.fn(),
+  attachFeedbackEmail: vi.fn(),
+  getLockedCloudHost: vi.fn(),
+  isTelemetryEnabled: vi.fn(),
+  conversationId: null as string | null,
+}));
+
+vi.mock("#/hooks/use-tracking", () => ({
+  useTracking: () => ({
+    trackFeedbackSubmitted: mocks.trackFeedbackSubmitted,
+    attachFeedbackEmail: mocks.attachFeedbackEmail,
+  }),
+}));
+
+vi.mock("#/api/agent-server-config", () => ({
+  getLockedCloudHost: mocks.getLockedCloudHost,
+}));
+
+vi.mock("#/services/telemetry", () => ({
+  isTelemetryEnabled: mocks.isTelemetryEnabled,
+}));
+
+vi.mock("#/hooks/use-conversation-id", () => ({
+  useOptionalConversationId: () => ({ conversationId: mocks.conversationId }),
+}));
+
+const openPanel = async () => {
+  const user = userEvent.setup();
+  render(<FeedbackLauncher />);
+  await user.click(screen.getByTestId("feedback-launcher"));
+  return user;
+};
+
+beforeEach(() => {
+  mocks.trackFeedbackSubmitted.mockResolvedValue(undefined);
+  mocks.attachFeedbackEmail.mockResolvedValue(undefined);
+  mocks.getLockedCloudHost.mockReturnValue(null);
+  mocks.isTelemetryEnabled.mockReturnValue(true);
+  mocks.conversationId = null;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("FeedbackLauncher", () => {
+  describe("install gating", () => {
+    it("renders the control on a non-OHE install", () => {
+      render(<FeedbackLauncher />);
+      expect(screen.getByTestId("feedback-launcher")).toBeInTheDocument();
+    });
+
+    it("renders nothing when the app is locked to Cloud", () => {
+      mocks.getLockedCloudHost.mockReturnValue("https://app.all-hands.dev");
+      render(<FeedbackLauncher />);
+      expect(screen.queryByTestId("feedback-launcher")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("opening the form", () => {
+    it("does not show the form until the button is clicked", () => {
+      render(<FeedbackLauncher />);
+      expect(screen.queryByTestId("feedback-panel")).not.toBeInTheDocument();
+    });
+
+    it("opens the form from the button", async () => {
+      await openPanel();
+      expect(screen.getByTestId("feedback-panel")).toBeInTheDocument();
+      expect(screen.getByTestId("feedback-message")).toBeInTheDocument();
+    });
+  });
+
+  describe("the email is optional", () => {
+    it("submits with no email and does not touch the person", async () => {
+      const user = await openPanel();
+      await user.type(
+        screen.getByTestId("feedback-message"),
+        "the sidebar lags",
+      );
+      await user.click(screen.getByTestId("feedback-submit"));
+
+      await waitFor(() =>
+        expect(mocks.trackFeedbackSubmitted).toHaveBeenCalledWith(
+          expect.objectContaining({
+            feedback: "the sidebar lags",
+            hasEmail: false,
+          }),
+        ),
+      );
+      expect(mocks.attachFeedbackEmail).not.toHaveBeenCalled();
+    });
+
+    it("attaches the email to the person when one is given", async () => {
+      const user = await openPanel();
+      await user.type(screen.getByTestId("feedback-message"), "looks good");
+      await user.type(screen.getByTestId("feedback-email"), "dev@example.com");
+      await user.click(screen.getByTestId("feedback-submit"));
+
+      await waitFor(() =>
+        expect(mocks.attachFeedbackEmail).toHaveBeenCalledWith(
+          "dev@example.com",
+        ),
+      );
+      expect(mocks.trackFeedbackSubmitted).toHaveBeenCalledWith(
+        expect.objectContaining({ hasEmail: true }),
+      );
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects a malformed email and says so instead of submitting", async () => {
+      const user = await openPanel();
+      await user.type(screen.getByTestId("feedback-message"), "hello");
+      await user.type(screen.getByTestId("feedback-email"), "not-an-email");
+      await user.click(screen.getByTestId("feedback-submit"));
+
+      expect(screen.getByTestId("feedback-email-error")).toBeInTheDocument();
+      expect(mocks.trackFeedbackSubmitted).not.toHaveBeenCalled();
+      expect(mocks.attachFeedbackEmail).not.toHaveBeenCalled();
+    });
+
+    it("cannot be submitted with empty feedback", async () => {
+      await openPanel();
+      expect(screen.getByTestId("feedback-submit")).toBeDisabled();
+    });
+  });
+
+  describe("outcome", () => {
+    it("confirms a successful submission", async () => {
+      const user = await openPanel();
+      await user.type(screen.getByTestId("feedback-message"), "nice work");
+      await user.click(screen.getByTestId("feedback-submit"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("feedback-success")).toBeInTheDocument(),
+      );
+    });
+
+    it("keeps what was typed when submission fails", async () => {
+      mocks.trackFeedbackSubmitted.mockRejectedValue(new Error("network"));
+      const user = await openPanel();
+      await user.type(screen.getByTestId("feedback-message"), "keep this");
+      await user.click(screen.getByTestId("feedback-submit"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("feedback-error")).toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("feedback-message")).toHaveValue("keep this");
+    });
+
+    it("reports an error rather than silently dropping feedback without consent", async () => {
+      // `trackEvent` resolves without capturing when consent is absent, so a
+      // resolved promise would otherwise read as success.
+      mocks.isTelemetryEnabled.mockReturnValue(false);
+      const user = await openPanel();
+      await user.type(screen.getByTestId("feedback-message"), "unheard");
+      await user.click(screen.getByTestId("feedback-submit"));
+
+      expect(screen.getByTestId("feedback-error")).toBeInTheDocument();
+      expect(mocks.trackFeedbackSubmitted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("session association", () => {
+    it("passes the conversation id when the user is in one", async () => {
+      mocks.conversationId = "conv-42";
+      const user = await openPanel();
+      await user.type(
+        screen.getByTestId("feedback-message"),
+        "in-conversation",
+      );
+      await user.click(screen.getByTestId("feedback-submit"));
+
+      await waitFor(() =>
+        expect(mocks.trackFeedbackSubmitted).toHaveBeenCalledWith(
+          expect.objectContaining({ conversationId: "conv-42" }),
+        ),
+      );
+    });
+
+    it("omits the conversation id outside a conversation", async () => {
+      const user = await openPanel();
+      await user.type(
+        screen.getByTestId("feedback-message"),
+        "on the home page",
+      );
+      await user.click(screen.getByTestId("feedback-submit"));
+
+      await waitFor(() =>
+        expect(mocks.trackFeedbackSubmitted).toHaveBeenCalledWith(
+          expect.objectContaining({ conversationId: undefined }),
+        ),
+      );
+    });
+  });
+});

--- a/__tests__/components/features/feedback/feedback-launcher.test.tsx
+++ b/__tests__/components/features/feedback/feedback-launcher.test.tsx
@@ -4,27 +4,45 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FeedbackLauncher } from "#/components/features/feedback/feedback-launcher";
 
+/**
+ * `use-tracking` is deliberately NOT mocked. The acceptance criteria name the
+ * PostHog submission and identify calls, so the real hook runs and the telemetry
+ * service is the seam — otherwise these tests would only prove that one mock
+ * called another.
+ */
 const mocks = vi.hoisted(() => ({
-  trackFeedbackSubmitted: vi.fn(),
-  attachFeedbackEmail: vi.fn(),
-  getLockedCloudHost: vi.fn(),
+  trackEvent: vi.fn(),
+  setTelemetryPersonProperties: vi.fn(),
+  setTelemetryBackendContext: vi.fn(),
   isTelemetryEnabled: vi.fn(),
+  getLockedCloudHost: vi.fn(),
+  backendKind: "local" as "local" | "cloud",
   conversationId: null as string | null,
 }));
 
-vi.mock("#/hooks/use-tracking", () => ({
-  useTracking: () => ({
-    trackFeedbackSubmitted: mocks.trackFeedbackSubmitted,
-    attachFeedbackEmail: mocks.attachFeedbackEmail,
-  }),
+vi.mock("#/services/telemetry", () => ({
+  trackEvent: mocks.trackEvent,
+  setTelemetryPersonProperties: mocks.setTelemetryPersonProperties,
+  setTelemetryBackendContext: mocks.setTelemetryBackendContext,
+  isTelemetryEnabled: mocks.isTelemetryEnabled,
 }));
 
 vi.mock("#/api/agent-server-config", () => ({
   getLockedCloudHost: mocks.getLockedCloudHost,
 }));
 
-vi.mock("#/services/telemetry", () => ({
-  isTelemetryEnabled: mocks.isTelemetryEnabled,
+vi.mock("#/contexts/active-backend-context", () => ({
+  useActiveBackend: () => ({
+    backend: { kind: mocks.backendKind, host: "http://127.0.0.1:8000" },
+  }),
+}));
+
+vi.mock("#/hooks/query/use-automation-sdk-version", () => ({
+  useAutomationSdkVersion: () => null,
+}));
+
+vi.mock("#/api/agent-server-compatibility", () => ({
+  getCachedAgentServerVersion: () => null,
 }));
 
 vi.mock("#/hooks/use-conversation-id", () => ({
@@ -38,11 +56,23 @@ const openPanel = async () => {
   return user;
 };
 
+const submitWith = async (message: string, email?: string) => {
+  const user = await openPanel();
+  await user.type(screen.getByTestId("feedback-message"), message);
+  if (email) await user.type(screen.getByTestId("feedback-email"), email);
+  await user.click(screen.getByTestId("feedback-submit"));
+  return user;
+};
+
+/** The event properties passed to the real `trackEvent`. */
+const capturedProperties = () => mocks.trackEvent.mock.calls[0][1];
+
 beforeEach(() => {
-  mocks.trackFeedbackSubmitted.mockResolvedValue(undefined);
-  mocks.attachFeedbackEmail.mockResolvedValue(undefined);
-  mocks.getLockedCloudHost.mockReturnValue(null);
+  mocks.trackEvent.mockResolvedValue(undefined);
+  mocks.setTelemetryPersonProperties.mockResolvedValue(undefined);
   mocks.isTelemetryEnabled.mockReturnValue(true);
+  mocks.getLockedCloudHost.mockReturnValue(null);
+  mocks.backendKind = "local";
   mocks.conversationId = null;
 });
 
@@ -52,7 +82,7 @@ afterEach(() => {
 
 describe("FeedbackLauncher", () => {
   describe("install gating", () => {
-    it("renders the control on a non-OHE install", () => {
+    it("renders on a local install that is not locked to Cloud", () => {
       render(<FeedbackLauncher />);
       expect(screen.getByTestId("feedback-launcher")).toBeInTheDocument();
     });
@@ -62,68 +92,104 @@ describe("FeedbackLauncher", () => {
       render(<FeedbackLauncher />);
       expect(screen.queryByTestId("feedback-launcher")).not.toBeInTheDocument();
     });
+
+    it("renders nothing on a non-local backend", () => {
+      // A self-hosted OHE reached on its own domain is not locked to Cloud, so
+      // the backend kind is the signal that keeps this off hosted installs.
+      mocks.backendKind = "cloud";
+      render(<FeedbackLauncher />);
+      expect(screen.queryByTestId("feedback-launcher")).not.toBeInTheDocument();
+    });
   });
 
-  describe("opening the form", () => {
+  describe("opening and closing", () => {
     it("does not show the form until the button is clicked", () => {
       render(<FeedbackLauncher />);
       expect(screen.queryByTestId("feedback-panel")).not.toBeInTheDocument();
     });
 
-    it("opens the form from the button", async () => {
+    it("opens the form from the button and marks the trigger expanded", async () => {
       await openPanel();
       expect(screen.getByTestId("feedback-panel")).toBeInTheDocument();
+      expect(screen.getByTestId("feedback-launcher")).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+
+    it("closes on Escape", async () => {
+      const user = await openPanel();
+      await user.keyboard("{Escape}");
+      expect(screen.queryByTestId("feedback-panel")).not.toBeInTheDocument();
+    });
+
+    it("does not reopen showing a stale confirmation", async () => {
+      const user = await submitWith("done");
+      await waitFor(() =>
+        expect(screen.getByTestId("feedback-success")).toBeInTheDocument(),
+      );
+
+      await user.click(screen.getByTestId("feedback-launcher")); // close
+      await user.click(screen.getByTestId("feedback-launcher")); // reopen
+
+      expect(screen.queryByTestId("feedback-success")).not.toBeInTheDocument();
       expect(screen.getByTestId("feedback-message")).toBeInTheDocument();
     });
   });
 
-  describe("the email is optional", () => {
-    it("submits with no email and does not touch the person", async () => {
-      const user = await openPanel();
-      await user.type(
-        screen.getByTestId("feedback-message"),
-        "the sidebar lags",
-      );
-      await user.click(screen.getByTestId("feedback-submit"));
+  describe("what reaches PostHog", () => {
+    it("captures the feedback with no email and touches no person property", async () => {
+      await submitWith("the sidebar lags");
 
-      await waitFor(() =>
-        expect(mocks.trackFeedbackSubmitted).toHaveBeenCalledWith(
-          expect.objectContaining({
-            feedback: "the sidebar lags",
-            hasEmail: false,
-          }),
-        ),
+      await waitFor(() => expect(mocks.trackEvent).toHaveBeenCalledTimes(1));
+      expect(mocks.trackEvent.mock.calls[0][0]).toBe(
+        "canvas_feedback_submitted",
       );
-      expect(mocks.attachFeedbackEmail).not.toHaveBeenCalled();
+      expect(capturedProperties()).toMatchObject({
+        feedback: "the sidebar lags",
+        feedback_length: 16,
+        has_email: false,
+      });
+      expect(mocks.setTelemetryPersonProperties).not.toHaveBeenCalled();
     });
 
-    it("attaches the email to the person when one is given", async () => {
-      const user = await openPanel();
-      await user.type(screen.getByTestId("feedback-message"), "looks good");
-      await user.type(screen.getByTestId("feedback-email"), "dev@example.com");
-      await user.click(screen.getByTestId("feedback-submit"));
+    it("sets the email as a person property rather than an event property", async () => {
+      await submitWith("looks good", "dev@example.com");
 
       await waitFor(() =>
-        expect(mocks.attachFeedbackEmail).toHaveBeenCalledWith(
-          "dev@example.com",
-        ),
+        expect(mocks.setTelemetryPersonProperties).toHaveBeenCalledWith({
+          email: "dev@example.com",
+        }),
       );
-      expect(mocks.trackFeedbackSubmitted).toHaveBeenCalledWith(
-        expect.objectContaining({ hasEmail: true }),
-      );
+      expect(capturedProperties()).toMatchObject({ has_email: true });
+      expect(capturedProperties()).not.toHaveProperty("email");
+    });
+
+    it("carries the conversation the user is in", async () => {
+      mocks.conversationId = "conv-42";
+      await submitWith("in-conversation");
+
+      await waitFor(() => expect(mocks.trackEvent).toHaveBeenCalled());
+      expect(capturedProperties()).toMatchObject({
+        conversation_id: "conv-42",
+      });
+    });
+
+    it("omits the conversation id outside a conversation", async () => {
+      await submitWith("on the home page");
+
+      await waitFor(() => expect(mocks.trackEvent).toHaveBeenCalled());
+      expect(capturedProperties().conversation_id).toBeUndefined();
     });
   });
 
   describe("validation", () => {
-    it("rejects a malformed email and says so instead of submitting", async () => {
-      const user = await openPanel();
-      await user.type(screen.getByTestId("feedback-message"), "hello");
-      await user.type(screen.getByTestId("feedback-email"), "not-an-email");
-      await user.click(screen.getByTestId("feedback-submit"));
+    it("rejects a malformed email and captures nothing", async () => {
+      await submitWith("hello", "not-an-email");
 
       expect(screen.getByTestId("feedback-email-error")).toBeInTheDocument();
-      expect(mocks.trackFeedbackSubmitted).not.toHaveBeenCalled();
-      expect(mocks.attachFeedbackEmail).not.toHaveBeenCalled();
+      expect(mocks.trackEvent).not.toHaveBeenCalled();
+      expect(mocks.setTelemetryPersonProperties).not.toHaveBeenCalled();
     });
 
     it("cannot be submitted with empty feedback", async () => {
@@ -134,20 +200,15 @@ describe("FeedbackLauncher", () => {
 
   describe("outcome", () => {
     it("confirms a successful submission", async () => {
-      const user = await openPanel();
-      await user.type(screen.getByTestId("feedback-message"), "nice work");
-      await user.click(screen.getByTestId("feedback-submit"));
-
+      await submitWith("nice work");
       await waitFor(() =>
         expect(screen.getByTestId("feedback-success")).toBeInTheDocument(),
       );
     });
 
-    it("keeps what was typed when submission fails", async () => {
-      mocks.trackFeedbackSubmitted.mockRejectedValue(new Error("network"));
-      const user = await openPanel();
-      await user.type(screen.getByTestId("feedback-message"), "keep this");
-      await user.click(screen.getByTestId("feedback-submit"));
+    it("keeps what was typed when the capture throws", async () => {
+      mocks.trackEvent.mockRejectedValue(new Error("boom"));
+      await submitWith("keep this");
 
       await waitFor(() =>
         expect(screen.getByTestId("feedback-error")).toBeInTheDocument(),
@@ -159,45 +220,10 @@ describe("FeedbackLauncher", () => {
       // `trackEvent` resolves without capturing when consent is absent, so a
       // resolved promise would otherwise read as success.
       mocks.isTelemetryEnabled.mockReturnValue(false);
-      const user = await openPanel();
-      await user.type(screen.getByTestId("feedback-message"), "unheard");
-      await user.click(screen.getByTestId("feedback-submit"));
+      await submitWith("unheard");
 
       expect(screen.getByTestId("feedback-error")).toBeInTheDocument();
-      expect(mocks.trackFeedbackSubmitted).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("session association", () => {
-    it("passes the conversation id when the user is in one", async () => {
-      mocks.conversationId = "conv-42";
-      const user = await openPanel();
-      await user.type(
-        screen.getByTestId("feedback-message"),
-        "in-conversation",
-      );
-      await user.click(screen.getByTestId("feedback-submit"));
-
-      await waitFor(() =>
-        expect(mocks.trackFeedbackSubmitted).toHaveBeenCalledWith(
-          expect.objectContaining({ conversationId: "conv-42" }),
-        ),
-      );
-    });
-
-    it("omits the conversation id outside a conversation", async () => {
-      const user = await openPanel();
-      await user.type(
-        screen.getByTestId("feedback-message"),
-        "on the home page",
-      );
-      await user.click(screen.getByTestId("feedback-submit"));
-
-      await waitFor(() =>
-        expect(mocks.trackFeedbackSubmitted).toHaveBeenCalledWith(
-          expect.objectContaining({ conversationId: undefined }),
-        ),
-      );
+      expect(mocks.trackEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/components/features/feedback/feedback-launcher.test.tsx
+++ b/__tests__/components/features/feedback/feedback-launcher.test.tsx
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   trackEvent: vi.fn(),
   setTelemetryPersonProperties: vi.fn(),
   setTelemetryBackendContext: vi.fn(),
-  isTelemetryEnabled: vi.fn(),
+  canCaptureTelemetry: vi.fn(),
   getLockedCloudHost: vi.fn(),
   backendKind: "local" as "local" | "cloud",
   conversationId: null as string | null,
@@ -24,7 +24,7 @@ vi.mock("#/services/telemetry", () => ({
   trackEvent: mocks.trackEvent,
   setTelemetryPersonProperties: mocks.setTelemetryPersonProperties,
   setTelemetryBackendContext: mocks.setTelemetryBackendContext,
-  isTelemetryEnabled: mocks.isTelemetryEnabled,
+  canCaptureTelemetry: mocks.canCaptureTelemetry,
 }));
 
 vi.mock("#/api/agent-server-config", () => ({
@@ -70,7 +70,7 @@ const capturedProperties = () => mocks.trackEvent.mock.calls[0][1];
 beforeEach(() => {
   mocks.trackEvent.mockResolvedValue(undefined);
   mocks.setTelemetryPersonProperties.mockResolvedValue(undefined);
-  mocks.isTelemetryEnabled.mockReturnValue(true);
+  mocks.canCaptureTelemetry.mockReturnValue(true);
   mocks.getLockedCloudHost.mockReturnValue(null);
   mocks.backendKind = "local";
   mocks.conversationId = null;
@@ -142,9 +142,7 @@ describe("FeedbackLauncher", () => {
       await submitWith("the sidebar lags");
 
       await waitFor(() => expect(mocks.trackEvent).toHaveBeenCalledTimes(1));
-      expect(mocks.trackEvent.mock.calls[0][0]).toBe(
-        "canvas_feedback_submitted",
-      );
+      expect(mocks.trackEvent.mock.calls[0][0]).toBe("feedback_submitted");
       expect(capturedProperties()).toMatchObject({
         feedback: "the sidebar lags",
         feedback_length: 16,
@@ -219,7 +217,7 @@ describe("FeedbackLauncher", () => {
     it("reports an error rather than silently dropping feedback without consent", async () => {
       // `trackEvent` resolves without capturing when consent is absent, so a
       // resolved promise would otherwise read as success.
-      mocks.isTelemetryEnabled.mockReturnValue(false);
+      mocks.canCaptureTelemetry.mockReturnValue(false);
       await submitWith("unheard");
 
       expect(screen.getByTestId("feedback-error")).toBeInTheDocument();

--- a/src/components/features/feedback/feedback-launcher.tsx
+++ b/src/components/features/feedback/feedback-launcher.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { getLockedCloudHost } from "#/api/agent-server-config";
 import { BrandButton } from "#/components/features/settings/brand-button";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { useTracking } from "#/hooks/use-tracking";
 import { I18nKey } from "#/i18n/declaration";
@@ -17,9 +18,8 @@ import { cn } from "#/utils/utils";
  * control cannot become a recurring interruption. The button is the anchor a
  * future survey bubble would attach to.
  *
- * Hidden entirely when the app is locked to Cloud — the same signal
- * `agent-canvas-update-card` uses to hide install-specific affordances on a
- * hosted deployment.
+ * Hidden on hosted installs, gated on the same pair of signals as
+ * `telemetry-consent-banner`: locked-to-Cloud, or a non-local active backend.
  *
  * ## Telemetry
  *
@@ -27,8 +27,9 @@ import { cn } from "#/utils/utils";
  * | --- | --- |
  * | `canvas_feedback_submitted` | `feedback`, `feedback_length`, `has_email`, `conversation_id`, plus the common backend context |
  *
- * A supplied email is attached to the PostHog person via `identify` as the
- * `email` person property, not repeated on the event.
+ * A supplied email is attached to the PostHog person with
+ * `setPersonProperties` as the `email` person property, not repeated on the
+ * event.
  */
 
 /** Deliberately permissive: reject obvious typos, not unusual-but-valid addresses. */
@@ -40,16 +41,41 @@ export function FeedbackLauncher() {
   const { t } = useTranslation();
   const { trackFeedbackSubmitted, attachFeedbackEmail } = useTracking();
   const { conversationId } = useOptionalConversationId();
+  const { backend } = useActiveBackend();
 
   const [isOpen, setIsOpen] = React.useState(false);
   const [feedback, setFeedback] = React.useState("");
   const [email, setEmail] = React.useState("");
   const [emailError, setEmailError] = React.useState(false);
   const [state, setState] = React.useState<SubmitState>("idle");
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
 
-  // Not a hook, so it is safe to read on every render; the early return below
-  // happens after every hook has run.
-  const isLockedToCloud = getLockedCloudHost() !== null;
+  // Both signals, matching `telemetry-consent-banner` — the other install-gated
+  // control mounted alongside this one. `getLockedCloudHost()` alone is not
+  // enough: a self-hosted OHE reached on its own domain is not locked to Cloud,
+  // and `backend-form-modal` notes it is otherwise indistinguishable from a
+  // local agent-server by host.
+  const isHostedInstall =
+    getLockedCloudHost() !== null || backend.kind !== "local";
+
+  const close = React.useCallback(() => {
+    setIsOpen(false);
+    // Reset here rather than only on the success button, so reopening never
+    // shows a stale "thank you" or error from the previous submission.
+    setState("idle");
+    setEmailError(false);
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      close();
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, close]);
 
   /**
    * The form is `noValidate`: the browser's own constraint messages are not
@@ -94,14 +120,15 @@ export function FeedbackLauncher() {
     }
   };
 
-  if (isLockedToCloud) return null;
+  if (isHostedInstall) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2">
+    <div className="fixed bottom-4 right-4 z-30 flex flex-col items-end gap-2">
       {isOpen && (
         <div
           data-testid="feedback-panel"
           role="dialog"
+          aria-modal="false"
           aria-label={t(I18nKey.FEEDBACK$TITLE)}
           className="w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-[var(--oh-border-subtle)] bg-tertiary p-4 shadow-lg"
         >
@@ -114,10 +141,7 @@ export function FeedbackLauncher() {
                 type="button"
                 variant="secondary"
                 testId="feedback-close"
-                onClick={() => {
-                  setIsOpen(false);
-                  setState("idle");
-                }}
+                onClick={close}
               >
                 {t(I18nKey.BUTTON$CLOSE)}
               </BrandButton>
@@ -185,7 +209,7 @@ export function FeedbackLauncher() {
                   type="button"
                   variant="secondary"
                   testId="feedback-cancel"
-                  onClick={() => setIsOpen(false)}
+                  onClick={close}
                 >
                   {t(I18nKey.FEEDBACK$CANCEL_LABEL)}
                 </BrandButton>
@@ -198,7 +222,7 @@ export function FeedbackLauncher() {
                 >
                   {state === "submitting"
                     ? t(I18nKey.FEEDBACK$SUBMITTING_LABEL)
-                    : t(I18nKey.FEEDBACK$SHARE_LABEL)}
+                    : t(I18nKey.BUTTON$SEND)}
                 </BrandButton>
               </div>
             </form>
@@ -207,11 +231,14 @@ export function FeedbackLauncher() {
       )}
 
       <BrandButton
+        ref={triggerRef}
         type="button"
         variant="primary"
         testId="feedback-launcher"
         ariaLabel={t(I18nKey.FEEDBACK$TITLE)}
-        onClick={() => setIsOpen((open) => !open)}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        onClick={() => (isOpen ? close() : setIsOpen(true))}
       >
         {t(I18nKey.FEEDBACK$TITLE)}
       </BrandButton>

--- a/src/components/features/feedback/feedback-launcher.tsx
+++ b/src/components/features/feedback/feedback-launcher.tsx
@@ -124,14 +124,21 @@ export function FeedbackLauncher() {
   if (isHostedInstall) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-30 flex flex-col items-end gap-2">
+    /*
+     * `pointer-events-none` on the wrapper, re-enabled on the button and the
+     * panel: the wrapper is a flex column that grows with the panel, so without
+     * it the empty space above the button would swallow clicks meant for the
+     * page beneath — which is what "does not block or interfere with normal
+     * user interaction" asks for, independently of viewport width.
+     */
+    <div className="pointer-events-none fixed bottom-4 right-4 z-30 flex flex-col items-end gap-2">
       {isOpen && (
         <div
           data-testid="feedback-panel"
           role="dialog"
           aria-modal="false"
           aria-label={t(I18nKey.FEEDBACK$TITLE)}
-          className="w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-[var(--oh-border-subtle)] bg-tertiary p-4 shadow-lg"
+          className="pointer-events-auto w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-[var(--oh-border-subtle)] bg-tertiary p-4 shadow-lg"
         >
           {state === "submitted" ? (
             <div className="flex flex-col gap-3">
@@ -235,6 +242,7 @@ export function FeedbackLauncher() {
         ref={triggerRef}
         type="button"
         variant="primary"
+        className="pointer-events-auto"
         testId="feedback-launcher"
         ariaLabel={t(I18nKey.FEEDBACK$TITLE)}
         aria-haspopup="dialog"

--- a/src/components/features/feedback/feedback-launcher.tsx
+++ b/src/components/features/feedback/feedback-launcher.tsx
@@ -1,0 +1,220 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { getLockedCloudHost } from "#/api/agent-server-config";
+import { BrandButton } from "#/components/features/settings/brand-button";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
+import { useTracking } from "#/hooks/use-tracking";
+import { I18nKey } from "#/i18n/declaration";
+import { isTelemetryEnabled } from "#/services/telemetry";
+import { cn } from "#/utils/utils";
+
+/**
+ * Persistent feedback control for non-OHE installs.
+ *
+ * Renders a floating button in the bottom-right that opens a small panel. It is
+ * deliberately not a popup: the panel only ever opens from a user click, so the
+ * control cannot become a recurring interruption. The button is the anchor a
+ * future survey bubble would attach to.
+ *
+ * Hidden entirely when the app is locked to Cloud — the same signal
+ * `agent-canvas-update-card` uses to hide install-specific affordances on a
+ * hosted deployment.
+ *
+ * ## Telemetry
+ *
+ * | name | properties |
+ * | --- | --- |
+ * | `canvas_feedback_submitted` | `feedback`, `feedback_length`, `has_email`, `conversation_id`, plus the common backend context |
+ *
+ * A supplied email is attached to the PostHog person via `identify` as the
+ * `email` person property, not repeated on the event.
+ */
+
+/** Deliberately permissive: reject obvious typos, not unusual-but-valid addresses. */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type SubmitState = "idle" | "submitting" | "submitted" | "error";
+
+export function FeedbackLauncher() {
+  const { t } = useTranslation();
+  const { trackFeedbackSubmitted, attachFeedbackEmail } = useTracking();
+  const { conversationId } = useOptionalConversationId();
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [feedback, setFeedback] = React.useState("");
+  const [email, setEmail] = React.useState("");
+  const [emailError, setEmailError] = React.useState(false);
+  const [state, setState] = React.useState<SubmitState>("idle");
+
+  // Not a hook, so it is safe to read on every render; the early return below
+  // happens after every hook has run.
+  const isLockedToCloud = getLockedCloudHost() !== null;
+
+  /**
+   * The form is `noValidate`: the browser's own constraint messages are not
+   * translated and differ per engine, so validation is owned here and reported
+   * through the i18n catalogue instead.
+   */
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const trimmedFeedback = feedback.trim();
+    const trimmedEmail = email.trim();
+    if (!trimmedFeedback) return;
+
+    if (trimmedEmail && !EMAIL_PATTERN.test(trimmedEmail)) {
+      setEmailError(true);
+      return;
+    }
+    setEmailError(false);
+
+    // Consent is the one failure this can detect up front. `trackEvent`
+    // resolves without capturing when consent is absent, so a resolved promise
+    // is not evidence the feedback landed.
+    if (!isTelemetryEnabled()) {
+      setState("error");
+      return;
+    }
+
+    setState("submitting");
+    try {
+      if (trimmedEmail) await attachFeedbackEmail(trimmedEmail);
+      await trackFeedbackSubmitted({
+        feedback: trimmedFeedback,
+        hasEmail: Boolean(trimmedEmail),
+        conversationId: conversationId ?? undefined,
+      });
+      setState("submitted");
+      setFeedback("");
+      setEmail("");
+    } catch {
+      // Keep what the user typed so a retry does not start from scratch.
+      setState("error");
+    }
+  };
+
+  if (isLockedToCloud) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2">
+      {isOpen && (
+        <div
+          data-testid="feedback-panel"
+          role="dialog"
+          aria-label={t(I18nKey.FEEDBACK$TITLE)}
+          className="w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-[var(--oh-border-subtle)] bg-tertiary p-4 shadow-lg"
+        >
+          {state === "submitted" ? (
+            <div className="flex flex-col gap-3">
+              <p data-testid="feedback-success" className="text-sm text-white">
+                {t(I18nKey.FEEDBACK$THANK_YOU_FOR_FEEDBACK)}
+              </p>
+              <BrandButton
+                type="button"
+                variant="secondary"
+                testId="feedback-close"
+                onClick={() => {
+                  setIsOpen(false);
+                  setState("idle");
+                }}
+              >
+                {t(I18nKey.BUTTON$CLOSE)}
+              </BrandButton>
+            </div>
+          ) : (
+            <form
+              className="flex flex-col gap-3"
+              onSubmit={handleSubmit}
+              noValidate
+            >
+              <p className="text-sm text-white">
+                {t(I18nKey.FEEDBACK$DESCRIPTION)}
+              </p>
+
+              <label className="flex flex-col gap-1 text-xs text-white">
+                {t(I18nKey.FEEDBACK$TITLE)}
+                <textarea
+                  data-testid="feedback-message"
+                  value={feedback}
+                  onChange={(e) => setFeedback(e.target.value)}
+                  rows={4}
+                  required
+                  className="rounded border border-[var(--oh-border-input)] bg-base p-2 text-sm text-white"
+                />
+              </label>
+
+              <label className="flex flex-col gap-1 text-xs text-white">
+                <span>
+                  {t(I18nKey.FEEDBACK$EMAIL_LABEL)} (
+                  {t(I18nKey.COMMON$OPTIONAL)})
+                </span>
+                <input
+                  data-testid="feedback-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder={t(I18nKey.FEEDBACK$EMAIL_PLACEHOLDER)}
+                  aria-invalid={emailError}
+                  className={cn(
+                    "rounded border bg-base p-2 text-sm text-white",
+                    emailError
+                      ? "border-danger"
+                      : "border-[var(--oh-border-input)]",
+                  )}
+                />
+              </label>
+
+              {emailError && (
+                <p
+                  data-testid="feedback-email-error"
+                  className="text-xs text-danger"
+                >
+                  {t(I18nKey.FEEDBACK$INVALID_EMAIL_FORMAT)}
+                </p>
+              )}
+
+              {state === "error" && (
+                <p data-testid="feedback-error" className="text-xs text-danger">
+                  {t(I18nKey.FEEDBACK$FAILED_TO_SUBMIT)}
+                </p>
+              )}
+
+              <div className="flex justify-end gap-2">
+                <BrandButton
+                  type="button"
+                  variant="secondary"
+                  testId="feedback-cancel"
+                  onClick={() => setIsOpen(false)}
+                >
+                  {t(I18nKey.FEEDBACK$CANCEL_LABEL)}
+                </BrandButton>
+                <BrandButton
+                  type="submit"
+                  variant="primary"
+                  testId="feedback-submit"
+                  isDisabled={state === "submitting" || !feedback.trim()}
+                  aria-busy={state === "submitting"}
+                >
+                  {state === "submitting"
+                    ? t(I18nKey.FEEDBACK$SUBMITTING_LABEL)
+                    : t(I18nKey.FEEDBACK$SHARE_LABEL)}
+                </BrandButton>
+              </div>
+            </form>
+          )}
+        </div>
+      )}
+
+      <BrandButton
+        type="button"
+        variant="primary"
+        testId="feedback-launcher"
+        ariaLabel={t(I18nKey.FEEDBACK$TITLE)}
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        {t(I18nKey.FEEDBACK$TITLE)}
+      </BrandButton>
+    </div>
+  );
+}

--- a/src/components/features/feedback/feedback-launcher.tsx
+++ b/src/components/features/feedback/feedback-launcher.tsx
@@ -7,7 +7,7 @@ import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useOptionalConversationId } from "#/hooks/use-conversation-id";
 import { useTracking } from "#/hooks/use-tracking";
 import { I18nKey } from "#/i18n/declaration";
-import { isTelemetryEnabled } from "#/services/telemetry";
+import { canCaptureTelemetry } from "#/services/telemetry";
 import { cn } from "#/utils/utils";
 
 /**
@@ -25,7 +25,7 @@ import { cn } from "#/utils/utils";
  *
  * | name | properties |
  * | --- | --- |
- * | `canvas_feedback_submitted` | `feedback`, `feedback_length`, `has_email`, `conversation_id`, plus the common backend context |
+ * | `feedback_submitted` | `feedback`, `feedback_length`, `has_email`, `conversation_id`, plus the common backend context |
  *
  * A supplied email is attached to the PostHog person with
  * `setPersonProperties` as the `email` person property, not repeated on the
@@ -95,10 +95,11 @@ export function FeedbackLauncher() {
     }
     setEmailError(false);
 
-    // Consent is the one failure this can detect up front. `trackEvent`
-    // resolves without capturing when consent is absent, so a resolved promise
-    // is not evidence the feedback landed.
-    if (!isTelemetryEnabled()) {
+    // `trackEvent` resolves without capturing whenever telemetry is off, so a
+    // resolved promise is not evidence the feedback landed. Checked up front,
+    // and against both switches: consent, and the embedder's
+    // `configureTelemetry()` flag, which consent alone does not reflect.
+    if (!canCaptureTelemetry()) {
       setState("error");
       return;
     }

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -11,9 +11,8 @@ import {
   getBackendTelemetryProperties,
 } from "#/services/telemetry-context";
 import {
-  getTelemetryDistinctId,
   setTelemetryBackendContext,
-  setTelemetryIdentity,
+  setTelemetryPersonProperties,
   trackEvent,
 } from "#/services/telemetry";
 
@@ -450,10 +449,15 @@ export const useTracking = () => {
    * `isTelemetryEnabled()` first rather than reading a resolved promise as
    * success.
    *
-   * The feedback text is the payload here, not incidental telemetry — it is the
-   * thing being reported. The email is deliberately absent: it is attached to
-   * the person rather than the event, so it is not duplicated across every
-   * captured event.
+   * Every other event here sends a length rather than the text
+   * (`query_character_length`, `current_message_length`), because that prose is
+   * incidental to the event. This one is the exception on purpose: the feedback
+   * *is* the report, and a length alone would make the event useless. Flagged
+   * rather than assumed — happy to send a length instead if the convention
+   * should hold here too.
+   *
+   * The email is deliberately absent: it goes on the person, not repeated on
+   * every event.
    */
   const trackFeedbackSubmitted = ({
     feedback,
@@ -477,20 +481,13 @@ export const useTracking = () => {
   /**
    * Attach a feedback author's email to their PostHog person.
    *
-   * Uses `identify` on the existing distinct id rather than minting a new one,
-   * so an anonymous OSS person gains an `email` property instead of becoming a
-   * second person. `getTelemetryDistinctId()` returns null without consent, in
-   * which case there is no person to annotate and this is a no-op.
-   *
-   * Only the email is passed: `setTelemetryIdentity` replaces the desired
-   * property set, and on the non-OHE installs this control is shown to,
-   * `use-telemetry-identity` does not set any (it gates on a cloud backend).
+   * Uses `setPersonProperties` rather than `identify`: there is no account to
+   * identify here, and identifying would both promote an anonymous person using
+   * the device id and contend with `use-telemetry-identity`, which owns the
+   * identity state.
    */
-  const attachFeedbackEmail = async (email: string): Promise<void> => {
-    const distinctId = await getTelemetryDistinctId();
-    if (!distinctId) return;
-    await setTelemetryIdentity(distinctId, { email });
-  };
+  const attachFeedbackEmail = (email: string): Promise<void> =>
+    setTelemetryPersonProperties({ email });
 
   const trackOnboardingLinkClicked = ({
     linkId,

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -10,7 +10,12 @@ import {
   type BackendConnectionMethod,
   getBackendTelemetryProperties,
 } from "#/services/telemetry-context";
-import { setTelemetryBackendContext, trackEvent } from "#/services/telemetry";
+import {
+  getTelemetryDistinctId,
+  setTelemetryBackendContext,
+  setTelemetryIdentity,
+  trackEvent,
+} from "#/services/telemetry";
 
 /**
  * Stable semantic identifier for an onboarding link or CTA. Identifies the
@@ -436,6 +441,57 @@ export const useTracking = () => {
     });
   };
 
+  /**
+   * User-submitted feedback from the persistent feedback control.
+   *
+   * Awaited rather than fire-and-forget: the form tells the user whether the
+   * submission landed, so it needs the capture to settle. `trackEvent` resolves
+   * without capturing when consent has not been granted, so callers must check
+   * `isTelemetryEnabled()` first rather than reading a resolved promise as
+   * success.
+   *
+   * The feedback text is the payload here, not incidental telemetry — it is the
+   * thing being reported. The email is deliberately absent: it is attached to
+   * the person rather than the event, so it is not duplicated across every
+   * captured event.
+   */
+  const trackFeedbackSubmitted = ({
+    feedback,
+    hasEmail,
+    conversationId,
+  }: {
+    feedback: string;
+    hasEmail: boolean;
+    conversationId?: string;
+  }): Promise<void> => {
+    setTelemetryBackendContext(getBackendTelemetryContext());
+    return trackEvent("canvas_feedback_submitted", {
+      ...commonProperties,
+      feedback,
+      feedback_length: feedback.length,
+      has_email: hasEmail,
+      conversation_id: conversationId,
+    });
+  };
+
+  /**
+   * Attach a feedback author's email to their PostHog person.
+   *
+   * Uses `identify` on the existing distinct id rather than minting a new one,
+   * so an anonymous OSS person gains an `email` property instead of becoming a
+   * second person. `getTelemetryDistinctId()` returns null without consent, in
+   * which case there is no person to annotate and this is a no-op.
+   *
+   * Only the email is passed: `setTelemetryIdentity` replaces the desired
+   * property set, and on the non-OHE installs this control is shown to,
+   * `use-telemetry-identity` does not set any (it gates on a cloud backend).
+   */
+  const attachFeedbackEmail = async (email: string): Promise<void> => {
+    const distinctId = await getTelemetryDistinctId();
+    if (!distinctId) return;
+    await setTelemetryIdentity(distinctId, { email });
+  };
+
   const trackOnboardingLinkClicked = ({
     linkId,
     destinationType,
@@ -496,5 +552,7 @@ export const useTracking = () => {
     trackOnboardingCompleted,
     trackOnboardingSkipped,
     trackOnboardingLinkClicked,
+    trackFeedbackSubmitted,
+    attachFeedbackEmail,
   };
 };

--- a/src/hooks/use-tracking.ts
+++ b/src/hooks/use-tracking.ts
@@ -469,7 +469,7 @@ export const useTracking = () => {
     conversationId?: string;
   }): Promise<void> => {
     setTelemetryBackendContext(getBackendTelemetryContext());
-    return trackEvent("canvas_feedback_submitted", {
+    return trackEvent("feedback_submitted", {
       ...commonProperties,
       feedback,
       feedback_length: feedback.length,

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -44,6 +44,7 @@ import { useConfig } from "#/hooks/query/use-config";
 import { QUERY_KEYS } from "#/hooks/query/query-keys";
 import { AgentServerUIRoot } from "#/components/providers";
 import { TelemetryConsentBanner } from "#/components/features/analytics/telemetry-consent-banner";
+import { FeedbackLauncher } from "#/components/features/feedback/feedback-launcher";
 import { buildAgentCanvasPath } from "#/utils/base-path";
 import { useOnboardingCompletion } from "#/components/features/onboarding/use-onboarding-completion";
 import { NavigationProvider } from "#/context/navigation-context";
@@ -375,6 +376,7 @@ export default function App() {
     <>
       <Outlet />
       <TelemetryConsentBanner />
+      <FeedbackLauncher />
     </>
   );
 }

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -44,7 +44,6 @@ import { useConfig } from "#/hooks/query/use-config";
 import { QUERY_KEYS } from "#/hooks/query/query-keys";
 import { AgentServerUIRoot } from "#/components/providers";
 import { TelemetryConsentBanner } from "#/components/features/analytics/telemetry-consent-banner";
-import { FeedbackLauncher } from "#/components/features/feedback/feedback-launcher";
 import { buildAgentCanvasPath } from "#/utils/base-path";
 import { useOnboardingCompletion } from "#/components/features/onboarding/use-onboarding-completion";
 import { NavigationProvider } from "#/context/navigation-context";
@@ -376,7 +375,6 @@ export default function App() {
     <>
       <Outlet />
       <TelemetryConsentBanner />
-      <FeedbackLauncher />
     </>
   );
 }

--- a/src/routes/root-layout.tsx
+++ b/src/routes/root-layout.tsx
@@ -23,6 +23,7 @@ import { LoadingSpinner } from "#/components/shared/loading-spinner";
 import { useAppTitle } from "#/hooks/use-app-title";
 import { ReactRouterNavigationProvider } from "./react-router-navigation-provider";
 import { OnboardingHost } from "#/components/features/onboarding";
+import { FeedbackLauncher } from "#/components/features/feedback/feedback-launcher";
 import { isOnboardingPreviewActive } from "#/components/features/onboarding/onboarding-preview";
 import { CanvasExtensionsRuntimeProvider } from "#/components/features/canvas-extensions/canvas-extensions-runtime";
 
@@ -149,6 +150,9 @@ export default function MainApp() {
             <CommandMenu />
           </React.Suspense>
           {showOnboardingPreview ? <OnboardingHost /> : null}
+          {/* Inside ReactRouterNavigationProvider so the feedback event can
+              carry the conversation the user is actually in. */}
+          <FeedbackLauncher />
         </SidebarMobileNavProvider>
       </CanvasExtensionsRuntimeProvider>
     </ReactRouterNavigationProvider>

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -619,6 +619,19 @@ export function isTelemetryEnabled(): boolean {
 }
 
 /**
+ * Whether a capture would actually reach PostHog right now.
+ *
+ * `isTelemetryEnabled()` reports consent alone, but an embedder can switch
+ * telemetry off through `configureTelemetry()`; every capture path honours that
+ * flag while consent does not reflect it. A caller that has to tell the user
+ * whether their submission landed must check both, or it will report success
+ * for a silently dropped event.
+ */
+export function canCaptureTelemetry(): boolean {
+  return !telemetryDisabled && getTelemetryConsent() === "granted";
+}
+
+/**
  * Check if first use event has already been sent
  */
 function hasFirstUseSent(): boolean {

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -816,6 +816,26 @@ export async function trackEvent(
   posthog.capture(eventName, properties);
 }
 
+/**
+ * Annotate the current person without changing who they are.
+ *
+ * `setTelemetryIdentity` is the wrong tool when there is no account to identify:
+ * it calls `identify`, which promotes an anonymous person to identified keyed by
+ * the device id, and it replaces the desired property set — so it races with
+ * `use-telemetry-identity`, which owns that state. `setPersonProperties` adds
+ * properties to whoever the current distinct id already refers to.
+ *
+ * No-ops without consent, like every other capture path here.
+ */
+export async function setTelemetryPersonProperties(
+  properties: Record<string, unknown>,
+): Promise<void> {
+  const posthog = await getPostHogForConsentedCapture();
+  if (!posthog) return;
+
+  posthog.setPersonProperties(properties);
+}
+
 /** Track an exception through the same consent-aware client as custom events. */
 export async function trackException(
   error: unknown,


### PR DESCRIPTION
HUMAN:

Ran it locally and used the feedback form end to end; the screenshot is from
that run.

---

AGENT:

## Why

Open-source users have no low-friction way to send feedback, and #16912 asks for
a persistent control rather than an intrusive survey popup.

## Summary

- A floating button in the bottom-right opens a small panel: free-form message,
  optional email. It only opens on click, so it cannot become a recurring popup,
  and it is the anchor a survey bubble would attach to later.
- Hidden on hosted installs, gated on the same two signals as
  `telemetry-consent-banner`: locked-to-Cloud, or a non-local backend.
- `feedback_submitted` carries `feedback`, `feedback_length`, `has_email` and
  `conversation_id`. A supplied email goes on the PostHog person via
  `setPersonProperties`, not repeated on the event.
- No new translation keys; the strings already existed in the catalogue.

## Issue Number

Fixes #16912

## How to Test

1. `npm run dev:mock`, add a local Agent-server backend, accept telemetry.
2. Use the Feedback button in the bottom-right.

`npx vitest run __tests__/components/features/feedback/` — 19 tests.

## Video/Screenshots

<img width="1800" height="1010" alt="Screenshot 2026-08-28 at 3 59 15 PM" src="https://github.com/user-attachments/assets/f405356f-0740-452d-9f14-64abf95484c1" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Acceptance criteria: 11 met, 3 partial, 2 not met.**

Partial:

- **7** — PostHog resolves without capturing if the SDK fails to load, so a
  dropped submission can still show the confirmation. Consent and the embedder
  switch are both checked up front; a load failure is not visible from here.
- **9** — switching between a cloud and local backend calls `posthog.reset()`,
  which can orphan an attached email.
- **12** — the survey bubble is not built; the issue asks only that the design
  leave room for one.

Not met: **14** and **15**, the live PostHog demo. Both need access to the
OpenHands project, so the screenshot above shows only the UI. Related and worth
raising separately — `disable_session_recording: true` is hardcoded in
`telemetry.ts`, so "inspect the session" cannot be demonstrated through replay by
anyone without changing that file.

Two behaviour notes: the control does not render on `shared/conversations/:id`,
which sits outside `root-layout`; and `useActiveBackend` returns a local backend
outside its provider, so the hosted-install gate fails open there.

Kept as a draft because the issue says this is not a good issue for external
contributors, verification needing PostHog. Happy to close it if you would rather
this waited for someone with access — the code is here either way.
