### PR TITLE
fix(mcp): wrap decodeURIComponent in per-call try-catch (#16978)

### DIFF
--- a/__tests__/utils/redact-mcp-secrets.test.ts
+++ b/__tests__/utils/redact-mcp-secrets.test.ts
@@ -63,4 +63,26 @@ describe("redactMcpSecrets", () => {
 
     expect(redactMcpSecrets(text, server)).toBe(text);
   });
+
+  it("still collects query-string secrets when the URL password has a malformed percent escape (fixes #16978)", () => {
+    // The userinfo "alice:pa%ssword" has a "%" that is not followed by two hex digits,
+    // which makes decodeURIComponent throw URIError. The collection must not abort:
+    // the raw password is still added by the addValue() call before the decode, and
+    // the API-key query parameter on the same URL must also be picked up.
+    const server: MCPServerConfig = {
+      id: "shttp-1",
+      type: "shttp",
+      url: "https://alice:pa%ssword@mcp.example.com/mcp?api_key=querysecret456",
+    };
+
+    const redacted = redactMcpSecrets(
+      "401 for https://alice:pa%ssword@mcp.example.com/mcp?api_key=querysecret456",
+      server,
+    );
+
+    expect(redacted).not.toContain("querysecret456");
+    // The raw "%ssword" survives too — the redactor only knows the literal text.
+    expect(redacted).not.toContain("pa%ssword");
+    expect(redacted).toContain(REDACTED_MCP_SECRET_VALUE);
+  });
 });

--- a/src/utils/redact-mcp-secrets.ts
+++ b/src/utils/redact-mcp-secrets.ts
@@ -52,8 +52,22 @@ function addUrlSecrets(values: Set<string>, rawUrl: string | undefined): void {
     const url = new URL(rawUrl);
     addValue(values, url.username);
     addValue(values, url.password);
-    addValue(values, decodeURIComponent(url.username));
-    addValue(values, decodeURIComponent(url.password));
+    // Wrapping each decodeURIComponent individually prevents a lone "%" in the
+    // username or password from aborting the entire collection, including the
+    // searchParams pass below (fixes #16978).
+    try {
+      addValue(values, decodeURIComponent(url.username));
+    } catch {
+      // Malformed %-encoding in username — skip the decoded form, keep the
+      // already-collected raw form and continue to the rest of the URL.
+    }
+    try {
+      addValue(values, decodeURIComponent(url.password));
+    } catch {
+      // Malformed %-encoding in password — same as above.
+    }
+    // Always attempt searchParams — a parseable URL may still carry secrets in
+    // its query string even when the userinfo has malformed %-encoding.
     url.searchParams.forEach((value, name) => {
       if (SECRETLIKE_PARAM_NAME.test(name)) addValue(values, value);
     });


### PR DESCRIPTION
## Summary

Closes #16978.

When a lone `%` in a MCP server URL password causes `decodeURIComponent` to throw `URIError`, the enclosing `catch` swallows it and **skips the entire `url.searchParams` pass** — leaving query-string secrets (`api_key`, `token`, `secret`, `auth`) uncollected.

The user-visible impact: configuring an MCP server with both a `%` in its password and an `api_key` in the query string causes the `api_key` to be echoed in plaintext when the MCP health probe fails (Test/Retry button at `src/components/features/mcp-page/mcp-server-health.tsx:160`).

## Fix

Wrap each `decodeURIComponent` call in its own `try-catch`:

1. Raw username/password are always collected (before the `decodeURIComponent` call).
2. Decoded forms are collected when valid.
3. The `searchParams` pass **always runs** regardless of userinfo %-encoding.

## Changes

- `src/utils/redact-mcp-secrets.ts`: `addUrlSecrets` — per-call `try-catch` around `decodeURIComponent`
- `__tests__/utils/redact-mcp-secrets.test.ts`: regression test with `pa%ssword` password + `api_key` query param

## Evidence

**Before** (broken — `api_key` not redacted because `decodeURIComponent` throws before `searchParams` loop):

```
// URL: https://alice:pa%ssword@mcp.example.com/mcp?api_key=querysecret456
// decodeURIComponent("pa%ssword") → throws URIError
// catch block runs → url.searchParams skipped
// Result: "api_key=querysecret456" NOT redacted
```

**After** (fixed):

```
try { addValue(values, decodeURIComponent(url.username)); } catch { /* ignore */ }
try { addValue(values, decodeURIComponent(url.password)); } catch { /* ignore */ }
url.searchParams.forEach(...) // always runs
// Result: "api_key=querysecret456" IS redacted ✓
```