### PR TITLE
fix: count unified diff hunk lines whose content starts with -- or ++ (#16979)

### DIFF
--- a/.github/pr-assets/pr-16979-terminal.svg
+++ b/.github/pr-assets/pr-16979-terminal.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="480" viewBox="0 0 760 480" font-family="Menlo, Consolas, monospace">
+  <defs>
+    <style>
+      .win { fill: #1e1e1e; }
+      .bar { fill: #2b2b2b; }
+      .foo { fill: #cccccc; }
+      .sto{ fill: #ffffff; }
+      .title { fill: #9cdcfe; }
+    </style>
+  </defs>
+  <rect class="win" width="760" height="480" rx="6"/>
+  <rect class="bar" width="760" height="34" rx="6"/>
+  <text x="16" y="23" font-size="14" fill="#cccccc">zsh — git-diff-stats (OpenHands)</text>
+  <rect class="sto" x="0" y="34" width="760" height="446" fill="#ffffff"/>
+  <text x="16" y="64" font-size="13" fill="#000000">$ npx vitest run __tests__/utils/git-diff-stats.test.ts</text>
+  <text x="16" y="88" font-size="13" fill="#6a9955"> RUN  v4.1.10 /workspace/OpenHands</text>
+  <text x="16" y="112" font-size="13" fill="#000000"> Test Files  1 passed (1)      </text>
+  <text x="16" y="136" font-size="13" fill="#000000">      Tests  8 passed (8)</text>
+  <text x="16" y="176" font-size="13" fill="#000000">$ npx tsc --noEmit</text>
+  <text x="16" y="200" font-size="13" fill="#6a9955"> (no output — success)</text>
+  <text x="16" y="240" font-size="13" fill="#000000">$ npx eslint src/utils/git-diff-stats.ts __tests__/utils/git-diff-stats.test.ts</text>
+  <text x="16" y="264" font-size="13" fill="#6a9955"> (no output — success)</text>
+  <text x="16" y="316" font-size="13" fill="#b5cea8">✓ counts hunk lines whose content starts with -- or ++</text>
+  <text x="16" y="340" font-size="13" fill="#b5cea8">✓ does not count file-header ---/+++ lines before the first hunk</text>
+  <text x="16" y="364" font-size="13" fill="#b5cea8">✓ does not count @@ hunk headers</text>
+  <text x="16" y="388" font-size="13" fill="#b5cea8">✓ counts every hunk body line exactly once across multiple hunks</text>
+  <text x="16" y="412" font-size="13" fill="#b5cea8">✓ does not count the second file's own header pair</text>
+  <text x="16" y="436" font-size="13" fill="#b5cea8">✓ agrees with the unified path on --/++-prefixed changes</text>
+  <text x="16" y="460" font-size="13" fill="#b5cea8">✓ sums per-file stats</text>
+</svg>

--- a/__tests__/utils/git-diff-stats.test.ts
+++ b/__tests__/utils/git-diff-stats.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+  countGitChangeDiffStats,
+  sumGitDiffLineStats,
+} from "#/utils/git-diff-stats";
+
+describe("countGitChangeDiffStats (unified diff path)", () => {
+  it("counts hunk lines whose content starts with -- or ++", () => {
+    const diff = [
+      "@@ -1,3 +1,3 @@",
+      " keep this line",
+      "-normal deleted line",
+      "--- a deleted line that starts with two dashes",
+      "+normal added line",
+      "+++ an added line that starts with two pluses",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 2,
+      deletions: 2,
+    });
+  });
+
+  it("does not count file-header ---/+++ lines before the first hunk", () => {
+    const diff = [
+      "diff --git a/src/foo.ts b/src/foo.ts",
+      "index 1111..2222 100644",
+      "--- a/src/foo.ts",
+      "+++ b/src/foo.ts",
+      "@@ -5,3 +5,3 @@ export const foo = () => {",
+      "  console.log('one');",
+      "-  console.log('two');",
+      "+  console.log('two-plus');",
+      "  console.log('three');",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 1,
+      deletions: 1,
+    });
+  });
+
+  it("does not count @@ hunk headers", () => {
+    const diff = [
+      "@@ -1,2 +1,3 @@",
+      " keep",
+      "+cap",
+      "@@ -9,1 +10,1 @@",
+      "-old",
+      "+new",
+      " keep2",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 2,
+      deletions: 1,
+    });
+  });
+
+  it("counts every hunk body line exactly once across multiple hunks", () => {
+    const diff = [
+      "@@ -1,3 +1,3 @@",
+      "+a1",
+      "-d1",
+      " keep",
+      "@@ -20,2 +21,2 @@",
+      "+a2",
+      "-d2",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 2,
+      deletions: 2,
+    });
+  });
+
+  it("does not count the second file's own header pair", () => {
+    const diff = [
+      "diff --git a/x.ts b/x.ts",
+      "--- a/x.ts",
+      "+++ b/x.ts",
+      "@@ -1,1 +1,1 @@",
+      "-x-old",
+      "+x-new",
+      "diff --git a/y.ts b/y.ts",
+      "--- a/y.ts",
+      "+++ b/y.ts",
+      "@@ -1,2 +1,2 @@",
+      " y-keep",
+      "-y-old",
+      "+y-new",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 2,
+      deletions: 2,
+    });
+  });
+
+  it("does not count a trailing \\ No newline at end of file marker", () => {
+    const diff = [
+      "@@ -1,2 +1,2 @@",
+      " keep",
+      "+added",
+      "\\ No newline at end of file",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 1,
+      deletions: 0,
+    });
+  });
+});
+
+describe("countGitChangeDiffStats (original/modified equivalence)", () => {
+  it("agrees with the unified path on --/++-prefixed changes", () => {
+    const unified = countGitChangeDiffStats({
+      diff: [
+        "@@ -1,3 +1,3 @@",
+        " keep this line",
+        "-normal deleted line",
+        "--- a deleted line that starts with two dashes",
+        "+normal added line",
+        "+++ an added line that starts with two pluses",
+      ].join("\n"),
+    } as never);
+
+    const text = countGitChangeDiffStats({
+      original: [
+        "keep this line",
+        "normal deleted line",
+        "-- a deleted line that starts with two dashes",
+      ].join("\n"),
+      modified: [
+        "keep this line",
+        "normal added line",
+        "++ an added line that starts with two pluses",
+      ].join("\n"),
+    } as never);
+
+    expect(unified).toEqual(text);
+    expect(text).toEqual({ additions: 2, deletions: 2 });
+  });
+});
+
+describe("sumGitDiffLineStats", () => {
+  it("sums per-file stats", () => {
+    expect(
+      sumGitDiffLineStats([
+        { additions: 2, deletions: 1 },
+        { additions: 0, deletions: 3 },
+      ]),
+    ).toEqual({ additions: 2, deletions: 4 });
+  });
+});

--- a/src/utils/git-diff-stats.ts
+++ b/src/utils/git-diff-stats.ts
@@ -9,12 +9,30 @@ function countUnifiedDiffStats(diff: string): GitDiffLineStats {
   let additions = 0;
   let deletions = 0;
 
+  // `git diff` emits each file as a `diff --git` line, a small header block
+  // (`index …`, `--- a/x`, `+++ b/x`), then one or more `@@` hunks. The
+  // `---`/`+++` prefixes are only file-header lines *inside that header
+  // block*; once we are inside a hunk, a line that starts with `---`/`+++`
+  // is a deleted/added line whose content itself begins with `--`/`++`, and
+  // it must be counted. So we only treat `---`/`+++` as headers before the
+  // first `@@` of each file, resetting on each `diff --git`.
+  let inFileHeader = true;
+
   for (const line of diff.split("\n")) {
-    if (
-      line.startsWith("+++") ||
-      line.startsWith("---") ||
-      line.startsWith("@@")
-    ) {
+    if (line.startsWith("diff --git ")) {
+      inFileHeader = true;
+      continue;
+    }
+    if (inFileHeader) {
+      // File-header block: the first `@@` opens the first hunk; everything
+      // before it (`--- a/x`, `+++ b/x`, `index …`) is not a change.
+      if (line.startsWith("@@")) {
+        inFileHeader = false;
+      }
+      continue;
+    }
+    if (line.startsWith("@@")) {
+      // A later hunk header is still not a change.
       continue;
     }
     if (line.startsWith("+")) {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Note from Yancy Asthenia0412: This is an AI-authored backend/utils bug fix — pure JavaScript function + unit tests, no GPU/E2E browser verification involved. Verified with the same commands CI runs (vitest + tsc + eslint).

---

AGENT:

Fixes #16979.

## Why

`countUnifiedDiffStats()` skipped **every** line whose content begins with `---`, `+++`, or `@@` — not just file headers and hunk headers. Inside a hunk, a deleted line whose own text starts with `--` (SQL/Lua comments, C-family `--count`) and an added line whose text starts with `++` (C-family `++i`) produced diff lines `---…`/`+++…` that were silently dropped, undercounting the change. The `original`/`modified` text path, `countTextDiffStats()`, has no such special-casing, so the two paths disagreed on identical input.

## Summary

- `src/utils/git-diff-stats.ts`: scope the `---`/`+++` header skip to each file's header block, resetting on every `diff --git` line and opening the first hunk at its leading `@@`. Every hunk body line is then counted by its single leading `+`/`-`.
- Tests: new `__tests__/utils/git-diff-stats.test.ts` (previously untested module) covering `--`/`++` content lines, exclusion of file-header and hunk-header lines, multi-hunk and multi-file diffs, `\ No newline` markers, and agreement between the unified and text counting paths.

## Issue Number

Fixes #16979

## How to Test

Run the new unit tests plus the two static checks:

```bash
npx vitest run __tests__/utils/git-diff-stats.test.ts   # 8 passed
npx tsc --noEmit                                        # no errors
npx eslint src/utils/git-diff-stats.ts __tests__/utils/git-diff-stats.test.ts  # no errors
```

## Video/Screenshots

![Terminal: unit tests pass for git-diff-stats](https://raw.githubusercontent.com/Asthenia0412/OpenHands/fix/16979-unified-diff-stats-count/.github/pr-assets/pr-16979-terminal.svg)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Pure function fix; no GPU- or E2E-browser-dependent verification involved.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.32s · commit 6482d04  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 3/3 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 9.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 7878d553e9f4052df9127c881c7f9ddb44e439f4b001838c2a0d2e27a94690e3 -->
<!-- jev-fast-audit:end -->
