### PR TITLE
fix(utils): handle bare percent sign in URL userinfo without aborting secret collection

### DIFF
--- a/__tests__/utils/redact-mcp-secrets.test.ts
+++ b/__tests__/utils/redact-mcp-secrets.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { MCPServerConfig } from "#/types/mcp-server";
 import { REDACTED_MCP_SECRET_VALUE } from "#/utils/mcp-config";
-import { redactMcpSecrets } from "#/utils/redact-mcp-secrets";
+import { collectMcpSecretValues, redactMcpSecrets } from "#/utils/redact-mcp-secrets";
 
 describe("redactMcpSecrets", () => {
   it("masks configured secret values wherever they appear in the text", () => {
@@ -62,5 +62,63 @@ describe("redactMcpSecrets", () => {
     const text = "could not resolve eu endpoint";
 
     expect(redactMcpSecrets(text, server)).toBe(text);
+  });
+});
+
+describe("collectMcpSecretValues, URL query-string secrets", () => {
+  const server = (url: string): MCPServerConfig =>
+    ({
+      id: "s1",
+      name: "s1",
+      type: "sse",
+      url,
+    }) as unknown as MCPServerConfig;
+
+  it("collects ?api_key= when the password is plain", () => {
+    const s = server(
+      "https://alice:plainpassword@mcp.example.com/sse?api_key=QUERYSECRET1234",
+    );
+    expect(collectMcpSecretValues(s)).toContain("QUERYSECRET1234");
+  });
+
+  it("collects ?api_key= when the password contains a bare percent sign", () => {
+    // Regression for issue #16978: a bare '%' in the password makes
+    // decodeURIComponent throw, which used to abort the whole
+    // addUrlSecrets() pass and silently drop the query-string secret.
+    const s = server(
+      "https://alice:pa%ssword@mcp.example.com/sse?api_key=QUERYSECRET1234",
+    );
+    expect(collectMcpSecretValues(s)).toContain("QUERYSECRET1234");
+  });
+
+  it("collects ?api_key= when the username contains a bare percent sign", () => {
+    const s = server(
+      "https://al%ice:password@mcp.example.com/sse?api_key=QUERYSECRET1234",
+    );
+    expect(collectMcpSecretValues(s)).toContain("QUERYSECRET1234");
+  });
+
+  it("still collects the raw username and password when percent decoding fails", () => {
+    const s = server("https://alice:pa%ssword@mcp.example.com/sse");
+    const values = collectMcpSecretValues(s);
+    expect(values).toContain("alice");
+    expect(values).toContain("pa%ssword");
+  });
+
+  it("redacts the query-string secret end-to-end when the password has a bare '%'", () => {
+    const s = server(
+      "https://alice:pa%ssword@mcp.example.com/sse?api_key=QUERYSECRET1234",
+    );
+    const redacted = redactMcpSecrets(
+      "401 for https://alice:pa%ssword@mcp.example.com/sse?api_key=QUERYSECRET1234",
+      s,
+    );
+    expect(redacted).not.toContain("QUERYSECRET1234");
+    expect(redacted).toContain(REDACTED_MCP_SECRET_VALUE);
+  });
+
+  it("collects nothing and does not throw for a genuinely unparseable URL", () => {
+    const s = server("not a url");
+    expect(collectMcpSecretValues(s)).toEqual([]);
   });
 });

--- a/src/utils/redact-mcp-secrets.ts
+++ b/src/utils/redact-mcp-secrets.ts
@@ -46,20 +46,36 @@ function addRecordValues(
   }
 }
 
+function safeDecodeURIComponent(value: string): string | undefined {
+  // `new URL()` accepts bare '%' characters in userinfo, but
+  // `decodeURIComponent()` throws URIError on a non-escape. Fall back to
+  // the raw value so collection can continue for the rest of the URL
+  // (query-string secrets in particular).
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return undefined;
+  }
+}
+
 function addUrlSecrets(values: Set<string>, rawUrl: string | undefined): void {
   if (!rawUrl) return;
+  let url: URL;
   try {
-    const url = new URL(rawUrl);
-    addValue(values, url.username);
-    addValue(values, url.password);
-    addValue(values, decodeURIComponent(url.username));
-    addValue(values, decodeURIComponent(url.password));
-    url.searchParams.forEach((value, name) => {
-      if (SECRETLIKE_PARAM_NAME.test(name)) addValue(values, value);
-    });
+    url = new URL(rawUrl);
   } catch {
     // Not a parseable URL — nothing to collect.
+    return;
   }
+  addValue(values, url.username);
+  addValue(values, url.password);
+  const decodedUsername = safeDecodeURIComponent(url.username);
+  if (decodedUsername !== undefined) addValue(values, decodedUsername);
+  const decodedPassword = safeDecodeURIComponent(url.password);
+  if (decodedPassword !== undefined) addValue(values, decodedPassword);
+  url.searchParams.forEach((value, name) => {
+    if (SECRETLIKE_PARAM_NAME.test(name)) addValue(values, value);
+  });
 }
 
 function addAuthSecrets(


### PR DESCRIPTION
Fixes #16978

## Summary

`addUrlSecrets()` in `src/utils/redact-mcp-secrets.ts` used a single try/catch wrapping the entire URL-parsing and secret-collection pass. When `decodeURIComponent()` encountered a bare `%` in the username or password it threw `URIError`, which aborted the pass before the `searchParams` loop ran, silently dropping every secret-looking query-string parameter (`api_key`, `token`, `secret`, `auth`).

## Reproduction

```ts
import { collectMcpSecretValues } from "#/utils/redact-mcp-secrets";
const s = { id: "s1", name: "s1", type: "sse", url: "https://alice:pa%ssword@mcp.example.com/sse?api_key=QUERYSECRET1234" } as any;
expect(collectMcpSecretValues(s)).toContain("QUERYSECRET1234");
```

Before this PR: assertion fails; the `?api_key=` value is silently dropped.

After this PR: assertion passes; `pa%ssword`, `alice`, and `QUERYSECRET1234` are all collected.

## Change

Extract URL parsing into its own try/catch so the collection can continue for the rest of the URL when only the decoded forms fail. Add a `safeDecodeURIComponent()` helper that returns `undefined` on `URIError`; the raw value is already collected, so the decoded form is best-effort.

## Tests

Added 6 regression cases under `collectMcpSecretValues, URL query-string secrets`:
- Bare `%` in password: query-string secret still collected
- Bare `%` in username: same
- Raw username/password still collected when decode fails
- End-to-end `redactMcpSecrets()` coverage
- Genuinely unparseable URL: no throw, empty collection
- Plain-password control case (regression guard)

## Risk

Very narrow. The narrow fix is to decode defensively: wrap each `decodeURIComponent()` so a failure contributes nothing instead of aborting the function. That keeps the collection order and the rest of the module untouched. The `catch` comment is updated to reflect the actual coverage ("Not a parseable URL"), matching the new control flow.