### PR TITLE
fix(security): add noopener and a scheme allowlist to the VS Code URL open

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-card.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-card.test.tsx
@@ -15,6 +15,7 @@ import { formatTimeDelta } from "#/utils/format-time-delta";
 import { ConversationCard } from "#/components/features/conversation-panel/conversation-card/conversation-card";
 import { clickOnEditButton } from "./utils";
 import { ConversationCardActions } from "#/components/features/conversation-panel/conversation-card/conversation-card-actions";
+import ConversationService from "#/api/conversation-service/conversation-service.api";
 import { ExecutionStatus } from "#/types/agent-server/core/base/common";
 import {
   __resetActiveStoreForTests,
@@ -386,6 +387,75 @@ describe("ConversationCard", () => {
 
     expect(onDelete).toHaveBeenCalled();
     expect(onContextMenuToggle).toHaveBeenCalledWith(false);
+  });
+
+  it("opens the VS Code URL with noopener so the new tab cannot reach back through window.opener", async () => {
+    const user = userEvent.setup();
+    const getVSCodeUrl = vi
+      .spyOn(ConversationService, "getVSCodeUrl")
+      .mockResolvedValue({
+        vscode_url: "https://vscode.example.com/?tkn=abc123",
+      });
+
+    renderWithProviders(
+      <ConversationCard
+        onDelete={onDelete}
+        onChangeTitle={onChangeTitle}
+        title="Conversation 1"
+        selectedRepository={null}
+        lastUpdatedAt="2021-10-01T12:00:00Z"
+        conversationId="conversation-1"
+        showOptions
+        contextMenuOpen
+        onContextMenuToggle={vi.fn()}
+      />,
+    );
+
+    const menu = screen.getByTestId("context-menu");
+    await user.click(within(menu).getByTestId("download-vscode-button"));
+
+    // `vi.waitFor`, not testing-library's: this suite stubs `window` with a
+    // plain object, so the DOM-bound helper has no `document` to poll.
+    await vi.waitFor(() =>
+      expect(window.open).toHaveBeenCalledWith(
+        "https://vscode.example.com/?tkn=abc123",
+        "_blank",
+        "noopener,noreferrer",
+      ),
+    );
+
+    getVSCodeUrl.mockRestore();
+  });
+
+  it("does not open a VS Code URL whose scheme is outside the allowlist", async () => {
+    const user = userEvent.setup();
+    const getVSCodeUrl = vi
+      .spyOn(ConversationService, "getVSCodeUrl")
+      .mockResolvedValue({
+        vscode_url: "javascript:alert(document.domain)",
+      });
+
+    renderWithProviders(
+      <ConversationCard
+        onDelete={onDelete}
+        onChangeTitle={onChangeTitle}
+        title="Conversation 1"
+        selectedRepository={null}
+        lastUpdatedAt="2021-10-01T12:00:00Z"
+        conversationId="conversation-1"
+        showOptions
+        contextMenuOpen
+        onContextMenuToggle={vi.fn()}
+      />,
+    );
+
+    const menu = screen.getByTestId("context-menu");
+    await user.click(within(menu).getByTestId("download-vscode-button"));
+
+    await vi.waitFor(() => expect(getVSCodeUrl).toHaveBeenCalled());
+    expect(window.open).not.toHaveBeenCalled();
+
+    getVSCodeUrl.mockRestore();
   });
 
   it("should call onArchive when the archive button is clicked", async () => {

--- a/__tests__/utils/vscode-url-helper.test.ts
+++ b/__tests__/utils/vscode-url-helper.test.ts
@@ -53,8 +53,21 @@ describe("transformVSCodeUrl", () => {
     expect(transformVSCodeUrl(input)).toBe(input);
   });
 
-  it("should handle invalid URLs gracefully", () => {
-    const input = "not-a-valid-url";
+  it("should return null for a malformed URL rather than passing it through", () => {
+    expect(transformVSCodeUrl("not-a-valid-url")).toBeNull();
+  });
+
+  it.each([
+    ["javascript:", "javascript:alert(document.domain)"],
+    ["data:", "data:text/html,<script>alert(1)</script>"],
+    ["vscode:", "vscode://file/etc/passwd"],
+    ["file:", "file:///etc/passwd"],
+  ])("should return null for a %s URL", (_scheme, input) => {
+    expect(transformVSCodeUrl(input)).toBeNull();
+  });
+
+  it("should keep https URLs", () => {
+    const input = "https://vscode.example.com/?tkn=abc123&folder=/workspace";
 
     expect(transformVSCodeUrl(input)).toBe(input);
   });

--- a/src/components/features/conversation-panel/conversation-card/conversation-card.tsx
+++ b/src/components/features/conversation-panel/conversation-card/conversation-card.tsx
@@ -154,7 +154,10 @@ export function ConversationCard({
         if (data.vscode_url) {
           const transformedUrl = transformVSCodeUrl(data.vscode_url);
           if (transformedUrl) {
-            window.open(transformedUrl, "_blank");
+            // `noopener` keeps the opened page from reaching back through
+            // `window.opener` to redirect this tab (reverse tabnabbing); the
+            // returned reference is not used.
+            window.open(transformedUrl, "_blank", "noopener,noreferrer");
           }
         }
         // VS Code URL not available

--- a/src/utils/vscode-url-helper.ts
+++ b/src/utils/vscode-url-helper.ts
@@ -1,31 +1,43 @@
 /**
+ * Schemes a VS Code URL may use. The value is backend-controlled and is handed
+ * straight to `window.open`, so anything outside this set — `javascript:`,
+ * `data:`, an OS-registered handler — is dropped rather than navigated to.
+ */
+const ALLOWED_VSCODE_URL_PROTOCOLS = new Set(["http:", "https:"]);
+
+/**
  * Helper function to transform VS Code URLs
  *
  * This function checks if a VS Code URL points to localhost and replaces it with
  * the current window's hostname if they don't match.
  *
  * @param vsCodeUrl The original VS Code URL from the backend
- * @returns The transformed URL with the correct hostname
+ * @returns The transformed URL with the correct hostname, or `null` when the
+ *   input is absent, unparsable, or uses a scheme outside the allowlist
  */
 export function transformVSCodeUrl(vsCodeUrl: string | null): string | null {
   if (!vsCodeUrl) return null;
 
+  let url: URL;
   try {
-    const url = new URL(vsCodeUrl);
-
-    // Check if the URL points to localhost
-    if (
-      url.hostname === "localhost" &&
-      window.location.hostname !== "localhost"
-    ) {
-      // Replace localhost with the current hostname
-      url.hostname = window.location.hostname;
-      return url.toString();
-    }
-
-    return vsCodeUrl;
+    url = new URL(vsCodeUrl);
   } catch {
-    // Silently handle the error and return the original URL
-    return vsCodeUrl;
+    // A string that doesn't parse can't be scheme-checked, so it never reaches
+    // the caller's `window.open`.
+    return null;
   }
+
+  if (!ALLOWED_VSCODE_URL_PROTOCOLS.has(url.protocol)) return null;
+
+  // Check if the URL points to localhost
+  if (
+    url.hostname === "localhost" &&
+    window.location.hostname !== "localhost"
+  ) {
+    // Replace localhost with the current hostname
+    url.hostname = window.location.hostname;
+    return url.toString();
+  }
+
+  return vsCodeUrl;
 }


### PR DESCRIPTION
HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

Ran the two affected suites locally on Node 22.23.2 with the fix reverted and
then applied, to show the new assertions actually catch the reported behavior.
The transcripts are under `## Video/Screenshots` below.

Two known PR-description check failures, both about the checker rather than the
change:

1. #16871 is not labeled `ready-for-dev`. The readiness bot ran on that issue
   *before* its `bug` label was applied and reported "The issue has neither the
   `bug` nor `enhancement` label", so the label was never granted — the same gap
   tracked in #16956. The issue body does satisfy the bug-report criteria; a
   re-run or a manual label clears this.
2. The bug-fix evidence rule accepts only an embedded image or video. This bug
   has no rendered surface, so the evidence is the before/after test transcript
   below.

## Why

The conversation card's "Download via VS Code" action called
`window.open(transformedUrl, "_blank")` without `noopener,noreferrer`. Unlike a
`target="_blank"` anchor, `window.open` keeps `window.opener` alive, so the
opened page can redirect the canvas tab to a lookalike page while the user's
attention is on the new tab (reverse tabnabbing).

The URL is backend-controlled and reached `window.open` unvalidated:
`transformVSCodeUrl` special-cased localhost hostnames and returned every other
input verbatim — including `javascript:`, `data:`, OS-handler schemes, and
strings that don't parse as a URL at all.

The sibling call site (`drawer-vscode-link.tsx:25`) already passed the feature
string; only the card was missed.

## Summary

- `conversation-card.tsx` passes `"noopener,noreferrer"` to `window.open` (the
  returned reference is not used).
- `transformVSCodeUrl` returns `null` for unparsable input and for any scheme
  outside an http/https allowlist, instead of passing the raw value through on
  both the parse-success and `catch` paths. The localhost-rewrite behavior is
  unchanged.
- Tests cover `javascript:`, `data:`, `vscode:`, `file:` and malformed input,
  and assert the card both passes `noopener,noreferrer` and skips `window.open`
  entirely for a rejected scheme.

## Issue Number

Fixes #16871

## How to Test

```
nvm use 22          # engines require >=22.12.0
npm install
npm run make-i18n
npx vitest run __tests__/utils/vscode-url-helper.test.ts \
  __tests__/components/features/conversation-panel/conversation-card.test.tsx
```

Expected: `Test Files 2 passed (2)`, `Tests 61 passed (61)`.

To see the tests fail against the old behavior, revert just the source files and
re-run:

```
git checkout HEAD~1 -- src/utils/vscode-url-helper.ts \
  src/components/features/conversation-panel/conversation-card/conversation-card.tsx
```

Expected: `Tests 7 failed | 54 passed (61)`.

Also verified: `npm run typecheck`, `eslint src`, and `prettier --check` pass on
the changed source files.

## Video/Screenshots

No UI surface to show — the bug is a missing `window.open` feature string and an
unvalidated scheme, both silent by design. Terminal evidence instead.

**Before** — fix reverted, the new tests kept:

```
> __tests__/utils/vscode-url-helper.test.ts (10 tests | 5 failed) 45ms
> __tests__/components/features/conversation-panel/conversation-card.test.tsx (51 tests | 2 failed) 1661ms

Failed Tests 7
AssertionError: expected 'not-a-valid-url' to be null
AssertionError: expected 'javascript:alert(document.domain)' to be null
AssertionError: expected 'data:text/html,<script>alert(1)</scri…' to be null
AssertionError: expected 'vscode://file/etc/passwd' to be null
AssertionError: expected 'file:///etc/passwd' to be null
AssertionError: expected "vi.fn()" to be called with arguments: [ …(3) ]
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

 Test Files  2 failed (2)
      Tests  7 failed | 54 passed (61)
```

The last two are the tabnabbing assertions: the card called `window.open`
without the feature string, and called it at all for a `javascript:` URL.

**After** — fix applied:

```
 Test Files  2 passed (2)
      Tests  61 passed (61)
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The allowlist is http/https only. #16871 mentions `vscode:`/`vscode-insiders:`
as optionally allowed; no call path in the repo produces those schemes today
(no `vscode://` reference exists in `src`, `tests`, or `docs`), so they are left
out. Adding them later is a one-line change to
`ALLOWED_VSCODE_URL_PROTOCOLS`.

`transformVSCodeUrl` is shared with `use-unified-vscode-url` (local and cloud
paths), so the drawer's VS Code button gets the same validation. Every existing
fixture in `__tests__/hooks/use-unified-vscode-url.test.tsx` uses http/https
URLs and is unaffected.
