### PR TITLE
refactor: move nested Vitest mocks/hoists to module scope

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -10,15 +10,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nextProvider } from "react-i18next";
 import i18n from "i18next";
 import { NavigationProvider } from "#/context/navigation-context";
-import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { createRoutesStub } from "react-router";
 import React from "react";
@@ -89,6 +81,17 @@ vi.mock("#/utils/custom-toast-handlers", () => ({
   TOAST_OPTIONS: {},
 }));
 
+// Mock react-router navigation hooks. Kept at module scope (not nested inside
+// beforeAll) because Vitest 4 emits warnings for nested vi.mock() calls and
+// will make them errors in a future release.
+vi.mock("react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router")>()),
+  Link: ({ children }: React.PropsWithChildren) => children,
+  useNavigate: vi.fn(() => vi.fn()),
+  useLocation: vi.fn(() => ({ pathname: "/conversation" })),
+  useParams: vi.fn(() => ({ conversationId: "2" })),
+}));
+
 describe("ConversationPanel", () => {
   const onCloseMock = vi.fn();
   const RouterStub = createRoutesStub([
@@ -106,16 +109,6 @@ describe("ConversationPanel", () => {
   const renderConversationPanel = (
     options?: Parameters<typeof renderWithProviders>[1],
   ) => renderWithProviders(<RouterStub />, options);
-
-  beforeAll(() => {
-    vi.mock("react-router", async (importOriginal) => ({
-      ...(await importOriginal<typeof import("react-router")>()),
-      Link: ({ children }: React.PropsWithChildren) => children,
-      useNavigate: vi.fn(() => vi.fn()),
-      useLocation: vi.fn(() => ({ pathname: "/conversation" })),
-      useParams: vi.fn(() => ({ conversationId: "2" })),
-    }));
-  });
 
   const mockConversations: AppConversation[] = [
     createMockConversation({ id: "1", title: "Conversation 1" }),

--- a/__tests__/hooks/use-terminal.test.tsx
+++ b/__tests__/hooks/use-terminal.test.tsx
@@ -18,26 +18,53 @@ vi.mock("#/contexts/conversation-websocket-context", () => ({
   useConversationWebSocket: () => null,
 }));
 
+// Terminal/terminal-addon mocks must live at module scope. Vitest 4 hoists
+// vi.mock() factories above imports and emits warnings (errors in a future
+// release) for nested vi.hoisted()/vi.mock() calls, so these can't be declared
+// inside describe/beforeAll. vi.hoisted() keeps them referenceable from the
+// hoisted vi.mock() factories below.
+const mockTerminal = vi.hoisted(() => ({
+  loadAddon: vi.fn(),
+  open: vi.fn(),
+  write: vi.fn(),
+  writeln: vi.fn(),
+  dispose: vi.fn(),
+  element: document.createElement("div"),
+}));
+
+const mockFitAddon = vi.hoisted(() => ({
+  fit: vi.fn(),
+}));
+
+vi.mock("@xterm/xterm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@xterm/xterm")>()),
+  Terminal: class {
+    loadAddon = mockTerminal.loadAddon;
+
+    open = mockTerminal.open;
+
+    write = mockTerminal.write;
+
+    writeln = mockTerminal.writeln;
+
+    dispose = mockTerminal.dispose;
+
+    element = mockTerminal.element;
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit = mockFitAddon.fit;
+  },
+}));
+
 function TestTerminalComponent() {
   const ref = useTerminal();
   return <div ref={ref} />;
 }
 
 describe("useTerminal", () => {
-  // Terminal is read-only - no longer tests user input functionality
-  const mockTerminal = vi.hoisted(() => ({
-    loadAddon: vi.fn(),
-    open: vi.fn(),
-    write: vi.fn(),
-    writeln: vi.fn(),
-    dispose: vi.fn(),
-    element: document.createElement("div"),
-  }));
-
-  const mockFitAddon = vi.hoisted(() => ({
-    fit: vi.fn(),
-  }));
-
   beforeAll(() => {
     // mock ResizeObserver - use class for Vitest 4 constructor support
     window.ResizeObserver = class {
@@ -47,31 +74,6 @@ describe("useTerminal", () => {
 
       disconnect = vi.fn();
     } as unknown as typeof ResizeObserver;
-
-    // mock Terminal - use class for Vitest 4 constructor support
-    vi.mock("@xterm/xterm", async (importOriginal) => ({
-      ...(await importOriginal<typeof import("@xterm/xterm")>()),
-      Terminal: class {
-        loadAddon = mockTerminal.loadAddon;
-
-        open = mockTerminal.open;
-
-        write = mockTerminal.write;
-
-        writeln = mockTerminal.writeln;
-
-        dispose = mockTerminal.dispose;
-
-        element = mockTerminal.element;
-      },
-    }));
-
-    // mock FitAddon
-    vi.mock("@xterm/addon-fit", () => ({
-      FitAddon: class {
-        fit = mockFitAddon.fit;
-      },
-    }));
   });
 
   afterEach(() => {


### PR DESCRIPTION
Fixes #15489

## Problem
Vitest 4.1.5 reports five constructs that will become errors in a future release:
- One nested `vi.mock("react-router")` in `conversation-panel.test.tsx`.
- Two nested `vi.hoisted()` calls in `use-terminal.test.tsx`.
- Two nested xterm `vi.mock()` calls in `use-terminal.test.tsx`.

## Fix
Move the affected declarations to valid module-level positions (no production changes):
- `conversation-panel.test.tsx`: the react-router mock moves out of `beforeAll` to module scope; the now-unused `beforeAll` import is removed.
- `use-terminal.test.tsx`: the two `vi.hoisted()` declarations and the two xterm `vi.mock()` calls move out of `beforeAll` to module scope.

## Verification
- Both focused files pass together: conversation-panel.test.tsx 59/59 and use-terminal.test.tsx 3/3 (62/62).
- Vitest emits no nested `vi.mock()`/`vi.hoisted()` warnings for either file.
- Mock reset semantics and per-test isolation unchanged; no assertions weakened or removed.
- `npm run typecheck` (`react-router typegen && tsc`) passes; prettier clean on both files.

HUMAN: Ran the two affected Vitest files on Node 24 -- conversation-panel.test.tsx (59/59) and use-terminal.test.tsx (3/3) pass together; confirmed no nested vi.mock/vi.hoisted warnings; typecheck and prettier pass.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.51s · commit 90a9821  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 5/5 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 8.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 1a9cf6a6eb00fefa0478c5fa0dedae5763811391289da88f286f50828b971bf2 -->
<!-- jev-fast-audit:end -->
