### PR TITLE
feat: add Quint checks for model-selection authority

### DIFF
--- a/.github/workflows/quint-model-selection.yml
+++ b/.github/workflows/quint-model-selection.yml
@@ -1,0 +1,117 @@
+name: Quint Model Selection Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/quint-model-selection.yml"
+      - "spec/quint/agent-canvas-model-selection.qnt"
+      - "src/api/conversation-metadata-store.ts"
+      - "src/api/conversation-service/agent-server-conversation-service.api.ts"
+      - "src/api/conversation-service/agent-server-conversation-service.types.ts"
+      - "src/components/features/chat/components/chat-input-llm-profile-picker.tsx"
+      - "src/components/features/chat/components/chat-input-model.tsx"
+      - "src/contexts/conversation-websocket-context.tsx"
+      - "src/hooks/chat/record-model-switch-message.ts"
+      - "src/hooks/mutation/use-create-conversation.ts"
+      - "src/hooks/mutation/use-switch-acp-model.ts"
+      - "src/hooks/mutation/use-switch-llm-profile.ts"
+      - "src/hooks/mutation/use-switch-llm-profile-and-log.ts"
+      - "src/hooks/use-acp-model-context.ts"
+      - "src/hooks/use-chat-input-model-state.ts"
+      - "src/hooks/use-chat-input-llm-profile-state.ts"
+      - "src/stores/model-store.ts"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/quint-model-selection.yml"
+      - "spec/quint/agent-canvas-model-selection.qnt"
+      - "src/api/conversation-metadata-store.ts"
+      - "src/api/conversation-service/agent-server-conversation-service.api.ts"
+      - "src/api/conversation-service/agent-server-conversation-service.types.ts"
+      - "src/components/features/chat/components/chat-input-llm-profile-picker.tsx"
+      - "src/components/features/chat/components/chat-input-model.tsx"
+      - "src/contexts/conversation-websocket-context.tsx"
+      - "src/hooks/chat/record-model-switch-message.ts"
+      - "src/hooks/mutation/use-create-conversation.ts"
+      - "src/hooks/mutation/use-switch-acp-model.ts"
+      - "src/hooks/mutation/use-switch-llm-profile.ts"
+      - "src/hooks/mutation/use-switch-llm-profile-and-log.ts"
+      - "src/hooks/use-acp-model-context.ts"
+      - "src/hooks/use-chat-input-model-state.ts"
+      - "src/hooks/use-chat-input-llm-profile-state.ts"
+      - "src/stores/model-store.ts"
+
+concurrency:
+  group: quint-model-selection-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-model-selection:
+    name: Check model-selection authority
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          # Match the Node line used by the main CI workflow.
+          node-version: "24.15"
+
+      - name: Typecheck specification
+        run: >-
+          npx --yes @informalsystems/quint@0.32.0 typecheck
+          spec/quint/agent-canvas-model-selection.qnt
+
+      - name: Run deterministic design tests
+        run: >-
+          npx --yes @informalsystems/quint@0.32.0 test
+          spec/quint/agent-canvas-model-selection.qnt
+
+      - name: Check the fixed authority invariant
+        run: >-
+          npx --yes @informalsystems/quint@0.32.0 run
+          spec/quint/agent-canvas-model-selection.qnt
+          --invariant=displayMatchesAuthority
+          --max-samples=10000
+          --max-steps=20
+
+      - name: Confirm stale implementations produce counterexamples
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          expect_counterexample() {
+            local init_action="$1"
+            local step_action="$2"
+            local output_file
+            output_file="$(mktemp)"
+
+            if npx --yes @informalsystems/quint@0.32.0 run \
+              spec/quint/agent-canvas-model-selection.qnt \
+              --init="$init_action" \
+              --step="$step_action" \
+              --invariant=displayMatchesAuthority \
+              --max-samples=1 \
+              --max-steps=1 >"$output_file" 2>&1; then
+              echo "::error::$step_action unexpectedly satisfied displayMatchesAuthority"
+              sed -n '1,200p' "$output_file"
+              exit 1
+            fi
+
+            sed -n '1,200p' "$output_file"
+            if ! grep -q "Invariant violated" "$output_file"; then
+              echo "::error::$step_action failed without the expected invariant counterexample"
+              exit 1
+            fi
+          }
+
+          expect_counterexample initStaleReopenWitness reopenWithStaleDisplay
+          expect_counterexample initStaleSwitchWitness switchWithStaleDisplay

--- a/spec/quint/agent-canvas-model-selection.qnt
+++ b/spec/quint/agent-canvas-model-selection.qnt
@@ -1,0 +1,210 @@
+/**
+ * Executable design model for Agent Canvas model-selection authority.
+ *
+ * This specification models the contract shared by the Home model selector,
+ * conversation creation/reopen, and live model switching. It does not execute
+ * the React implementation. Keep the transitions and the workflow path filters
+ * in sync when those product semantics change.
+ *
+ * Authority rules:
+ *   - Home displays the current account default.
+ *   - An open conversation displays its persisted, running model.
+ *   - Changing the account default does not change an open conversation.
+ *   - A live switch updates the persisted, running, and displayed model together.
+ *
+ * The intentionally stale reopen and switch actions are negative controls. They
+ * must violate displayMatchesAuthority, proving that the invariant can detect
+ * the regressions it is intended to guard against.
+ */
+module agent_canvas_model_selection {
+  type Model = ModelA | ModelB
+  type Surface = Home | Conversation
+
+  var accountDefault: Model
+  var persistedConversationModel: Model
+  var runningConversationModel: Model
+  var displayedModel: Model
+  var surface: Surface
+
+  action init = all {
+    accountDefault' = ModelA,
+    persistedConversationModel' = ModelA,
+    runningConversationModel' = ModelA,
+    displayedModel' = ModelA,
+    surface' = Home,
+  }
+
+  action setAccountDefault(model: Model): bool = all {
+    accountDefault' = model,
+    persistedConversationModel' = persistedConversationModel,
+    runningConversationModel' = runningConversationModel,
+    displayedModel' = if (surface == Home) model else displayedModel,
+    surface' = surface,
+  }
+
+  action createConversation = all {
+    surface == Home,
+    accountDefault' = accountDefault,
+    persistedConversationModel' = accountDefault,
+    runningConversationModel' = accountDefault,
+    displayedModel' = accountDefault,
+    surface' = Conversation,
+  }
+
+  action returnHome = all {
+    surface == Conversation,
+    accountDefault' = accountDefault,
+    persistedConversationModel' = persistedConversationModel,
+    runningConversationModel' = runningConversationModel,
+    displayedModel' = accountDefault,
+    surface' = Home,
+  }
+
+  action reopenConversation = all {
+    surface == Home,
+    accountDefault' = accountDefault,
+    persistedConversationModel' = persistedConversationModel,
+    runningConversationModel' = persistedConversationModel,
+    displayedModel' = persistedConversationModel,
+    surface' = Conversation,
+  }
+
+  action switchConversationModel(model: Model): bool = all {
+    surface == Conversation,
+    accountDefault' = accountDefault,
+    persistedConversationModel' = model,
+    runningConversationModel' = model,
+    displayedModel' = model,
+    surface' = Conversation,
+  }
+
+  action step = any {
+    setAccountDefault(ModelA),
+    setAccountDefault(ModelB),
+    createConversation,
+    returnHome,
+    reopenConversation,
+    switchConversationModel(ModelA),
+    switchConversationModel(ModelB),
+  }
+
+  val displayMatchesAuthority = {
+    if (surface == Home) {
+      displayedModel == accountDefault
+    } else {
+      and {
+        runningConversationModel == persistedConversationModel,
+        displayedModel == runningConversationModel,
+      }
+    }
+  }
+
+  // This Home state is reachable after creating a ModelA conversation,
+  // switching it to ModelB, and returning Home.
+  action initStaleReopenWitness = all {
+    accountDefault' = ModelA,
+    persistedConversationModel' = ModelB,
+    runningConversationModel' = ModelB,
+    displayedModel' = ModelA,
+    surface' = Home,
+  }
+
+  action reopenWithStaleDisplay = all {
+    surface == Home,
+    accountDefault' = accountDefault,
+    persistedConversationModel' = persistedConversationModel,
+    runningConversationModel' = persistedConversationModel,
+    displayedModel' = displayedModel,
+    surface' = Conversation,
+  }
+
+  action initStaleSwitchWitness = all {
+    accountDefault' = ModelA,
+    persistedConversationModel' = ModelA,
+    runningConversationModel' = ModelA,
+    displayedModel' = ModelA,
+    surface' = Conversation,
+  }
+
+  action switchWithStaleDisplay = all {
+    surface == Conversation,
+    accountDefault' = accountDefault,
+    persistedConversationModel' = ModelB,
+    runningConversationModel' = ModelB,
+    displayedModel' = displayedModel,
+    surface' = Conversation,
+  }
+
+  run homeDisplaysAccountDefaultTest =
+    init
+      .then(setAccountDefault(ModelB))
+      .expect(and {
+        displayedModel == ModelB,
+        displayMatchesAuthority,
+      })
+
+  run conversationStartsWithAccountDefaultTest =
+    init
+      .then(setAccountDefault(ModelB))
+      .then(createConversation)
+      .expect(and {
+        persistedConversationModel == ModelB,
+        runningConversationModel == ModelB,
+        displayedModel == ModelB,
+        displayMatchesAuthority,
+      })
+
+  run defaultChangeDoesNotChangeOpenConversationTest =
+    init
+      .then(createConversation)
+      .then(setAccountDefault(ModelB))
+      .expect(and {
+        accountDefault == ModelB,
+        persistedConversationModel == ModelA,
+        displayedModel == ModelA,
+        displayMatchesAuthority,
+      })
+
+  run reopenedConversationDisplaysPersistedModelTest =
+    init
+      .then(createConversation)
+      .then(switchConversationModel(ModelB))
+      .then(returnHome)
+      .then(reopenConversation)
+      .expect(and {
+        persistedConversationModel == ModelB,
+        runningConversationModel == ModelB,
+        displayedModel == ModelB,
+        displayMatchesAuthority,
+      })
+
+  run liveSwitchUpdatesAllConversationModelsTest =
+    init
+      .then(createConversation)
+      .then(switchConversationModel(ModelB))
+      .expect(and {
+        persistedConversationModel == ModelB,
+        runningConversationModel == ModelB,
+        displayedModel == ModelB,
+        displayMatchesAuthority,
+      })
+
+  run staleReopenViolatesInvariantTest =
+    init
+      .then(createConversation)
+      .then(switchConversationModel(ModelB))
+      .then(returnHome)
+      .expect(and {
+        persistedConversationModel == ModelB,
+        displayedModel == ModelA,
+        displayMatchesAuthority,
+      })
+      .then(reopenWithStaleDisplay)
+      .expect(not(displayMatchesAuthority))
+
+  run staleSwitchViolatesInvariantTest =
+    init
+      .then(createConversation)
+      .then(switchWithStaleDisplay)
+      .expect(not(displayMatchesAuthority))
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN: 

I reviewed the Quint specification and CI workflow and verified the intended behavior: the fixed model satisfies the model-selection authority invariant across 10,000 traces, while both stale-reopen and stale-switch variants produce the expected counterexamples. The dedicated Quint workflow passes on this PR, and I also reviewed the successful local lint, full test suite, app and library builds, and package dry run.

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

## Why

Agent Canvas model selection has two distinct authorities: the account default used for a new conversation and the persisted model owned by an existing conversation. Reopen and live-switch regressions can leave the displayed model stale even when each individual UI path looks reasonable. This adds an executable design contract that exercises those transitions together and includes negative controls to prove the safety property detects the known failure modes.

## Summary

- Add a Quint state machine for Home selection, conversation creation, account-default changes, conversation reopen, and live model switching.
- Add deterministic positive scenarios plus reachable stale-reopen and stale-switch negative controls.
- Add a path-scoped workflow that typechecks the spec, runs its tests, explores 10,000 fixed-model traces, and requires both buggy variants to produce invariant counterexamples.

## Issue Number

Fixes #17024

## How to Test

Run the same checks as the new workflow:

```bash
npx --yes @informalsystems/quint@0.32.0 typecheck spec/quint/agent-canvas-model-selection.qnt
npx --yes @informalsystems/quint@0.32.0 test spec/quint/agent-canvas-model-selection.qnt
npx --yes @informalsystems/quint@0.32.0 run spec/quint/agent-canvas-model-selection.qnt \
  --invariant=displayMatchesAuthority --max-samples=10000 --max-steps=20
```

The workflow's final step also runs each deliberately stale transition for one step and requires a non-zero exit containing `Invariant violated`.

Repository checks run locally:

```text
TZ=UTC npm test       623 files passed; 5281 tests passed; 4 skipped; 7 todo
npm run lint          0 errors (3 pre-existing warnings)
npm run build         passed
npm run build:lib     passed
npm pack --dry-run    passed
```

## Video/Screenshots

This is a non-UI executable specification. Terminal evidence from the real Quint CLI:

```text
7 passing
[ok] No violation found (10,000 fixed-model traces)

reopenWithStaleDisplay: error: Invariant violated
switchWithStaleDisplay: error: Invariant violated
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The workflow pins Quint to `0.32.0` and runs only when the specification, workflow, or model-selection implementation paths change. The specification is an executable design model; it intentionally does not claim to execute the React implementation and documents that it must evolve with those semantics.
