### PR TITLE
docs: specify OpenHands Enterprise sandbox images

### DIFF
--- a/docs/superpowers/plans/2026-09-01-enterprise-sandbox-production-image.md
+++ b/docs/superpowers/plans/2026-09-01-enterprise-sandbox-production-image.md
@@ -1,0 +1,357 @@
+# Enterprise Sandbox Production Image Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Enterprise-compatible sandbox image and a separated local control-plane/sandbox Docker topology without changing product behavior.
+
+**Architecture:** Refactor the existing Dockerfile into named targets built from one pinned Agent Server base. Enterprise and local sandbox targets preserve the upstream entrypoint; the control-plane target reuses the local orchestration script in explicit external-Agent-Server mode, while the all-in-one target remains the compatibility default.
+
+**Tech Stack:** Docker BuildKit, Docker Compose, Bash, Node.js ESM, Vitest, GitHub Actions, OpenHands Agent Server and Automation.
+
+---
+
+## File map
+
+- `docker/Dockerfile`: shared runtime, sandbox, control-plane, and legacy targets.
+- `docker/entrypoint.sh`: local control-plane and legacy orchestration only.
+- `docker/compose.yml`: separated local topology and directional URLs.
+- `scripts/docker-build.mjs`: deterministic target/image/platform selection.
+- `scripts/docker-dev.mjs`: one-command Compose startup and secret injection.
+- `config/defaults.json`: image/version/port source of truth.
+- `__tests__/scripts/docker-image-contract.test.ts`: Docker and workflow boundaries.
+- `__tests__/scripts/docker-build.test.ts`: build-helper behavior.
+- `__tests__/scripts/docker-separated-topology.test.ts`: entrypoint and Compose wiring.
+- `.github/workflows/docker.yml`: Enterprise amd64 build/publication.
+- `docs/SELF_HOSTING.md`, `AGENTS.md`: operator and repository contracts.
+
+### Task 1: Establish Docker target contracts
+
+**Files:**
+- Create: `__tests__/scripts/docker-image-contract.test.ts`
+- Modify: `docker/Dockerfile`
+
+- [ ] **Step 1: Write the failing target test**
+
+Read `docker/Dockerfile`, parse `FROM ... AS ...` stages, and assert:
+
+```ts
+expect(stages).toEqual(expect.arrayContaining([
+  "agent-runtime-base", "enterprise-sandbox", "dev-sandbox",
+  "control-plane-runtime", "control-plane", "final",
+]));
+expect(stageParent("enterprise-sandbox")).toBe("agent-runtime-base");
+expect(stageParent("dev-sandbox")).toBe("agent-runtime-base");
+expect(stageBody("enterprise-sandbox"))
+  .not.toMatch(/ENTRYPOINT|CMD|frontend|automation|entrypoint\.sh/i);
+expect(lastStage()).toBe("final");
+expect(stageBody("final")).toContain("ENTRYPOINT");
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run `npx vitest run __tests__/scripts/docker-image-contract.test.ts`.
+Expected: FAIL because the targets do not exist.
+
+- [ ] **Step 3: Add the minimal build graph**
+
+Reshape the Dockerfile around:
+
+```dockerfile
+FROM ${AGENT_SERVER_IMAGE} AS agent-runtime-base
+ARG AGENT_CANVAS_VERSION=dev
+ARG AGENT_SERVER_VERSION=unknown
+ARG OPENHANDS_BUILD_GIT_SHA=unknown
+ARG OPENHANDS_BUILD_GIT_REF=unknown
+LABEL org.opencontainers.image.source="https://github.com/OpenHands/OpenHands" \
+      org.opencontainers.image.version="${AGENT_CANVAS_VERSION}" \
+      org.opencontainers.image.revision="${OPENHANDS_BUILD_GIT_SHA}" \
+      dev.openhands.agent-server.version="${AGENT_SERVER_VERSION}"
+
+FROM agent-runtime-base AS enterprise-sandbox
+LABEL org.opencontainers.image.title="agent-canvas-enterprise-sandbox"
+
+FROM agent-runtime-base AS dev-sandbox
+LABEL org.opencontainers.image.title="agent-canvas-dev-sandbox"
+
+FROM agent-runtime-base AS control-plane-runtime
+# Existing Automation/frontend/defaults installation and copies.
+
+FROM control-plane-runtime AS control-plane
+ENV AGENT_CANVAS_AGENT_SERVER_MODE=external
+ENTRYPOINT ["tini", "--", "/opt/agent-canvas/entrypoint.sh"]
+
+FROM control-plane-runtime AS final
+ENV AGENT_CANVAS_AGENT_SERVER_MODE=embedded
+ENTRYPOINT ["tini", "--", "/opt/agent-canvas/entrypoint.sh"]
+```
+
+Do not add `ENTRYPOINT` or `CMD` to the shared or sandbox targets. Keep `final`
+last so unqualified builds retain existing behavior.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run the focused test, then commit:
+
+```bash
+git add docker/Dockerfile __tests__/scripts/docker-image-contract.test.ts
+git commit -m "build: add enterprise sandbox docker target"
+```
+
+### Task 2: Make local Docker builds target-aware
+
+**Files:**
+- Create: `__tests__/scripts/docker-build.test.ts`
+- Modify: `scripts/docker-build.mjs`
+- Modify: `config/defaults.json`
+- Modify: `package.json`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Require import-safe `parseArgs()` and `buildDockerCommand()` helpers:
+
+```ts
+expect(parseArgs([]).target).toBe("final");
+expect(parseArgs(["--enterprise"]).target).toBe("enterprise-sandbox");
+expect(parseArgs(["--enterprise"]).platform).toBe("linux/amd64");
+expect(parseArgs(["--enterprise"]).tag).toBe(
+  `agent-canvas-enterprise-sandbox:${canvasVersion}-agent-server-${agentServerVersion}`,
+);
+expect(buildDockerCommand(parseArgs(["--enterprise"])))
+  .toEqual(expect.arrayContaining(["--target", "enterprise-sandbox", "--platform", "linux/amd64"]));
+```
+
+Cover `--agent-server-image`, `--tag`, `--platform`, and passthrough arguments.
+Reject unknown targets and non-amd64 Enterprise builds.
+
+- [ ] **Step 2: Verify RED**
+
+Run `npx vitest run __tests__/scripts/docker-build.test.ts`.
+Expected: FAIL because the script is not import-safe or target-aware.
+
+- [ ] **Step 3: Implement deterministic build selection**
+
+Every command must include the selected target/platform and these build args:
+
+```js
+`AGENT_SERVER_IMAGE=${options.agentServerImage}`
+`AGENT_SERVER_VERSION=${options.agentServerVersion}`
+`AUTOMATION_VERSION=${config.versions.automation}`
+`AGENT_CANVAS_VERSION=${packageJson.version}`
+```
+
+Add `images.enterpriseSandbox` to `config/defaults.json`, an ESM main guard, and:
+
+```json
+"build:docker:enterprise": "node scripts/docker-build.mjs --enterprise",
+"build:docker:control-plane": "node scripts/docker-build.mjs --target control-plane"
+```
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run both Docker contract tests, then commit the four changed files with
+`build: add target-aware docker commands`.
+
+### Task 3: Support an external sandbox service
+
+**Files:**
+- Create: `__tests__/scripts/docker-separated-topology.test.ts`
+- Modify: `docker/entrypoint.sh`
+- Modify: `__tests__/scripts/docker-vscode-route-sync.test.ts`
+
+- [ ] **Step 1: Write failing executable topology tests**
+
+Extract a marked `# >>> agent-server-topology` shell block and assert:
+
+```ts
+expect(resolve({ AGENT_CANVAS_AGENT_SERVER_MODE: "embedded" }).proxyUrl)
+  .toBe("http://127.0.0.1:18000");
+expect(resolve({
+  AGENT_CANVAS_AGENT_SERVER_MODE: "external",
+  AGENT_SERVER_URL: "http://agent-server:8000",
+  VSCODE_HOST: "agent-server",
+}).proxyUrl).toBe("http://agent-server:8000");
+expect(resolve({ AGENT_CANVAS_AGENT_SERVER_MODE: "external" }).status)
+  .not.toBe(0);
+```
+
+Also assert that external mode cannot start `openhands-agent-server`, proxy
+routes use `AGENT_SERVER_PROXY_URL`, and the editor route uses `VSCODE_HOST`.
+
+- [ ] **Step 2: Verify RED**
+
+Run `npx vitest run __tests__/scripts/docker-separated-topology.test.ts`.
+Expected: FAIL because no topology mode exists.
+
+- [ ] **Step 3: Implement explicit topology resolution**
+
+Resolve exactly once:
+
+```bash
+AGENT_CANVAS_AGENT_SERVER_MODE="${AGENT_CANVAS_AGENT_SERVER_MODE:-embedded}"
+case "$AGENT_CANVAS_AGENT_SERVER_MODE" in
+  embedded)
+    AGENT_SERVER_PROXY_URL="${AGENT_SERVER_URL:-http://127.0.0.1:${AGENT_SERVER_PORT}}"
+    VSCODE_HOST="${VSCODE_HOST:-127.0.0.1}"
+    ;;
+  external)
+    : "${AGENT_SERVER_URL:?AGENT_SERVER_URL is required in external mode}"
+    AGENT_SERVER_PROXY_URL="$AGENT_SERVER_URL"
+    VSCODE_HOST="${VSCODE_HOST:-agent-server}"
+    ;;
+  *) log_error "Unsupported AGENT_CANVAS_AGENT_SERVER_MODE"; exit 1 ;;
+esac
+```
+
+Embedded mode preserves current secret generation and Agent Server startup.
+External mode skips both, waits on the explicit health URL with a bounded Node
+`fetch()` loop, and defaults `AUTOMATION_AGENT_SERVER_URL` to the proxy URL.
+All proxy routes use the explicit URL. Runtime metadata uses
+`SANDBOX_AGENT_SERVER_URL` for the agent self-view and `AUTOMATION_BASE_URL` for
+the sandbox-to-control-plane view.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run the new topology test plus `docker-vscode-route-sync.test.ts`, then commit
+with `feat: support an external sandbox service`.
+
+### Task 4: Add the separated one-command stack
+
+**Files:**
+- Create: `docker/compose.yml`
+- Create: `scripts/docker-dev.mjs`
+- Modify: `__tests__/scripts/docker-separated-topology.test.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Extend tests and confirm RED**
+
+Require Compose services/targets and explicit directional URLs:
+
+```ts
+expect(compose).toContain("target: control-plane");
+expect(compose).toContain("target: dev-sandbox");
+expect(compose).toContain("AGENT_SERVER_URL: http://agent-server:8000");
+expect(compose).toContain("AUTOMATION_BASE_URL: http://control-plane:8000");
+expect(compose).toContain("SANDBOX_AGENT_SERVER_URL: http://localhost:8000");
+```
+
+Require `buildComposeCommand()` to inject non-empty session/encryption secrets
+through the child environment, never command arguments or committed defaults.
+Run the topology test and observe the expected missing-file/export failure.
+
+- [ ] **Step 2: Implement Compose and launcher**
+
+Compose builds `control-plane` and `dev-sandbox`, uses one private network,
+publishes only the control-plane port, mounts project/state volumes, requires
+`${LOCAL_BACKEND_API_KEY:?}` and `${OH_SECRET_KEY:?}`, and waits for sandbox
+health. The import-safe launcher uses `randomBytes(32).toString("hex")` for
+missing values and invokes:
+
+```js
+["docker", "compose", "-f", "docker/compose.yml", "up", "--build", ...args]
+```
+
+Add `"dev:docker:separated": "node scripts/docker-dev.mjs"`.
+
+- [ ] **Step 3: Verify GREEN and commit**
+
+Run:
+
+```bash
+npx vitest run __tests__/scripts/docker-separated-topology.test.ts
+env LOCAL_BACKEND_API_KEY=test-session-key OH_SECRET_KEY=test-secret-key docker compose -f docker/compose.yml config --quiet
+```
+
+Commit with `feat: add separated docker development stack`.
+
+### Task 5: Publish and document the Enterprise image
+
+**Files:**
+- Modify: `.github/workflows/docker.yml`
+- Modify: `docs/SELF_HOSTING.md`
+- Modify: `AGENTS.md`
+- Modify: `__tests__/scripts/docker-image-contract.test.ts`
+
+- [ ] **Step 1: Add failing workflow/documentation assertions**
+
+```ts
+expect(workflow).toContain("target: enterprise-sandbox");
+expect(workflow).toContain("platforms: linux/amd64");
+expect(workflow).toContain("agent-canvas-enterprise-sandbox");
+expect(selfHosting).toContain("OpenHands Enterprise sandbox image");
+expect(selfHosting).toContain("Sandbox Image Tag");
+```
+
+Run the contract test and confirm these assertions fail.
+
+- [ ] **Step 2: Add the Enterprise workflow job**
+
+Add an `enterprise_image` workflow input and an amd64 job that uses
+`docker/build-push-action` with `target: enterprise-sandbox`, explicit Agent
+Server/Canvas versions, SHA/PR tags, and stable
+`<canvas-version>-agent-server-<agent-server-version>` tags. Never publish an
+Enterprise `latest` tag. Inspect the result against the upstream effective
+entrypoint and command.
+
+- [ ] **Step 3: Document operation and repository contracts**
+
+Document `npm run build:docker:enterprise`, `npm run dev:docker:separated`,
+amd64, exact Enterprise version matching, registry push, Admin Console Sandbox
+Image fields, secrets, and the retained legacy path. Update `AGENTS.md` with the
+new Docker topology source of truth.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+Run all three focused Docker tests and commit with
+`ci: publish enterprise sandbox images`.
+
+### Task 6: Complete verification
+
+**Files:** Modify only when a verification failure identifies a defect.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+npx vitest run __tests__/scripts/docker-image-contract.test.ts __tests__/scripts/docker-build.test.ts __tests__/scripts/docker-separated-topology.test.ts __tests__/scripts/docker-vscode-route-sync.test.ts
+```
+
+- [ ] **Step 2: Build and inspect the amd64 Enterprise image**
+
+```bash
+npm run build:docker:enterprise -- --load
+docker image inspect ghcr.io/openhands/agent-server:1.44.1-python --format '{{json .Config.Entrypoint}} {{json .Config.Cmd}}'
+docker image inspect agent-canvas-enterprise-sandbox:1.16.0-agent-server-1.44.1 --format '{{json .Config.Entrypoint}} {{json .Config.Cmd}} {{.Architecture}}'
+```
+
+Expected: upstream and custom entrypoint/command match exactly; architecture is
+`amd64`.
+
+- [ ] **Step 3: Smoke-test the separated stack**
+
+```bash
+npm run dev:docker:separated -- --detach
+curl --fail http://127.0.0.1:8000/alive
+docker compose -f docker/compose.yml ps
+docker compose -f docker/compose.yml down
+```
+
+Expected: both services are healthy and shutdown succeeds.
+
+- [ ] **Step 4: Run repository gates**
+
+```bash
+npm run lint
+npm test
+npm run build
+npm run build:lib
+```
+
+- [ ] **Step 5: Audit the branch delta**
+
+```bash
+git diff upstream/main...HEAD --check
+git status --short
+git log --oneline upstream/main..HEAD
+```
+
+Expected: no whitespace errors, untracked implementation artifacts, or
+unplanned changes.

--- a/docs/superpowers/specs/2026-09-01-enterprise-sandbox-production-image-design.md
+++ b/docs/superpowers/specs/2026-09-01-enterprise-sandbox-production-image-design.md
@@ -1,0 +1,439 @@
+# Enterprise Sandbox Production Image Design
+
+**Status:** Approved design, pending implementation plan
+
+**Date:** 2026-09-01
+
+**Repository:** `OpenHands/OpenHands` (Agent Canvas)
+**Scope:** Docker packaging, local container topology, build/release automation, and operator documentation
+
+## Summary
+
+Agent Canvas currently publishes an all-in-one Docker image that starts the Agent
+Server, Automation backend, static Canvas frontend, and ingress proxy in one
+container. OpenHands Enterprise runs those responsibilities in a different
+topology: its control plane manages isolated sandbox pods, and each sandbox pod
+runs the standard OpenHands Agent Server contract.
+
+This change introduces a production-grade custom sandbox image for OpenHands
+Enterprise and a separated local container topology. The Enterprise image will
+extend the exact Agent Server image expected by the target Enterprise release,
+add only sandbox-relevant tools and dependencies, and preserve the upstream
+entrypoint and command without modification. Local container development will
+run the Canvas/Automation/proxy control plane separately from a sandbox
+container built from the same shared runtime layer.
+
+The existing product behavior is unchanged. This is a deployment-boundary
+change only: the local control plane reaches the Agent Server through a service
+hostname and port instead of `127.0.0.1` in the same container.
+
+## Goals
+
+1. Produce an OpenHands Enterprise-compatible sandbox image from this
+   repository.
+2. Preserve the upstream Agent Server runtime contract, including its
+   `ENTRYPOINT` and `CMD`.
+3. Share the sandbox runtime layer between local container development and the
+   Enterprise production image.
+4. Separate the local containerized control plane from the sandbox so local
+   networking, environment injection, and failure boundaries more closely
+   resemble Enterprise.
+5. Keep the existing one-command local workflow available through a launcher or
+   Compose orchestration layer.
+6. Keep the current all-in-one image available as a legacy compatibility target
+   during the first migration PR.
+7. Build, inspect, test, and publish the Enterprise image reproducibly for
+   `linux/amd64`.
+
+## Non-goals
+
+- No new Canvas, Agent, Automation, API, or user-facing feature.
+- No change to Agent Server API or WebSocket contracts.
+- No attempt to reimplement the Enterprise runtime manager locally.
+- No per-conversation Kubernetes pod lifecycle in the first local Compose
+  topology; the local sandbox container may remain long-lived.
+- No replacement of Enterprise application, Automation, ingress, database, or
+  control-plane service images.
+- No custom wrapper around the Enterprise sandbox entrypoint.
+- No secrets, credentials, deployment URLs, or task-specific source changes
+  baked into either image.
+- No removal of the legacy all-in-one image in the first PR.
+
+## Terminology
+
+- **Control plane / server:** Canvas frontend, Automation backend, and ingress
+  proxy. In Enterprise these are platform-managed services. In the local
+  container topology they run in a repository-built control-plane container.
+- **Pod / sandbox:** The isolated environment in which an agent edits files and
+  runs commands. It runs the OpenHands Agent Server process.
+- **Agent Server:** The process and API inside the sandbox. It is not the same as
+  the Enterprise control-plane server.
+- **Legacy all-in-one image:** The existing repository image whose custom
+  entrypoint starts Agent Server, Automation, Canvas, and proxy together.
+
+## Architecture
+
+### Target topology
+
+```text
+Local container development
+
+Browser
+  |
+  v
+Control-plane container
+  - Canvas static frontend
+  - Automation backend
+  - ingress/proxy
+  |
+  | HTTP + WebSocket on a private container network
+  v
+Sandbox container
+  - upstream Agent Server entrypoint
+  - shared tools and dependencies
+
+
+OpenHands Enterprise
+
+Enterprise-managed control plane
+  |
+  | Enterprise runtime protocol
+  v
+Sandbox pod
+  - the same shared tools and dependencies
+  - upstream Agent Server entrypoint
+```
+
+The external browser URL and public Canvas behavior remain unchanged. Only the
+internal Agent Server address changes from an in-container loopback address to a
+configured sandbox service address.
+
+### Docker build graph
+
+One multi-target Dockerfile is the source of truth:
+
+```text
+official pinned agent-server image
+              |
+              v
+      agent-runtime-base
+      - sandbox tools
+      - sandbox dependencies
+      - safe shared ENV defaults
+      - OCI metadata
+          |           |
+          v           v
+   dev-sandbox   enterprise-sandbox
+                     - no ENTRYPOINT
+                       or CMD override
+
+frontend-build + automation dependencies
+              |
+              v
+       control-plane image
+       - Canvas
+       - Automation
+       - proxy entrypoint
+
+shared/legacy stages
+              |
+              v
+       legacy all-in-one target
+```
+
+The final stage may remain the legacy target initially so existing unqualified
+`docker build` consumers do not change behavior. New build helpers and CI must
+name their intended target explicitly.
+
+### Enterprise sandbox contract
+
+The `enterprise-sandbox` target must:
+
+1. use a pinned `ghcr.io/openhands/agent-server:<version>-python` base image;
+2. match the Agent Server major and minor version required by the deployed
+   Enterprise release;
+3. inherit the base image's `ENTRYPOINT` and `CMD` unchanged;
+4. contain only sandbox-relevant additions from this repository;
+5. run as the user expected by the upstream image;
+6. build for `linux/amd64`;
+7. expose no Canvas, Automation, SQLite, local-secret generation, or ingress
+   runtime behavior; and
+8. include OCI labels that identify the Canvas source revision, Canvas version,
+   and Agent Server base version.
+
+The Enterprise Admin Console's default Sandbox Image Tag is authoritative for
+the required Agent Server version. The image must be rebuilt for each Enterprise
+upgrade rather than relying on a floating tag.
+
+### Entrypoint ownership
+
+The pod/sandbox image has no repository-owned entrypoint. It inherits and runs
+the official Agent Server image entrypoint.
+
+The local control-plane image retains a repository-owned entrypoint only because
+it starts multiple local services: Automation and the Canvas static
+server/proxy. It must not start an Agent Server process. If those control-plane
+processes are split into individual containers in a later change, that
+orchestration entrypoint can also be removed.
+
+The legacy all-in-one target continues using the existing entrypoint during the
+migration period.
+
+## Environment contract
+
+Environment similarity is achieved through shared canonical variables and
+explicit injection, not through a shared entrypoint.
+
+### Common sandbox variables
+
+Only non-secret, sandbox-relevant defaults may be declared in
+`agent-runtime-base`. Examples include a shared tool import path or stable
+workspace/tool configuration. A common default must be valid in both local and
+Enterprise sandboxes without knowing the surrounding control-plane topology.
+
+### Platform-owned sandbox variables
+
+Runtime identity, Agent Server bind configuration, authentication, workspace
+assignment, persistence, secrets, and other per-pod values are injected when the
+sandbox starts. Compose owns these values locally; Enterprise owns them in
+production. They are not generated by the image.
+
+### Dev-only control-plane variables
+
+The following concerns remain in the local control plane and must not leak into
+the Enterprise sandbox image:
+
+- Canvas and proxy ports/base paths;
+- Automation ports, database, file storage, callbacks, and API keys;
+- `LOCAL_BACKEND_API_KEY` convenience handling;
+- public-mode test server configuration;
+- local secret generation and persisted local state;
+- frontend and Automation telemetry configuration; and
+- local runtime-service discovery inputs.
+
+Local convenience names may remain supported, but the control-plane entrypoint
+must translate them once into canonical variables. Internal components should
+not each invent their own aliases or fallback rules.
+
+### Secret policy
+
+Secrets must be injected at runtime. They must not appear in Docker build args,
+image layers, labels, generated defaults, CI artifacts, Compose files committed
+to the repository, or logs. Local generated secrets remain local control-plane
+state and are never copied into the Enterprise sandbox image.
+
+## Networking and data flow
+
+The separated local topology uses a private container network:
+
+1. The browser connects only to the control-plane ingress port.
+2. The control plane receives an explicit internal Agent Server URL, such as
+   `http://agent-server:8000`.
+3. Proxy routes for `/api`, `/sockets`, Agent Server health/docs endpoints, and
+   the editor path use that explicit URL.
+4. Automation receives an explicit URL and credential for its calls to the
+   Agent Server.
+5. The sandbox receives the Automation/ingress URL that is reachable from the
+   sandbox's own network perspective.
+6. `runtime_services` is rendered from these explicit directional URLs. A
+   control-plane-to-sandbox URL must not be reused as a
+   sandbox-to-control-plane URL.
+
+Separated mode has no silent `127.0.0.1` fallback for the Agent Server. Missing
+or invalid URLs cause a clear startup error. The control plane waits for the
+sandbox with a bounded readiness timeout. If the sandbox later fails, the
+control plane remains alive and proxied routes return a clear unavailable/502
+response; container restart policy may recover the sandbox independently.
+
+These rules affect only internal host and port selection. Browser-visible routes,
+payloads, authentication headers, APIs, WebSockets, and product behavior remain
+unchanged.
+
+## Local workflow and compatibility
+
+A Compose file or equivalent launcher starts the control-plane and dev-sandbox
+targets together. It creates the private network, injects explicit directional
+URLs and runtime secrets, mounts the same persistent/project paths required by
+the current local workflow, publishes only the control-plane port, and shuts
+both containers down together.
+
+The existing one-command experience remains available. The command may delegate
+to Compose internally, but users must not need to manually coordinate two
+containers.
+
+The existing all-in-one image remains buildable and keeps its current default
+behavior during this first migration. Existing release, CLI, and mock-LLM E2E
+paths continue using it until a later, separately reviewed migration changes
+their default topology.
+
+## Build and release
+
+### Local builds
+
+Build tooling must expose explicit modes or targets for:
+
+- legacy all-in-one image;
+- local control-plane image;
+- local dev-sandbox image; and
+- Enterprise sandbox image.
+
+The Agent Server image is resolved from `config/defaults.json` by default. An
+explicit override is supported for an Enterprise release that expects a
+different compatible tag. Build output must print the resolved base image,
+target, platform, and destination tag without printing secrets.
+
+### CI builds
+
+CI continues building the legacy multi-architecture image. It additionally
+builds the Enterprise sandbox for `linux/amd64` and verifies its image contract.
+Same-repository PRs may receive PR/SHA image tags consistent with existing
+repository policy.
+
+The proposed repository is:
+
+```text
+ghcr.io/openhands/agent-canvas-enterprise-sandbox
+```
+
+Stable releases use immutable, compatibility-explicit tags:
+
+```text
+<canvas-version>-agent-server-<agent-server-version>
+```
+
+For example:
+
+```text
+1.16.0-agent-server-1.44.1
+```
+
+The workflow does not publish an unqualified `latest` tag for this image. A
+manual workflow dispatch may override the Agent Server base image; the resolved
+version must be reflected in the output tag, OCI labels, and build metadata.
+
+### Enterprise configuration
+
+Operator documentation covers:
+
+1. selecting the Agent Server tag expected by the Enterprise Admin Console;
+2. building and pushing the image for `linux/amd64`;
+3. configuring repository, tag, and registry credentials under Sandbox Image;
+4. deploying the updated Enterprise configuration; and
+5. rebuilding the image for every Enterprise upgrade.
+
+## Testing strategy
+
+Implementation follows test-driven development.
+
+### Static and unit contract tests
+
+Tests must fail before implementation and then verify that:
+
+- all required Docker targets exist;
+- target relationships share the intended runtime base;
+- the Enterprise target cannot acquire Canvas, Automation, proxy, SQLite, local
+  secret, or repository-owned entrypoint content;
+- build scripts resolve the target, Agent Server image, platform, and tag
+  deterministically;
+- separated-mode URL construction has no loopback fallback; and
+- runtime-service URLs preserve their two network perspectives.
+
+### Image inspection
+
+After building the upstream base and Enterprise target, automated inspection
+compares their effective `Config.Entrypoint` and `Config.Cmd`. It also verifies
+the expected architecture, labels, user, and absence of control-plane artifacts.
+
+### Compose smoke test
+
+A bounded smoke test starts the separated stack and verifies:
+
+- control plane and sandbox become healthy;
+- Canvas is reachable on the existing external port/base path;
+- HTTP and WebSocket proxy routes reach the separate sandbox;
+- Automation can reach the same sandbox with the configured authentication;
+- the generated runtime-service metadata contains the correct directional
+  service URLs; and
+- stopping or restarting the sandbox does not terminate the control plane.
+
+### Existing quality gates
+
+The final validation set includes, at minimum:
+
+```text
+npm run lint
+npm test
+npm run build
+npm run build:lib
+```
+
+Relevant Docker builds, image inspections, and the separated-stack smoke test
+are additional gates. Existing mock-LLM E2E coverage remains on the legacy
+all-in-one path for this first migration unless implementation reveals a small,
+non-disruptive way to exercise both targets without changing test semantics.
+
+## Acceptance criteria
+
+1. A documented command builds an Enterprise-compatible sandbox image for
+   `linux/amd64`.
+2. The image is based on an explicit Agent Server version and preserves its
+   effective entrypoint and command exactly.
+3. The Enterprise image contains no Control Plane, Automation, local storage,
+   local secret generation, or custom orchestration runtime behavior.
+4. Local control-plane and sandbox containers can run as a separated stack using
+   the existing public Canvas port and routes.
+5. The separated stack has no silent loopback fallback for cross-container
+   communication.
+6. Local and Enterprise sandbox targets share one sandbox runtime layer and the
+   same resolved Agent Server base image.
+7. The existing all-in-one build remains functional and remains the compatibility
+   default during the first migration.
+8. CI builds and inspects the Enterprise image and can publish immutable,
+   version-explicit tags.
+9. Operator documentation explains the Enterprise Admin Console configuration
+   and upgrade/version compatibility requirement.
+10. Existing product behavior and API contracts are unchanged; the authored
+    change is limited to image, environment, network, process, test, and release
+    boundaries.
+
+## Risks and mitigations
+
+### Enterprise version mismatch
+
+An Enterprise release rejects incompatible Agent Server versions. Builds use an
+explicit base image and compatibility-explicit output tag; documentation makes
+the Admin Console's expected tag authoritative.
+
+### Hidden loopback assumptions
+
+Existing all-in-one code may assume `127.0.0.1`. Contract tests and the Compose
+smoke test exercise explicit service URLs and reject separated-mode fallbacks.
+
+### Entrypoint drift
+
+A future refactor could accidentally add a wrapper or inherit the local
+entrypoint. Image inspection compares the effective Enterprise entrypoint and
+command with the pinned upstream image.
+
+### Oversized sandbox image
+
+Only sandbox-relevant tools and dependencies enter the shared runtime layer.
+Frontend, Automation, proxy, and their dependencies remain outside the
+Enterprise target.
+
+### Migration regression
+
+The legacy all-in-one target remains the default during the first PR. Existing
+tests and release paths continue to validate it while the separated topology
+receives focused new coverage.
+
+## Follow-up candidates
+
+The following are intentionally deferred:
+
+- switch the default Docker/CLI distribution from all-in-one to the separated
+  topology;
+- migrate mock-LLM production-fidelity E2E fully to the separated topology;
+- emulate one disposable sandbox per conversation locally;
+- split Automation and Canvas/proxy into separate control-plane containers; and
+- remove the legacy all-in-one target and entrypoint.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

## Why

OpenHands Enterprise manages its control plane and per-conversation sandbox pods separately, while the current Agent Canvas Docker image starts Agent Server, Automation, Canvas, and ingress together. The intended production image boundary and migration path need an explicit reviewed contract before implementation is merged.

## Summary

- Specify an Enterprise-compatible sandbox image that inherits the selected upstream Agent Server `ENTRYPOINT`, `CMD`, and runtime contract without Canvas orchestration.
- Define shared Dev/Prod sandbox layers, a separate local control plane, explicit directional networking, runtime-only secrets, versioned amd64 publishing, compatibility behavior, and acceptance criteria.
- Provide a TDD-oriented implementation plan covering Docker targets, local tooling, separated Compose topology, CI inspection, documentation, and verification.

## Issue Number

No linked issue (direct specification requested).

## How to Test

```text
git diff --check upstream/main...codex/enterprise-sandbox-prod-image-spec
  PASS
```

Review the design and plan together:

- `docs/superpowers/specs/2026-09-01-enterprise-sandbox-production-image-design.md`
- `docs/superpowers/plans/2026-09-01-enterprise-sandbox-production-image.md`

## Video/Screenshots

Not applicable: this PR contains documentation only and changes no rendered UI.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The implementation is intentionally delivered in separate PR #17076 so this architecture and compatibility contract can be reviewed independently.