### PR TITLE
docs: correct stale comments in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 # OpenHands Agent Server target
 # These defaults assume you are manually pointing the frontend at a backend on
 # 127.0.0.1:8000. The recommended local workflow is `npm run dev`, which starts
-# an isolated local backend for this checkout. Use `npm run dev:frontend` only
+# a local agent-server + automation stack for this checkout. Use `npm run dev:frontend` only
 # when you intentionally want to point at a separately managed backend.
 VITE_BACKEND_HOST="127.0.0.1:8000" # Host:port used by the Vite dev proxy
 VITE_BACKEND_BASE_URL="http://127.0.0.1:8000" # Base URL used by browser-side direct requests
@@ -9,7 +9,7 @@ VITE_BACKEND_BASE_URL="http://127.0.0.1:8000" # Base URL used by browser-side di
 # e.g. VITE_BACKEND_BASE_URL="http://localhost:8010" — see examples/acp-docker/
 # and docs/ACP_AGENTS.md → "Running ACP agents in a Docker container".
 # VITE_SESSION_API_KEY="" # Set to the same value as backend SESSION_API_KEY or OH_SESSION_API_KEYS_0 when auth is enabled
-# VITE_WORKING_DIR="/workspace/project/agent-canvas" # Base dir for per-conversation working_dirs. Each conversation's working_dir is <VITE_WORKING_DIR>/<id_hex>. Defaults to <OH_CANVAS_SAFE_STATE_DIR>/workspaces, which is the sibling of the agent server's <state_dir>/conversations/ persistence dir — both share the same <id_hex> per conversation.
+# VITE_WORKING_DIR="/workspace/project/agent-canvas" # Base dir for per-conversation working_dirs. Each conversation's working_dir is <VITE_WORKING_DIR>/<id_hex>. Defaults to <OH_CANVAS_SAFE_STATE_DIR>/workspaces, which is the sibling of the agent server's <state_dir>/dev_conversations persistence dir — both share the same <id_hex> per conversation.
 # VITE_ENABLE_BROWSER_TOOLS="true" # Set to false to omit BrowserToolSet from new conversations
 
 # Frontend dev server
@@ -26,12 +26,12 @@ VITE_INSECURE_SKIP_VERIFY="false" # Skip TLS certificate verification for proxie
 # Mocking / test helpers
 VITE_MOCK_API="false" # Enable/disable API mocking with MSW
 
-# `npm run dev` (scripts/dev-safe.mjs) — isolated local backend via uvx
+# `npm run dev` (scripts/dev-with-automation.mjs) — full local stack via uvx; dev:minimal uses scripts/dev-safe.mjs
 # OH_CANVAS_SAFE_BACKEND_PORT="18000" # Port the spawned agent-server listens on
-# OH_CANVAS_SAFE_VSCODE_PORT="18001" # Port forwarded to the embedded VS Code (defaults to backend port + 1)
-# OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas" # Where conversations and bash events are stored (tmux sockets live under /tmp)
+# OH_CANVAS_SAFE_VSCODE_PORT="18001" # dev:minimal default is backend+1 (18001); full-dev uses backend+1000 (19000) so it does not collide with automation on 18001
+# OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas" # Conversations (dev_conversations/), workspaces, bash events, and tmux sockets (tmux/) live here
 
 # Agent server version selection (uvx) — listed in order of precedence (highest first)
 # OH_AGENT_SERVER_LOCAL_PATH="" # Absolute path to a local software-agent-sdk checkout. Runs the local checkout via uvx with editable openhands-sdk/tools/workspace installs so source edits are picked up on restart. Highest precedence.
 # OH_AGENT_SERVER_GIT_REF="" # Git commit SHA or branch name (e.g., "main", "abc1234"). Takes precedence over version.
-# OH_AGENT_SERVER_VERSION="" # Specific PyPI version (e.g., "1.18.0"). Uses latest release if unset.
+# OH_AGENT_SERVER_VERSION="" # Specific PyPI version (e.g., "1.44.1"). If unset, uses the pin in config/defaults.json (versions.agentServer).


### PR DESCRIPTION
HUMAN:

Checked .env.sample comments against package.json, config/defaults.json, and the local launchers on current main.

---

AGENT:

Comment-only updates to .env.sample so the sample matches the launchers and config/defaults.json on current main. No launcher behavior change.

## Why

`.env.sample` still describes an older local workflow: `npm run dev` as scripts/dev-safe.mjs, OH_AGENT_SERVER_VERSION as 1.18.0 / latest PyPI, tmux sockets under /tmp, VS Code at backend+1, and conversations under conversations/. Those comments no longer match package.json, config/defaults.json, scripts/dev-safe.mjs, or scripts/dev-with-automation.mjs.

## Summary

- Document `npm run dev` as scripts/dev-with-automation.mjs and dev:minimal as scripts/dev-safe.mjs.
- Document unset OH_AGENT_SERVER_VERSION as the config/defaults.json versions.agentServer pin (example 1.44.1), not latest PyPI.
- Document tmux sockets under ~/.openhands/agent-canvas/tmux, conversations as dev_conversations, and VS Code as backend+1 for dev:minimal vs backend+1000 for full-dev.

## Issue Number
Fixes #17069

## How to Test

Docs-only comment change. No runtime behavior to exercise.

1. Diff .env.sample against main.
2. Confirm package.json: `npm run dev` -> scripts/dev-with-automation.mjs; `npm run dev:minimal` -> scripts/dev-safe.mjs.
3. Confirm config/defaults.json versions.agentServer is 1.44.1 and ports.automation is 18001.
4. Confirm scripts/dev-safe.mjs: tmuxTmpDir defaults to stateDir/tmux; conversationsPath is stateDir/dev_conversations; vscodePort defaults to backendPort+1; unset OH_AGENT_SERVER_VERSION uses DEFAULT_AGENT_SERVER_VERSION.
5. Confirm scripts/dev-with-automation.mjs sets vscodePort to preferredBackendPort+1000.

## Video/Screenshots

N/A — comment-only change to .env.sample; no UI or runtime behavior change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Comment-only. Did not change docs/DEVELOPMENT.md. Did not change AGENTS.md.
