### PR TITLE
docs: correct OH_*_GIT_REF defaults in DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -48,11 +48,11 @@ it instead.
 
 ### Environment Variables
 
-| Variable                  | Description                    | Default |
-| ------------------------- | ------------------------------ | ------- |
-| `PORT`                    | Ingress port                   | `8000`  |
-| `OH_AUTOMATION_GIT_REF`   | Git ref for automation backend | `main`  |
-| `OH_AGENT_SERVER_GIT_REF` | Git ref for agent-server       | `main`  |
+| Variable                  | Description                                      | Default |
+| ------------------------- | ------------------------------------------------ | ------- |
+| `PORT`                    | Ingress port                                     | `8000`  |
+| `OH_AUTOMATION_GIT_REF`   | Git ref for automation backend (overrides pin)   | unset (`config/defaults.json`) |
+| `OH_AGENT_SERVER_GIT_REF` | Git ref for agent-server (overrides pin)         | unset (`config/defaults.json`) |
 
 ### Alternative: Minimal Mode (without Automation)
 
@@ -67,7 +67,7 @@ Access at `http://localhost:3001/`
 
 ### Agent server version selection
 
-By default, the latest released version from PyPI is used. You can override this (highest precedence first):
+By default, launchers pin the PyPI versions from [`config/defaults.json`](../config/defaults.json) (`versions.agentServer`, and `versions.automation` for the automation backend). You can override this (highest precedence first):
 
 ```sh
 # Run against a local software-agent-sdk checkout.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Verified on main that DEVELOPMENT.md still documents OH_*_GIT_REF defaults as `main` / latest PyPI, while config/defaults.json pins agentServer 1.44.1 and automation 1.9.1 and the launchers use those pins when the env vars are unset. Reviewed the one-file docs diff; no runtime code changed.

---

AGENT:

- `docs/DEVELOPMENT.md` claimed `OH_AUTOMATION_GIT_REF` / `OH_AGENT_SERVER_GIT_REF` default to `main`, and that the latest PyPI release is used by default.
- Launchers actually pin PyPI versions from `config/defaults.json` unless `*_GIT_REF` / `*_VERSION` / `*_LOCAL_PATH` is set.
- One-file docs fix only. Reviewer artifact: the PR diff.

Repro (GitHub API against `main`):

`docs/DEVELOPMENT.md` (before this PR):

```
| `OH_AUTOMATION_GIT_REF`   | Git ref for automation backend | `main`  |
| `OH_AGENT_SERVER_GIT_REF` | Git ref for agent-server       | `main`  |
```

```
By default, the latest released version from PyPI is used.
```

`config/defaults.json`:

```
"versions": {
  "agentServer": "1.44.1",
  "agentCanvas": "1.16.0",
  "automation": "1.9.1"
}
```

`scripts/dev-safe.mjs` / `scripts/dev-with-automation.mjs` use those pins when LOCAL_PATH / GIT_REF / VERSION are unset.

`git diff --check` on this commit: no errors.

## Why

The documented defaults (`main` / latest PyPI) do not match the launchers, which pin released versions from `config/defaults.json`. Contributors who omit the env vars will get those pins, not `main`.

## Summary

- Document that `OH_AUTOMATION_GIT_REF` and `OH_AGENT_SERVER_GIT_REF` are unset by default and override the `config/defaults.json` pins.
- Replace "latest released version from PyPI" with a pointer to `versions.agentServer` / `versions.automation` in `config/defaults.json`.

## Issue Number

Fixes #17065

## How to Test

1. On `main`, fetch `docs/DEVELOPMENT.md`, `config/defaults.json`, `scripts/dev-safe.mjs`, and `scripts/dev-with-automation.mjs` (e.g. `gh api repos/OpenHands/OpenHands/contents/...`).
2. Confirm the docs table still says default `main` and "latest released version from PyPI", while `config/defaults.json` pins `agentServer` `1.44.1` and `automation` `1.9.1` and the launchers use those pins when the env vars are unset.
3. Review this PR's `docs/DEVELOPMENT.md` diff and confirm it describes the pinned defaults without hardcoding version numbers.

## Video/Screenshots

Not applicable: documentation-only change. The [one-file diff](https://github.com/OpenHands/OpenHands/compare/main...fuergaosi233:docs/correct-git-ref-defaults) is the complete review surface.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Left out of this PR on purpose: VS Code sidecar port docs vs `package.json`, and the documented `.openhands-dev/` state dir vs `~/.openhands/agent-canvas/`.
