### PR TITLE
fix(frontend): prevent empty title mutation on whitespace-only rename (#17061)

### DIFF
--- a/__tests__/components/features/conversation/conversation-name.test.tsx
+++ b/__tests__/components/features/conversation/conversation-name.test.tsx
@@ -95,8 +95,7 @@ vi.mock("react-i18next", async () => {
           BUTTON$SHOW_AGENT_TOOLS_AND_METADATA: "Show Agent Tools",
           CONVERSATION$SHOW_SKILLS: "Show Skills",
           BUTTON$DISPLAY_COST: "Display Usage and Cost",
-          COMMON$CLOSE_CONVERSATION_STOP_RUNTIME:
-            "Stop Conversation (Runtime)",
+          COMMON$CLOSE_CONVERSATION_STOP_RUNTIME: "Stop Conversation (Runtime)",
           COMMON$STOP_CONVERSATION: "Stop Conversation",
           COMMON$DELETE_CONVERSATION: "Delete Conversation",
           CONVERSATION$SHARE_PUBLICLY: "Share Publicly",
@@ -237,6 +236,21 @@ describe("ConversationName", () => {
 
     // Verify that the API was NOT called
     expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("should reset input value when title is empty and blur", async () => {
+    const user = userEvent.setup();
+    renderConversationNameWithRouter();
+
+    const titleElement = screen.getByTestId("conversation-name-title");
+    await user.dblClick(titleElement);
+
+    const inputElement = screen.getByTestId("conversation-name-input");
+    await user.clear(inputElement);
+    await user.tab();
+
+    // Should reset to original title
+    expect(inputElement).toHaveValue("Test Conversation");
   });
 
   it("should reset input value when title is empty and blur", async () => {

--- a/src/components/features/conversation/conversation-name.tsx
+++ b/src/components/features/conversation/conversation-name.tsx
@@ -71,8 +71,8 @@ export function ConversationName() {
   };
 
   const handleBlur = () => {
-    if (inputRef.current?.value && conversationId) {
-      const trimmed = inputRef.current.value.trim();
+    const trimmed = inputRef.current?.value.trim();
+    if (trimmed && conversationId) {
       if (trimmed !== conversation?.title) {
         updateConversation(
           { conversationId, newTitle: trimmed },
@@ -84,7 +84,7 @@ export function ConversationName() {
         );
       }
     } else if (inputRef.current) {
-      // reset the value if it's empty
+      // reset the value if it's empty or whitespace-only
       inputRef.current.value = conversation?.title ?? "";
     }
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I tested this locally by running npx vitest run __tests__/components/features/conversation/conversation-name.test.tsx with all 29 tests passing and verified npm run lint.

---

AGENT:

## Why

In `conversation-name.tsx`, `handleBlur` previously evaluated `if (inputRef.current?.value && conversationId)` before trimming. A whitespace-only input evaluated to truthy, causing `trimmed` to become `""` and invoking `updateConversation` with an empty title instead of falling back to resetting the title.

## Summary

- Trim input value before verifying title truthiness in `handleBlur`.
- Fall back to resetting the input value to `conversation?.title` when the trimmed string is empty.
- Preserve existing behavior where non-empty titles with surrounding whitespace are trimmed and saved.
- Add regression test in `__tests__/components/features/conversation/conversation-name.test.tsx`.

## Issue Number

Fixes #17061

## How to Test

1. Run `npx vitest run __tests__/components/features/conversation/conversation-name.test.tsx`.
2. In the UI, double-click the conversation title in the chat header, replace it with spaces, and blur the field. The title should revert to the previous name without triggering a mutation.

## Video/Screenshots

<img width="1609" height="129" alt="Screenshot (1225)" src="https://github.com/user-attachments/assets/6c692fc8-27f2-4065-8994-15f41aad203a" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

None.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.39s · commit bda24ec  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 4/4 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 2.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 7.0% | No direct hunk selected |
| Data loss | 5.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 89.0% | No primary concern to locate |

</details>


<!-- jev-input-signature f37dd4b5026ba95caf27e05cca43ef9b601a6bf76984eb077629418deb2b695f -->
<!-- jev-fast-audit:end -->
