### PR TITLE
fix(utils): correctly count diff stats for hunk lines starting with -- or ++ (#16979)

### DIFF
--- a/__tests__/utils/git-diff-stats.test.ts
+++ b/__tests__/utils/git-diff-stats.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  countGitChangeDiffStats,
+  countUnifiedDiffStats,
+} from "#/utils/git-diff-stats";
+
+describe("git-diff-stats", () => {
+  it("counts hunk lines whose content starts with -- or ++", () => {
+    const diff = [
+      "--- a/file.txt",
+      "+++ b/file.txt",
+      "@@ -1,3 +1,3 @@",
+      " keep this line",
+      "-normal deleted line",
+      "--- a deleted line that starts with two dashes",
+      "+normal added line",
+      "+++ an added line that starts with two pluses",
+    ].join("\n");
+
+    expect(countUnifiedDiffStats(diff)).toEqual({
+      additions: 2,
+      deletions: 2,
+    });
+  });
+
+  it("handles multi-file diffs without counting subsequent file headers", () => {
+    const multiDiff = [
+      "diff --git a/file1.txt b/file1.txt",
+      "--- a/file1.txt",
+      "+++ b/file1.txt",
+      "@@ -1,1 +1,1 @@",
+      "-old1",
+      "+new1",
+      "diff --git a/file2.txt b/file2.txt",
+      "--- a/file2.txt",
+      "+++ b/file2.txt",
+      "@@ -1,1 +1,1 @@",
+      "-old2",
+      "+new2",
+    ].join("\n");
+
+    expect(countUnifiedDiffStats(multiDiff)).toEqual({
+      additions: 2,
+      deletions: 2,
+    });
+  });
+
+  it("integrates with countGitChangeDiffStats", () => {
+    const diff = [
+      "@@ -1,3 +1,3 @@",
+      " keep this line",
+      "-normal deleted line",
+      "--- a deleted line that starts with two dashes",
+      "+normal added line",
+      "+++ an added line that starts with two pluses",
+    ].join("\n");
+
+    expect(countGitChangeDiffStats({ diff } as never)).toEqual({
+      additions: 2,
+      deletions: 2,
+    });
+  });
+});

--- a/src/utils/git-diff-stats.ts
+++ b/src/utils/git-diff-stats.ts
@@ -5,22 +5,37 @@ export interface GitDiffLineStats {
   deletions: number;
 }
 
-function countUnifiedDiffStats(diff: string): GitDiffLineStats {
+export function countUnifiedDiffStats(diff: string): {
+  additions: number;
+  deletions: number;
+} {
   let additions = 0;
   let deletions = 0;
+  let inHunk = false;
 
   for (const line of diff.split("\n")) {
-    if (
-      line.startsWith("+++") ||
-      line.startsWith("---") ||
-      line.startsWith("@@")
-    ) {
+    if (line.startsWith("diff --git") || line.startsWith("index ")) {
+      inHunk = false;
       continue;
     }
-    if (line.startsWith("+")) {
-      additions += 1;
-    } else if (line.startsWith("-")) {
-      deletions += 1;
+
+    if (line.startsWith("@@")) {
+      inHunk = true;
+      continue;
+    }
+
+    if (!inHunk) {
+      if (line.startsWith("---") || line.startsWith("+++")) {
+        continue;
+      }
+    }
+
+    if (inHunk) {
+      if (line.startsWith("+")) {
+        additions += 1;
+      } else if (line.startsWith("-")) {
+        deletions += 1;
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I tested this locally by adding a new test suite in __tests__/utils/git-diff-stats.test.ts covering lines starting with -- and ++, multi-file diffs, and countGitChangeDiffStats integration. I ran npx vitest run __tests__/utils/git-diff-stats.test.ts with all 3 tests passing and ran npm run lint.

---

AGENT:

## Why

`countUnifiedDiffStats()` previously skipped any line starting with `+++`, `---`, or `@@` globally across the entire diff. Inside a hunk body, deleted lines starting with `--` (such as SQL/Lua comments, decrement operators, or CLI flags) produce lines starting with `---`, and added lines starting with `++` produce `+++`. These were erroneously treated as file headers and omitted from the diff stats count.

## Summary

- Track hunk state (`inHunk`) so `---` and `+++` are only ignored when processing file headers before the first `@@` hunk header.
- Reset `inHunk` state upon encountering `diff --git` or `index ` boundaries for multi-file diffs.
- Add comprehensive test coverage in `__tests__/utils/git-diff-stats.test.ts` for unified diff stat counting.

## Issue Number

Fixes #16979

## How to Test

1. Run `npx vitest run __tests__/utils/git-diff-stats.test.ts` to verify all test cases pass.

## Video/Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d9bc403e-b43d-43cb-b0f4-86e1ab1f06c5" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

None.