### PR TITLE
fix: count marker-prefixed unified diff lines

### DIFF
--- a/__tests__/utils/git-diff-stats.test.ts
+++ b/__tests__/utils/git-diff-stats.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { countGitChangeDiffStats } from "../../src/utils/git-diff-stats";
+
+describe("countGitChangeDiffStats", () => {
+  it("counts hunk lines whose content starts with diff markers", () => {
+    const diff = [
+      "@@ -1,3 +1,3 @@",
+      " keep this line",
+      "-normal deleted line",
+      "--- a deleted line that starts with two dashes",
+      "+normal added line",
+      "+++ an added line that starts with two pluses",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 2,
+      deletions: 2,
+    });
+  });
+
+  it("does not count file headers in a multi-file diff", () => {
+    const diff = [
+      "diff --git a/first.ts b/first.ts",
+      "--- a/first.ts",
+      "+++ b/first.ts",
+      "@@ -1 +1 @@",
+      "-old first",
+      "+new first",
+      "diff --git a/second.ts b/second.ts",
+      "--- a/second.ts",
+      "+++ b/second.ts",
+      "@@ -2 +2 @@",
+      "---old second",
+      "+++new second",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 2,
+      deletions: 2,
+    });
+  });
+
+  it("matches text diff stats for marker-prefixed content", () => {
+    const original = ["keep this line", "-- deleted"].join("\n");
+    const modified = ["keep this line", "++ added"].join("\n");
+    const diff = [
+      "@@ -1,2 +1,2 @@",
+      " keep this line",
+      "--- deleted",
+      "+++ added",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual(
+      countGitChangeDiffStats({ original, modified } as never),
+    );
+  });
+});

--- a/src/utils/git-diff-stats.ts
+++ b/src/utils/git-diff-stats.ts
@@ -8,13 +8,18 @@ export interface GitDiffLineStats {
 function countUnifiedDiffStats(diff: string): GitDiffLineStats {
   let additions = 0;
   let deletions = 0;
+  let inHunk = false;
 
   for (const line of diff.split("\n")) {
-    if (
-      line.startsWith("+++") ||
-      line.startsWith("---") ||
-      line.startsWith("@@")
-    ) {
+    if (line.startsWith("diff --git ")) {
+      inHunk = false;
+      continue;
+    }
+    if (line.startsWith("@@")) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) {
       continue;
     }
     if (line.startsWith("+")) {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

The unified-diff parser now tracks whether it is inside a hunk. This keeps file headers out of the totals while counting real hunk lines whose content starts with `--` or `++`.

## Why

The previous prefix-only filter treated any `---` or `+++` line as a file header, including real changed lines inside a hunk. That made Canvas undercount additions and deletions for common source content.

## Summary

- Track `diff --git` file boundaries and `@@` hunk starts while counting unified diffs.
- Add focused coverage for marker-prefixed content, multiple files, and agreement with the text fallback.

## Issue Number

Fixes #16979

## How to Test

From the repository root:

```bash
npm test -- __tests__/utils/git-diff-stats.test.ts
```

I ran the focused test with the same Vitest 4 runner available in the local workspace:

```text
Test Files  1 passed (1)
Tests       3 passed (3)
```

The pre-fix reproduction reports `{ additions: 1, deletions: 1 }`; the patched implementation reports `{ additions: 2, deletions: 2 }`, matching `git diff --numstat` for the fixture.

## Video/Screenshots

This is a non-UI statistics fix. The terminal reproduction and exact focused-test result are included above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `HUMAN:` section is intentionally untouched as required by the repository instructions.
