### PR TITLE
fix: list a cloud conversation own skills in show available skills

### DIFF
--- a/__tests__/api/cloud/skills-service.test.ts
+++ b/__tests__/api/cloud/skills-service.test.ts
@@ -80,3 +80,57 @@ describe("SkillsService.getSkills against cloud backend", () => {
     expect(skills[1]).toMatchObject({ triggers: ["foo"] });
   });
 });
+
+describe("SkillsService.getConversationSkills against cloud backend", () => {
+  it("reads the conversation's own skills route and maps entries to SkillInfo", async () => {
+    // Arrange
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        skills: [
+          {
+            name: "release-notes",
+            type: "agentskills",
+            content: "# Release notes",
+            triggers: ["/release-notes"],
+          },
+          {
+            name: "repo",
+            type: "repo",
+            content: "Repository instructions",
+            triggers: [],
+          },
+        ],
+      }),
+    );
+
+    // Act
+    const skills = await SkillsService.getConversationSkills("conv-1");
+
+    // Assert
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = getFetchCall(fetchMock, 0);
+    expect(url).toBe(
+      "https://app.all-hands.dev/api/v1/app-conversations/conv-1/skills",
+    );
+    expect(init).toMatchObject({
+      method: "GET",
+      headers: { Authorization: "Bearer bearer-token" },
+    });
+    expect(skills).toEqual([
+      {
+        name: "release-notes",
+        type: "agentskills",
+        content: "# Release notes",
+        triggers: ["/release-notes"],
+        source: null,
+      },
+      {
+        name: "repo",
+        type: "repo",
+        content: "Repository instructions",
+        triggers: [],
+        source: null,
+      },
+    ]);
+  });
+});

--- a/__tests__/hooks/query/use-conversation-skills.test.tsx
+++ b/__tests__/hooks/query/use-conversation-skills.test.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AgentServerConversationService from "#/api/conversation-service/agent-server-conversation-service.api";
+import SkillsService from "#/api/skills-service";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+import { NavigationProvider } from "#/context/navigation-context";
+import { ActiveBackendProvider } from "#/contexts/active-backend-context";
+import { useConversationSkills } from "#/hooks/query/use-conversation-skills";
+import type { SkillInfo } from "#/types/settings";
+
+const localBackend: Backend = {
+  id: "local-1",
+  name: "Local",
+  host: "http://localhost:8000",
+  apiKey: "session-key",
+  kind: "local",
+};
+
+const cloudBackend: Backend = {
+  id: "cloud-1",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "bearer-key",
+  kind: "cloud",
+};
+
+const CONVERSATION_ID = "conv-1";
+const WORKSPACE = "/workspace/project/demo";
+
+function makeConversation(
+  overrides: Partial<AppConversation> = {},
+): AppConversation {
+  return {
+    id: CONVERSATION_ID,
+    created_by_user_id: null,
+    selected_repository: null,
+    selected_branch: null,
+    git_provider: null,
+    title: "Test",
+    trigger: null,
+    pr_number: [],
+    llm_model: null,
+    metrics: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    execution_status: null,
+    sandbox_status: "RUNNING",
+    conversation_url: "https://sandbox.example.com/api",
+    session_api_key: null,
+    sandbox_id: null,
+    sub_conversation_ids: [],
+    selected_workspace: WORKSPACE,
+    ...overrides,
+  };
+}
+
+function makeSkill(name: string): SkillInfo {
+  return {
+    name,
+    type: "agentskills",
+    source: null,
+    content: `# ${name}`,
+    triggers: [],
+  };
+}
+
+function makeWrapper(conversationId: string | null) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ActiveBackendProvider>
+          <NavigationProvider
+            value={{
+              currentPath: "/",
+              conversationId,
+              isNavigating: false,
+              navigate: vi.fn(),
+            }}
+          >
+            {children}
+          </NavigationProvider>
+        </ActiveBackendProvider>
+      </QueryClientProvider>
+    );
+  }
+  return { wrapper: Wrapper, queryClient };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  setRegisteredBackends([localBackend, cloudBackend]);
+  // Mock the services the hook depends on, not the hooks themselves.
+  vi.spyOn(
+    AgentServerConversationService,
+    "batchGetAppConversations",
+  ).mockResolvedValue([makeConversation()]);
+  vi.spyOn(SkillsService, "getConversationSkills").mockResolvedValue([
+    makeSkill("release-notes"),
+  ]);
+  vi.spyOn(SkillsService, "getSkills").mockResolvedValue([
+    makeSkill("catalog-only"),
+  ]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+});
+
+describe("useConversationSkills", () => {
+  it("lists the conversation's own skills on a cloud backend once its sandbox runs", async () => {
+    // Arrange
+    setActiveSelection({ backendId: cloudBackend.id });
+    const { wrapper } = makeWrapper(CONVERSATION_ID);
+
+    // Act
+    const { result } = renderHook(() => useConversationSkills(), { wrapper });
+
+    // Assert
+    await waitFor(() =>
+      expect(result.current.data).toEqual([makeSkill("release-notes")]),
+    );
+    expect(SkillsService.getConversationSkills).toHaveBeenCalledWith(
+      CONVERSATION_ID,
+    );
+    expect(SkillsService.getSkills).not.toHaveBeenCalled();
+  });
+
+  it("does not request skills for a cloud conversation whose sandbox is not running yet", async () => {
+    // Arrange
+    setActiveSelection({ backendId: cloudBackend.id });
+    vi.mocked(
+      AgentServerConversationService.batchGetAppConversations,
+    ).mockResolvedValue([makeConversation({ sandbox_status: "STARTING" })]);
+    const { wrapper, queryClient } = makeWrapper(CONVERSATION_ID);
+
+    // Act
+    const { result } = renderHook(() => useConversationSkills(), { wrapper });
+
+    // Assert — even once the conversation itself has loaded.
+    await waitFor(() => {
+      const [entry] = queryClient.getQueriesData<AppConversation | null>({
+        queryKey: ["user", "conversation"],
+      });
+      expect(entry?.[1]?.sandbox_status).toBe("STARTING");
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(result.current.data).toBeUndefined();
+    expect(SkillsService.getConversationSkills).not.toHaveBeenCalled();
+    expect(SkillsService.getSkills).not.toHaveBeenCalled();
+  });
+
+  it("keeps the workspace-scoped catalog on a local backend", async () => {
+    // Arrange
+    setActiveSelection({ backendId: localBackend.id });
+    const { wrapper } = makeWrapper(CONVERSATION_ID);
+
+    // Act
+    const { result } = renderHook(() => useConversationSkills(), { wrapper });
+
+    // Assert
+    await waitFor(() =>
+      expect(SkillsService.getSkills).toHaveBeenCalledWith(WORKSPACE),
+    );
+    await waitFor(() =>
+      expect(result.current.data).toEqual([makeSkill("catalog-only")]),
+    );
+    expect(SkillsService.getConversationSkills).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the global catalog on a cloud backend without a conversation route", async () => {
+    // Arrange
+    setActiveSelection({ backendId: cloudBackend.id });
+    const { wrapper } = makeWrapper(null);
+
+    // Act
+    const { result } = renderHook(() => useConversationSkills(), { wrapper });
+
+    // Assert
+    await waitFor(() =>
+      expect(result.current.data).toEqual([makeSkill("catalog-only")]),
+    );
+    expect(SkillsService.getSkills).toHaveBeenCalledWith(undefined);
+    expect(SkillsService.getConversationSkills).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/cloud/skills-service.api.ts
+++ b/src/api/cloud/skills-service.api.ts
@@ -47,3 +47,37 @@ export async function fetchCloudSkills(): Promise<SkillInfo[]> {
 
   return skills;
 }
+
+interface CloudConversationSkill {
+  name: string;
+  type: SkillInfo["type"];
+  content: string;
+  triggers: string[];
+}
+
+interface CloudConversationSkillsResponse {
+  skills: CloudConversationSkill[];
+}
+
+/**
+ * Fetch the skills loaded into a running cloud conversation from the
+ * per-conversation route (the one the OpenHands web UI's own "Show Available
+ * Skills" modal uses). Unlike `/api/v1/skills/search`, which only scans the
+ * API host's built-in skills directory, this resolves the conversation's
+ * sandbox and asks its agent-server for the merged set: public catalog,
+ * user/org repos, project skills and auto-loaded marketplace plugins. The
+ * route reports no `source`, so it is `null`.
+ */
+export async function fetchCloudConversationSkills(
+  conversationId: string,
+): Promise<SkillInfo[]> {
+  const backend = getActiveCloudBackend();
+
+  const data = await callCloudProxy<CloudConversationSkillsResponse>({
+    backend,
+    method: "GET",
+    path: `/api/v1/app-conversations/${conversationId}/skills`,
+  });
+
+  return (data?.skills ?? []).map((skill) => ({ ...skill, source: null }));
+}

--- a/src/api/skills-service.ts
+++ b/src/api/skills-service.ts
@@ -6,7 +6,10 @@ import {
 import { SkillInfo } from "#/types/settings";
 import { getAgentServerWorkingDir } from "./agent-server-config";
 import { getActiveBackend } from "./backend-registry/active-store";
-import { fetchCloudSkills } from "./cloud/skills-service.api";
+import {
+  fetchCloudConversationSkills,
+  fetchCloudSkills,
+} from "./cloud/skills-service.api";
 import { getAgentServerClientOptions } from "./agent-server-client-options";
 
 function catalogEntryToSkillInfo(entry: SkillCatalogEntry): SkillInfo {
@@ -61,6 +64,16 @@ class SkillsService {
     }
 
     return [...localSkills, ...PUBLIC_SKILLS];
+  }
+
+  /**
+   * Skills loaded into a running cloud conversation (see
+   * `fetchCloudConversationSkills`). Cloud-only: local conversations keep
+   * using `getSkills(projectDir)`, whose agent-server call already scopes to
+   * the conversation's workspace.
+   */
+  static getConversationSkills(conversationId: string): Promise<SkillInfo[]> {
+    return fetchCloudConversationSkills(conversationId);
   }
 }
 

--- a/src/hooks/query/use-conversation-skills.ts
+++ b/src/hooks/query/use-conversation-skills.ts
@@ -1,13 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+import SkillsService from "#/api/skills-service";
+import { useActiveBackend } from "#/contexts/active-backend-context";
+import { useOptionalConversationId } from "#/hooks/use-conversation-id";
+import { SkillInfo } from "#/types/settings";
 import { useActiveConversation } from "./use-active-conversation";
-import { useSkills } from "./use-skills";
 
 /**
- * Skills catalog scoped to the active conversation's attached workspace, so
- * the slash-command menu and skills modal list the same project skills that
- * were loaded into the conversation. Falls back to the global workspace dir
- * for "No workspace" conversations (``selected_workspace`` is null).
+ * Skills catalog scoped to the active conversation, so the slash-command menu
+ * and skills modal list the same skills that were loaded into it.
+ *
+ * Cloud: the per-conversation route reports what the conversation's
+ * agent-server actually loaded (public catalog, user/org repos, project
+ * skills, auto-loaded marketplace plugins); the global `/api/v1/skills/search`
+ * catalog only scans the API host's built-in skills directory. The route needs
+ * a running sandbox, which `useActiveConversation` polls for.
+ *
+ * Local (and cloud with no conversation route, e.g. the home page): the
+ * workspace-scoped catalog, falling back to the global workspace dir for
+ * "No workspace" conversations (`selected_workspace` is null).
  */
 export const useConversationSkills = () => {
-  const conversation = useActiveConversation();
-  return useSkills(conversation.data?.selected_workspace ?? undefined);
+  const isCloud = useActiveBackend().backend.kind === "cloud";
+  const { conversationId } = useOptionalConversationId();
+  const { data: conversation } = useActiveConversation();
+  const projectDir = conversation?.selected_workspace ?? undefined;
+  // Keyed on the route id so a still-loading cloud conversation does not fall
+  // back to the global catalog; only a missing route does.
+  const cloudConversationId = isCloud ? conversationId : null;
+
+  return useQuery<SkillInfo[]>({
+    queryKey: cloudConversationId
+      ? ["conversation", cloudConversationId, "skills"]
+      : ["skills", projectDir ?? null],
+    queryFn: () =>
+      cloudConversationId
+        ? SkillsService.getConversationSkills(cloudConversationId)
+        : SkillsService.getSkills(projectDir),
+    // The cloud route 404s until the sandbox runs.
+    enabled: !cloudConversationId || conversation?.sandbox_status === "RUNNING",
+    staleTime: 1000 * 60 * 10, // 10 minutes – skill list rarely changes
+    refetchOnWindowFocus: false,
+  });
 };


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes.

---

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
Write a concise summary of what changed and link any reviewer artifacts, such
as files under `.pr/`. For HTML artifacts, include a rendered preview link:
https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/.pr/<file>.html
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc. -->

On a Cloud (OHE) backend, ⋯ → **Show Available Skills** listed only ~26 built-in OpenHands skills under "User skills", while the agent in the same conversation reported 73 (`<available_skills>`). The conversation itself was correct; only the listing was wrong.

Root cause: for cloud backends `SkillsService.getSkills()` fetched `GET /api/v1/skills/search`, which on the backend only scans the API pod's repo `skills/*.md` (27 files − README = 26) and `$HOME/.openhands/microagents` on the pod — no user context, no org/personal repos, no marketplaces, no public catalog. Its `source: "global"` is what mapped everything into the "User skills" section. The conversation-scoped route `GET /api/v1/app-conversations/{id}/skills` (what the OpenHands web UI's own modal uses) already returns what the conversation's sandbox agent-server loaded.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `src/api/cloud/skills-service.api.ts` / `src/api/skills-service.ts`: new `fetchCloudConversationSkills(conversationId)` → `GET /api/v1/app-conversations/{id}/skills`, mapped to `SkillInfo` (`source: null`), exposed as `SkillsService.getConversationSkills`. `fetchCloudSkills` / `getSkills` are unchanged (global Skills page, no-conversation case).
- `src/hooks/query/use-conversation-skills.ts`: owns its `useQuery`. Cloud + conversation route → key `["conversation", id, "skills"]`, `enabled` only when `sandbox_status === "RUNNING"`; otherwise byte-for-byte the previous `useSkills(projectDir)` behaviour. Keyed on the route id (`useOptionalConversationId`) so a still-loading cloud conversation does not fall back to the global catalog. Consumers (`skills-modal`, `use-slash-command`, `conversation-overview-skills-panel`) are untouched.
- Tests: `__tests__/api/cloud/skills-service.test.ts` (route contract + mapping) and new `__tests__/hooks/query/use-conversation-skills.test.tsx` (cloud RUNNING, cloud not-running, local, cloud without a route). Services are mocked, hooks are real.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Automated (run from `agent-server-gui/`):

```
npm run lint
# → typecheck (react-router typegen + tsc) clean, eslint 0 errors (3 pre-existing warnings in untouched files), prettier clean

npx vitest run \
  __tests__/hooks/query/use-conversation-skills.test.tsx \
  __tests__/api/cloud/skills-service.test.ts \
  __tests__/components/modals/skills/skill-modal.test.tsx \
  __tests__/components/features/conversation/conversation-overview-skills-panel.test.tsx \
  __tests__/hooks/chat/use-slash-command.test.ts
# → Test Files 5 passed (5), Tests 19 passed (19)
```

Manual, against a cloud backend (needs the companion `OpenHands/enterprise` change deployed for marketplace skills):

1. In the cloud UI, Settings → Skills & Plugins → **+ Add Repository** (Personal scope, Auto-Load on) pointing at a repo with a few skills; Save.
2. In the Canvas connected to that backend, start a conversation and wait until the sandbox is RUNNING.
3. ⋯ → **Show Available Skills**: the list now includes the public catalog, the personal-marketplace skills and any org/repo skills — the same set the agent reports when asked "which skills are enabled?".
4. Type `/` in the chat input: slash commands from those skills appear.
5. On the home page (no conversation) the `/` menu is unchanged (global catalog).
6. While the sandbox is still starting, the modal shows the empty state and no request is made; it populates once the sandbox is RUNNING. The refresh button re-fetches.

I could not run the manual steps: no cloud backend was reachable from the development session.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

N/A.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.44.1-python` |
| **Automation** | `openhands-automation==1.9.1` |
| **Commit** | `471abb4cdd236f626b61c562b7c828a0da39b54e` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-471abb4
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-471abb4
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-471abb4-amd64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3175-amd64
ghcr.io/openhands/agent-canvas:pr-17067-amd64
ghcr.io/openhands/agent-canvas:sha-471abb4-arm64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3175-arm64
ghcr.io/openhands/agent-canvas:pr-17067-arm64
ghcr.io/openhands/agent-canvas:sha-471abb4
ghcr.io/openhands/agent-canvas:hieptl-ohe-3175
ghcr.io/openhands/agent-canvas:pr-17067
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-471abb4`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-471abb4-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->