### PR TITLE
Refactor handleBlur logic in conversation-name.tsx

### DIFF
--- a/src/components/features/conversation/conversation-name.tsx
+++ b/src/components/features/conversation/conversation-name.tsx
@@ -70,24 +70,25 @@ export function ConversationName() {
     setTitleMode("edit");
   };
 
-  const handleBlur = () => {
-    if (inputRef.current?.value && conversationId) {
+    const handleBlur = () => {
+    if (inputRef.current && conversationId) {
       const trimmed = inputRef.current.value.trim();
-      if (trimmed !== conversation?.title) {
-        updateConversation(
-          { conversationId, newTitle: trimmed },
-          {
-            onSuccess: () => {
-              displaySuccessToast(t(I18nKey.CONVERSATION$TITLE_UPDATED));
+      if (trimmed) {
+        if (trimmed !== conversation?.title) {
+          updateConversation(
+            { conversationId, newTitle: trimmed },
+            {
+              onSuccess: () => {
+                displaySuccessToast(t(I18nKey.CONVERSATION$TITLE_UPDATED));
+              },
             },
-          },
-        );
+          );
+        }
+      } else {
+        // reset the value if it's empty or only whitespace
+        inputRef.current.value = conversation?.title ?? "";
       }
-    } else if (inputRef.current) {
-      // reset the value if it's empty
-      inputRef.current.value = conversation?.title ?? "";
     }
-
     setTitleMode("view");
   };
 


### PR DESCRIPTION
### Title
Fix: whitespace-only conversation titles bypass the empty-value check in `handleBlur`

### Description

**Bug:** In `src/components/features/conversation/conversation-name.tsx`, `handleBlur` checks the raw, untrimmed input value for truthiness before deciding whether to save or reset:

```ts
if (inputRef.current?.value && conversationId) {
  const trimmed = inputRef.current.value.trim();
  ...
```

A whitespace-only value (e.g. a single space) is truthy in JavaScript, so it takes the save branch. `trimmed` then becomes `""`, and `updateConversation` is called with `newTitle: ""`, blanking the header. The reset branch (`else if (inputRef.current)`), which exists specifically to handle an empty field, never runs for this case because the branch decision was made on the untrimmed value.

The sidebar rename path (`conversation-card-title.tsx` / `conversation-card.tsx`) already trims before checking for emptiness, so this only affects the header rename path.

**Fix:** Trim the value first, then branch on the trimmed result — matching the sidebar's existing behavior.

**Also checked:** `handleKeyUp` in the same file only calls `.blur()` on Enter (routing back through `handleBlur`), so there's no separate untrimmed check elsewhere in this file that needs the same fix.

### Steps to reproduce (from the original report)
1. Open a conversation with a title
2. Double-click the title in the chat header to enter edit mode
3. Select all, type a single space
4. Click elsewhere to blur the field
5. **Before fix:** header goes blank, empty title sent to the update mutation
6. **After fix:** input resets to the original title, nothing is sent

### Test
The existing test `should reset input value when title is only whitespace and blur` in `__tests__/components/features/conversation/conversation-name.test.tsx` should now pass with this change.

### AI assistance disclosure
Root cause was traced with AI-assisted code investigation (Meeba Brain). The diagnosis and suggested fix were reviewed against the actual source file, the fix was diffed line-by-line against the original to confirm the change is scoped to exactly `handleBlur` with no unintended edits elsewhere, and the reasoning above (including the `handleKeyUp` check) was independently verified before submitting.