### PR TITLE
fix(settings): disable Save when settings are unchanged

### DIFF
--- a/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
+++ b/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
@@ -865,6 +865,73 @@ describe("SdkSectionPage", () => {
     });
   });
 
+  it("disables Save after confirmation mode is reverted to the saved value", async () => {
+    const conversationSchema: NonNullable<
+      Settings["conversation_settings_schema"]
+    > = {
+      model_name: "ConversationSettings",
+      sections: [
+        {
+          key: "verification",
+          label: "Verification",
+          fields: [
+            {
+              key: "confirmation_mode",
+              label: "Confirmation mode",
+              section: "verification",
+              section_label: "Verification",
+              value_type: "boolean",
+              default: false,
+              choices: [],
+              depends_on: [],
+              prominence: "critical",
+              secret: false,
+              required: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        conversation_settings_schema: conversationSchema,
+        conversation_settings: {
+          confirmation_mode: false,
+        },
+      }),
+    );
+    const saveSettingsSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+
+    renderSdkSectionPage({
+      settingsSources: [
+        {
+          settingsSource: "conversation_settings",
+          sectionKeys: ["verification"],
+        },
+      ],
+    });
+
+    const confirmationInput = await screen.findByTestId(
+      "sdk-settings-confirmation_mode",
+    );
+    const saveButton = screen.getByTestId("save-button") as HTMLButtonElement;
+    const label = confirmationInput.closest("label")!;
+
+    expect(saveButton).toBeDisabled();
+
+    await userEvent.click(label);
+    expect(saveButton).toBeEnabled();
+
+    await userEvent.click(label);
+    expect(saveButton).toBeDisabled();
+
+    await userEvent.click(saveButton);
+    expect(saveSettingsSpy).not.toHaveBeenCalled();
+  });
+
   it("shows an error toast when saving settings fails", async () => {
     vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
       buildSavableSettings(),

--- a/__tests__/routes/agent-settings.test.tsx
+++ b/__tests__/routes/agent-settings.test.tsx
@@ -663,6 +663,115 @@ describe("AgentSettingsScreen", () => {
     });
   });
 
+  it("disables Save after ACP edits are reverted to the saved values", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings: {
+          schema_version: 1,
+          agent_kind: "acp",
+          acp_server: "claude-code",
+          acp_command: ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+          acp_model: "my-pinned-fork-model",
+        },
+      }),
+    );
+    const save = vi.spyOn(SettingsService, "saveSettings");
+
+    renderAgentSettingsScreen();
+    const cmd = (await screen.findByTestId(
+      "agent-command-input",
+    )) as HTMLTextAreaElement;
+    const model = screen.getByTestId("agent-model-input") as HTMLInputElement;
+    const saveButton = screen.getByTestId(
+      "agent-save-button",
+    ) as HTMLButtonElement;
+    const originalCommand = cmd.value;
+    const originalModel = model.value;
+
+    expect(saveButton).toBeDisabled();
+
+    await user.clear(cmd);
+    await user.type(cmd, `${originalCommand} --flag`);
+    expect(saveButton).toBeEnabled();
+
+    await user.clear(cmd);
+    await user.type(cmd, originalCommand);
+    expect(saveButton).toBeDisabled();
+
+    await user.clear(model);
+    await user.type(model, "other-model");
+    expect(saveButton).toBeEnabled();
+
+    await user.clear(model);
+    await user.type(model, originalModel);
+    expect(saveButton).toBeDisabled();
+
+    await user.click(screen.getByTestId("agent-type-selector"));
+    await user.click(
+      await screen.findByRole("option", {
+        name: "SETTINGS$AGENT_TYPE_OPENHANDS",
+      }),
+    );
+    expect(saveButton).toBeEnabled();
+
+    await user.click(screen.getByTestId("agent-type-selector"));
+    await user.click(
+      await screen.findByRole("option", { name: "SETTINGS$AGENT_TYPE_ACP" }),
+    );
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("disables Save after OpenHands fields and agent type are reverted to the saved values", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.agent_settings,
+          agent_kind: "openhands",
+          enable_sub_agents: false,
+        },
+      }),
+    );
+    const save = vi.spyOn(SettingsService, "saveSettings");
+
+    renderAgentSettingsScreen();
+    await screen.findByTestId("agent-settings-screen");
+    const saveButton = screen.getByTestId(
+      "agent-save-button",
+    ) as HTMLButtonElement;
+
+    expect(saveButton).toBeDisabled();
+
+    const toggle = screen.getByTestId("agent-settings-enable-sub-agents");
+    const label = toggle.closest("label")!;
+    await user.click(label);
+    expect(saveButton).toBeEnabled();
+
+    await user.click(label);
+    expect(saveButton).toBeDisabled();
+
+    await user.click(screen.getByTestId("agent-type-selector"));
+    await user.click(
+      await screen.findByRole("option", { name: "SETTINGS$AGENT_TYPE_ACP" }),
+    );
+    expect(saveButton).toBeEnabled();
+
+    await user.click(screen.getByTestId("agent-type-selector"));
+    await user.click(
+      await screen.findByRole("option", {
+        name: "SETTINGS$AGENT_TYPE_OPENHANDS",
+      }),
+    );
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    expect(save).not.toHaveBeenCalled();
+  });
+
   it("disables Save when the user has cleared the command on the ACP path", async () => {
     const user = userEvent.setup();
     vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
@@ -792,13 +901,13 @@ describe("AgentSettingsScreen", () => {
       "npx -y @agentclientprotocol/claude-agent-acp@0.63.0 --extra-arg",
     );
 
-    // Touch the form to mark it dirty (Save is disabled until isDirty),
-    // then submit. The data the form sends has to carry the registry-
-    // default prefix the user can now SEE in the textarea, not the bare
-    // ``--extra-arg`` that was stored.
-    await user.click(cmd);
-    await user.keyboard("{End} ");
-    await user.keyboard("{Backspace}");
+    // Extra args make detectPreset miss the built-in default, so the form
+    // is on Custom (no model dropdown). Change the custom model field so
+    // Save enables without rewriting the expanded command. The payload
+    // still has to carry the registry-default prefix the user can SEE.
+    const model = screen.getByTestId("agent-model-input") as HTMLInputElement;
+    await user.clear(model);
+    await user.type(model, "haiku");
 
     await user.click(screen.getByTestId("agent-save-button"));
     await waitFor(() => {
@@ -814,6 +923,7 @@ describe("AgentSettingsScreen", () => {
       "@agentclientprotocol/claude-agent-acp@0.63.0",
       "--extra-arg",
     ]);
+    expect(call.agent_settings_diff?.acp_model).toBe("haiku");
     // ``acp_args: []`` resets the API-set args so they don't double up
     // at spawn time.
     expect(call.agent_settings_diff?.acp_args).toEqual([]);
@@ -823,15 +933,16 @@ describe("AgentSettingsScreen", () => {
     // Data-corruption regression: a user with an ``acp_server`` value
     // canvas's registry doesn't know about (e.g. set via the API for a
     // future provider that hasn't been mirrored into ``ACP_PROVIDERS``
-    // yet) opens Settings → Agent and clicks Save. Without preservation
-    // the save flow demotes ``acp_server: "amp"`` → ``acp_server:
-    // "custom"`` because ``detectPreset`` returns ``custom`` for any
-    // unknown server. The original key name is silently lost.
+    // yet) opens Settings → Agent and saves a non-command change.
+    // Without preservation the save flow demotes ``acp_server: "amp"``
+    // → ``acp_server: "custom"`` because ``detectPreset`` returns
+    // ``custom`` for any unknown server. The original key name is
+    // silently lost.
     //
-    // The fix is narrow: when the user hasn't touched the command since
-    // load AND the loaded server is non-empty, non-``"custom"``, and
-    // absent from ``ACP_PROVIDERS``, write the loaded key back verbatim
-    // via the ``allowUnknownServer`` pass-through.
+    // The fix is narrow: when the command is unchanged since load AND
+    // the loaded server is non-empty, non-``"custom"``, and absent from
+    // ``ACP_PROVIDERS``, write the loaded key back verbatim via the
+    // ``allowUnknownServer`` pass-through.
     const user = userEvent.setup();
     vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
       buildSettings({
@@ -852,12 +963,12 @@ describe("AgentSettingsScreen", () => {
     )) as HTMLTextAreaElement;
     expect(cmd.value).toBe("npx -y @some-future/amp-acp");
 
-    // Touch + revert the textarea to flip isDirty without changing
-    // the persisted command text — matches "user opens settings and
-    // hits Save without intending to change anything."
-    await user.click(cmd);
-    await user.keyboard("{End} ");
-    await user.keyboard("{Backspace}");
+    // Change the model only so Save enables while the command stays at
+    // the loaded value. Unknown-server preservation is keyed off an
+    // unchanged command, not a latched dirty flag.
+    const model = screen.getByTestId("agent-model-input") as HTMLInputElement;
+    await user.clear(model);
+    await user.type(model, "amp-model");
 
     await user.click(screen.getByTestId("agent-save-button"));
     await waitFor(() => {
@@ -872,6 +983,7 @@ describe("AgentSettingsScreen", () => {
       "-y",
       "@some-future/amp-acp",
     ]);
+    expect(call.agent_settings_diff?.acp_model).toBe("amp-model");
   });
 
   it("demotes an unknown loaded acp_server to 'custom' when the user edits the command", async () => {

--- a/src/components/features/settings/sdk-settings/sdk-section-page.tsx
+++ b/src/components/features/settings/sdk-settings/sdk-section-page.tsx
@@ -37,6 +37,24 @@ import { ViewToggle } from "./view-toggle";
 
 const EMPTY_EXCLUDE_KEYS = new Set<string>();
 
+function withSourceFieldDirty(
+  prev: Partial<Record<SettingsValueSource, SettingsDirtyState>>,
+  sourceKey: SettingsValueSource,
+  fieldKey: string,
+  isDirty: boolean,
+): Partial<Record<SettingsValueSource, SettingsDirtyState>> {
+  const nextSourceDirty = { ...(prev[sourceKey] ?? {}) };
+  if (isDirty) {
+    nextSourceDirty[fieldKey] = true;
+  } else {
+    delete nextSourceDirty[fieldKey];
+  }
+  return {
+    ...prev,
+    [sourceKey]: nextSourceDirty,
+  };
+}
+
 const VIEW_ORDER: Record<SettingsView, number> = {
   basic: 0,
   advanced: 1,
@@ -364,8 +382,15 @@ export function SdkSectionPage({
     Partial<Record<SettingsValueSource, SettingsDirtyState>>
   >({});
   const hasHydratedViewRef = React.useRef(false);
+  // Persisted (pre-override) values. Field edits compare against this so
+  // reverting a toggle such as confirmation_mode clears dirty instead of
+  // latching Save enabled. Updated again after a successful save so the
+  // next revert uses the values that were just written.
+  const dirtyBaselineRef = React.useRef<Partial<
+    Record<SettingsValueSource, SettingsFormValues>
+  > | null>(null);
 
-  const initialValuesBySource = React.useMemo<Partial<
+  const persistedValuesBySource = React.useMemo<Partial<
     Record<SettingsValueSource, SettingsFormValues>
   > | null>(() => {
     if (!settings) return null;
@@ -381,17 +406,26 @@ export function SdkSectionPage({
         ),
       };
     }
-    if (initialValueOverrides) {
-      const firstSource = resolvedSources[0]?.settingsSource;
-      if (firstSource && result[firstSource]) {
-        result[firstSource] = {
-          ...result[firstSource],
-          ...initialValueOverrides,
-        };
-      }
-    }
     return result;
-  }, [settings, resolvedSources, overridesSignature]);
+  }, [settings, resolvedSources]);
+
+  const initialValuesBySource = React.useMemo<Partial<
+    Record<SettingsValueSource, SettingsFormValues>
+  > | null>(() => {
+    if (!persistedValuesBySource) return null;
+    if (!initialValueOverrides) return persistedValuesBySource;
+    const firstSource = resolvedSources[0]?.settingsSource;
+    if (!firstSource || !persistedValuesBySource[firstSource]) {
+      return persistedValuesBySource;
+    }
+    return {
+      ...persistedValuesBySource,
+      [firstSource]: {
+        ...persistedValuesBySource[firstSource],
+        ...initialValueOverrides,
+      },
+    };
+  }, [persistedValuesBySource, resolvedSources, overridesSignature]);
 
   const initialView = React.useMemo(() => {
     if (!settings) return null;
@@ -424,6 +458,7 @@ export function SdkSectionPage({
   React.useEffect(() => {
     if (!initialValuesBySource || !initialView) return;
 
+    dirtyBaselineRef.current = persistedValuesBySource;
     setValuesBySource(initialValuesBySource);
     if (initialValueOverrides) {
       const firstSource = resolvedSources[0]?.settingsSource;
@@ -447,7 +482,7 @@ export function SdkSectionPage({
     } else {
       setView((currentView) => getLessDetailedView(currentView, initialView));
     }
-  }, [initialValuesBySource, initialView]);
+  }, [initialValuesBySource, initialView, persistedValuesBySource]);
 
   const fieldKeyToSource = React.useMemo(() => {
     const map = new Map<string, SettingsValueSource>();
@@ -492,13 +527,12 @@ export function SdkSectionPage({
           [fieldKey]: nextValue,
         },
       }));
-      setDirtyBySource((prev) => ({
-        ...prev,
-        [sourceKey]: {
-          ...(prev[sourceKey] ?? {}),
-          [fieldKey]: true,
-        },
-      }));
+      // Delete the key on revert. ``isDirty`` is ``Object.keys(flatDirty)``,
+      // so a ``false`` flag would still keep Save enabled.
+      const baseline = dirtyBaselineRef.current?.[sourceKey]?.[fieldKey];
+      setDirtyBySource((prev) =>
+        withSourceFieldDirty(prev, sourceKey, fieldKey, nextValue !== baseline),
+      );
     },
     [fieldKeyToSource],
   );
@@ -577,6 +611,7 @@ export function SdkSectionPage({
         if (!suppressSuccessToast) {
           displaySuccessToast(t(I18nKey.SETTINGS$SAVED_WARNING));
         }
+        dirtyBaselineRef.current = valuesBySource;
         setDirtyBySource({});
         onSaveSuccess?.();
       },

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -101,6 +101,59 @@ function isKnownAcpModel(
   );
 }
 
+interface LoadedAgentFormSnapshot {
+  agentType: AgentType;
+  commandText: string;
+  acpModel: string;
+  acpServer: string | null;
+  isCustomAcpModel: boolean;
+}
+
+/**
+ * Values the Agent Settings form seeds from the loaded/saved snapshot.
+ * Dirty tracking compares live fields against this so reverting an edit
+ * disables Save again.
+ */
+function getLoadedAgentFormSnapshot(
+  source: Record<string, SettingsValue> | null,
+): LoadedAgentFormSnapshot {
+  if (source?.agent_kind !== "acp") {
+    return {
+      agentType: "openhands",
+      commandText: "",
+      acpModel: "",
+      acpServer: null,
+      isCustomAcpModel: false,
+    };
+  }
+
+  const rawAcpServer = source.acp_server;
+  const acpServer = typeof rawAcpServer === "string" ? rawAcpServer : undefined;
+  const provider = getAcpProvider(acpServer);
+  const storedCommand = toStringArray(source.acp_command);
+  const effectiveBaseCommand =
+    storedCommand.length > 0
+      ? storedCommand
+      : (provider?.default_command ?? []);
+  const tokens = [...effectiveBaseCommand, ...toStringArray(source.acp_args)];
+  const commandText = tokens.length > 0 ? formatCommand(tokens) : "";
+  const savedModel = source.acp_model;
+  const normalizedSavedModel =
+    typeof savedModel === "string" ? savedModel.trim() : "";
+  const acpModel =
+    normalizedSavedModel || getAcpPreferredDefaultModel(acpServer) || "";
+
+  return {
+    agentType: "acp",
+    commandText,
+    acpModel,
+    acpServer: acpServer ?? null,
+    isCustomAcpModel:
+      !!normalizedSavedModel &&
+      (!provider || !isKnownAcpModel(provider, normalizedSavedModel)),
+  };
+}
+
 /**
  * Variant-specific AgentProfile fields derived from the form state. The
  * OpenHands branch omits `llm_profile_ref` — the profile editor supplies it.
@@ -338,7 +391,6 @@ export function AgentSettingsScreen({
   const [commandText, setCommandText] = useState("");
   const [acpModel, setAcpModel] = useState("");
   const [isCustomAcpModel, setIsCustomAcpModel] = useState(false);
-  const [isDirty, setIsDirty] = useState(false);
 
   // ACP credentials live alongside the agent spec, so the page owns the
   // credential form and a single Save persists both. Called unconditionally
@@ -356,6 +408,13 @@ export function AgentSettingsScreen({
   const lastInitializedSettingsRef = useRef<unknown>(null);
   const loadedAcpServerRef = useRef<string | null>(null);
   const loadedCommandTextRef = useRef<string>("");
+  const [savedDirtySnapshot, setSavedDirtySnapshot] = useState<
+    Pick<LoadedAgentFormSnapshot, "agentType" | "commandText" | "acpModel">
+  >({
+    agentType: "openhands",
+    commandText: "",
+    acpModel: "",
+  });
 
   useEffect(() => {
     // Seed from the profile override (embedded) or the live global settings.
@@ -365,49 +424,18 @@ export function AgentSettingsScreen({
     if (lastInitializedSettingsRef.current === initIdentity) return;
 
     lastInitializedSettingsRef.current = initIdentity;
-    const kind = source?.agent_kind;
-
-    if (kind === "acp") {
-      setAgentType("acp");
-
-      const rawAcpServer = source?.acp_server;
-      const acpServer =
-        typeof rawAcpServer === "string" ? rawAcpServer : undefined;
-      const provider = getAcpProvider(acpServer);
-      const storedCommand = toStringArray(source?.acp_command);
-      const effectiveBaseCommand =
-        storedCommand.length > 0
-          ? storedCommand
-          : (provider?.default_command ?? []);
-      const tokens = [
-        ...effectiveBaseCommand,
-        ...toStringArray(source?.acp_args),
-      ];
-      const renderedCommandText =
-        tokens.length > 0 ? formatCommand(tokens) : "";
-      setCommandText(renderedCommandText);
-      loadedAcpServerRef.current = acpServer ?? null;
-      loadedCommandTextRef.current = renderedCommandText;
-
-      const savedModel = source?.acp_model;
-      const normalizedSavedModel =
-        typeof savedModel === "string" ? savedModel.trim() : "";
-      setAcpModel(
-        normalizedSavedModel || getAcpPreferredDefaultModel(acpServer) || "",
-      );
-      setIsCustomAcpModel(
-        !!normalizedSavedModel &&
-          (!provider || !isKnownAcpModel(provider, normalizedSavedModel)),
-      );
-    } else {
-      setAgentType("openhands");
-      setCommandText("");
-      setAcpModel("");
-      loadedAcpServerRef.current = null;
-      loadedCommandTextRef.current = "";
-      setIsCustomAcpModel(false);
-    }
-    setIsDirty(false);
+    const snapshot = getLoadedAgentFormSnapshot(source);
+    setAgentType(snapshot.agentType);
+    setCommandText(snapshot.commandText);
+    setAcpModel(snapshot.acpModel);
+    setIsCustomAcpModel(snapshot.isCustomAcpModel);
+    loadedAcpServerRef.current = snapshot.acpServer;
+    loadedCommandTextRef.current = snapshot.commandText;
+    setSavedDirtySnapshot({
+      agentType: snapshot.agentType,
+      commandText: snapshot.commandText,
+      acpModel: snapshot.acpModel,
+    });
   }, [settings, agentSettingsOverride]);
 
   // Sync the sub-agents toggle when settings reload
@@ -510,18 +538,24 @@ export function AgentSettingsScreen({
       toolConcurrency,
     });
 
-  // Dirty tracking: for OpenHands path, also check the sub-agents and
-  // LLM-switching toggles and the parallel-tool-calls input.
+  // Dirty tracking compares live fields to the loaded/saved snapshot so
+  // reverting an edit disables Save again. OpenHands toggles/fields already
+  // did this; ACP previously latched ``isDirty`` on the first keystroke.
+  // ``savedDirtySnapshot`` also absorbs a successful save immediately, so
+  // Save disables before settings refetch replaces the server snapshot.
+  const isAgentTypeDirty = agentType !== savedDirtySnapshot.agentType;
+  const isAcpDirty =
+    isAcp &&
+    (commandText !== savedDirtySnapshot.commandText ||
+      acpModel.trim() !== savedDirtySnapshot.acpModel.trim());
   const isOpenHandsDirty =
     !isAcp &&
     (subAgentsEnabled !== initialSubAgentsEnabled ||
       switchLlmToolEnabled !== initialSwitchLlmToolEnabled ||
       toolConcurrency !== initialToolConcurrency);
-  const settingsDirty = isDirty || isOpenHandsDirty;
+  const settingsDirty = isAgentTypeDirty || isAcpDirty || isOpenHandsDirty;
   // The single Save covers both the agent spec and ACP credentials, so it is
   // active when either changed, and shows "Saving…" while either is in flight.
-  // ``isDirty`` is already false off the ACP path (no credential fields), so no
-  // ``isAcp`` guard is needed.
   const credentialsDirty = acpCredentialForm.isDirty;
   const isAnyDirty = settingsDirty || credentialsDirty;
   const isSavingAny = isSaving || acpCredentialForm.isSaving;
@@ -577,7 +611,13 @@ export function AgentSettingsScreen({
           },
           onSuccess: () => {
             displaySuccessToast(t(I18nKey.SETTINGS$SAVED));
-            setIsDirty(false);
+            loadedCommandTextRef.current = commandText;
+            loadedAcpServerRef.current = providerKey;
+            setSavedDirtySnapshot({
+              agentType: "acp",
+              commandText,
+              acpModel: acpModel.trim(),
+            });
           },
         },
       );
@@ -626,7 +666,13 @@ export function AgentSettingsScreen({
           },
           onSuccess: () => {
             displaySuccessToast(t(I18nKey.SETTINGS$SAVED));
-            setIsDirty(false);
+            loadedAcpServerRef.current = null;
+            loadedCommandTextRef.current = "";
+            setSavedDirtySnapshot({
+              agentType: "openhands",
+              commandText: "",
+              acpModel: "",
+            });
           },
         },
       );
@@ -703,7 +749,6 @@ export function AgentSettingsScreen({
           } else if (newType === "openhands") {
             setIsCustomAcpModel(false);
           }
-          setIsDirty(true);
         }}
       />
 
@@ -800,7 +845,6 @@ export function AgentSettingsScreen({
                 setAcpModel("");
                 setIsCustomAcpModel(true);
               }
-              setIsDirty(true);
             }}
           />
 
@@ -832,7 +876,6 @@ export function AgentSettingsScreen({
                   setIsCustomAcpModel(false);
                 }
                 setCommandText(nextCommandText);
-                setIsDirty(true);
               }}
             />
             <Typography.Text className="text-xs text-[#717888]">
@@ -867,7 +910,6 @@ export function AgentSettingsScreen({
                     setIsCustomAcpModel(false);
                     setAcpModel(modelKey);
                   }
-                  setIsDirty(true);
                 }}
               />
             )}
@@ -885,7 +927,6 @@ export function AgentSettingsScreen({
                 showOptionalTag
                 onChange={(value) => {
                   setAcpModel(value);
-                  setIsDirty(true);
                 }}
               />
             )}


### PR DESCRIPTION
HUMAN:
I investigated the issue and manually tested the Verification Settings page. The Save button is disabled when Confirmation mode matches the saved value, becomes enabled after the mode is changed, and is disabled again after the change is reverted. This matches the expected behavior described in the issue.

AGENT:

## Why

The Save button should only be enabled when the current settings differ from the persisted settings. Reverting a change should return the form to a clean state and avoid an unnecessary save request.

## Summary

- Compare SDK settings fields with their persisted baseline so reverting Confirmation mode clears the dirty state.
- Derive ACP Agent Settings dirty state from the loaded snapshot instead of latching it on first edit.
- Add regression coverage for change, revert, and no-save behavior.

## Testing

- 
pm test -- __tests__/routes/agent-settings.test.tsx __tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx — 44 tests passed.
- Prettier check passed.
- ESLint check passed.
- git diff --check passed.
- Manual UI smoke check at /settings/verification passed: disabled initially, enabled after toggling, disabled again after reverting; disabled Save was not clicked.

Fixes #15776

## How to Test

- Automated tests: `npm test -- __tests__/routes/agent-settings.test.tsx __tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx` (44 tests passed).
- `npm run lint` passed.
- `git diff --check` passed.
- Manual verification at `/settings/verification`: Save is disabled initially, becomes enabled after changing Confirmation mode, and becomes disabled again after reverting it. The disabled Save button was not clicked.

## Video/Screenshots
https://github.com/user-attachments/assets/950057b8-d004-4701-80cf-c4be913ec961