### PR TITLE
build: base the Canvas image on the slim agent-server variant

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,11 +89,12 @@ jobs:
           # Single source of truth for version pins — no hardcoded values in this workflow.
           AGENT_SERVER_VERSION=$(node -p "require('./config/defaults.json').versions.agentServer")
           AGENT_SERVER_IMAGE_BASE=$(node -p "require('./config/defaults.json').images.agentServer")
+          AGENT_SERVER_VARIANT=$(node -p "require('./config/defaults.json').variants.agentServer")
           AUTOMATION_VERSION=$(node -p "require('./config/defaults.json').versions.automation")
           AGENT_CANVAS_VERSION=$(node -p "require('./package.json').version")
           CANVAS_BASE_PATH=$(node -p "require('./config/defaults.json').paths.canvasBasePath")
           echo "agent_server_version=$AGENT_SERVER_VERSION" >> "$GITHUB_OUTPUT"
-          echo "default_agent_server_image=${AGENT_SERVER_IMAGE_BASE}:${AGENT_SERVER_VERSION}-python" >> "$GITHUB_OUTPUT"
+          echo "default_agent_server_image=${AGENT_SERVER_IMAGE_BASE}:${AGENT_SERVER_VERSION}-${AGENT_SERVER_VARIANT}" >> "$GITHUB_OUTPUT"
           echo "default_automation_version=$AUTOMATION_VERSION" >> "$GITHUB_OUTPUT"
           echo "agent_canvas_version=$AGENT_CANVAS_VERSION" >> "$GITHUB_OUTPUT"
           echo "canvas_base_path=$CANVAS_BASE_PATH" >> "$GITHUB_OUTPUT"

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,5 +1,9 @@
 {
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
+  "_agentServerVariantComment": "Image variant suffix for the agent-server tag: <images.agentServer>:<versions.agentServer>-<variants.agentServer>. `python-slim` omits the preinstalled ACP providers (~324 MB on amd64); the SDK falls back to a version-pinned `npx` install on first use. Use `python` to get them preinstalled.",
+  "variants": {
+    "agentServer": "python-slim"
+  },
   "versions": {
     "agentServer": "1.44.1",
     "agentCanvas": "1.16.0",

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
-  "_agentServerVariantComment": "Image variant suffix for the agent-server tag: <images.agentServer>:<versions.agentServer>-<variants.agentServer>. `python-slim` omits the preinstalled ACP providers (~324 MB on amd64); the SDK falls back to a version-pinned `npx` install on first use. Use `python` to get them preinstalled.",
+  "_agentServerVariantComment": "Image variant suffix for the agent-server tag: <images.agentServer>:<versions.agentServer>-<variants.agentServer>. `python-slim` omits the preinstalled ACP providers (~324 MB on amd64); the SDK falls back to a version-pinned `npx` install on first use, cached under ~/.openhands. Set to `python` to get them preinstalled — see docs/ACP_AGENTS.md#slim-vs-full-images.",
   "variants": {
     "agentServer": "python-slim"
   },

--- a/docs/ACP_AGENTS.md
+++ b/docs/ACP_AGENTS.md
@@ -158,6 +158,48 @@ docker run -d --name oh-acp -p 8010:8000 -v acp-data:/workspace \
 VITE_BACKEND_BASE_URL=http://localhost:8010 npm run dev:frontend
 ```
 
+### Slim vs. full images
+
+The published **Agent Canvas** image is built on `agent-server:<version>-python-slim`,
+which omits the preinstalled ACP provider CLIs (~324 MB compressed). Nothing changes
+for you: the first time you pick an ACP agent, the SDK installs that provider at its
+pinned version via `npx` — typically a few seconds — and caches it under
+`~/.openhands`, so it happens once per machine rather than once per container.
+
+You want the **full** image (`agent-server:<version>-python`, providers baked in) if:
+
+- the machine has no npm registry access — air-gapped, or behind a proxy that blocks it
+- you need a byte-identical, reproducible image with no install step at run time
+- you cannot accept a few seconds of first-use latency on a cold cache
+
+The `examples/acp-docker/` setup above already uses the full image, so it works
+offline as-is.
+
+To build Canvas itself on the full image, set the variant in
+[`config/defaults.json`](../config/defaults.json) and rebuild:
+
+```jsonc
+{
+  "variants": {
+    "agentServer": "python"      // instead of "python-slim"
+  }
+}
+```
+
+```bash
+npm run docker:build
+```
+
+Or override it for a one-off build without editing config:
+
+```bash
+docker build -f docker/Dockerfile \
+  --build-arg AGENT_SERVER_IMAGE=ghcr.io/openhands/agent-server:<version>-python \
+  --build-arg AUTOMATION_VERSION=$(node -p "require('./config/defaults.json').versions.automation") \
+  --build-arg VITE_BASE_PATH=$(node -p "require('./config/defaults.json').paths.canvasBasePath") \
+  -t agent-canvas:full .
+```
+
 ### How credentials reach a containerized agent
 
 In onboarding's **Set up credentials** step, the credentials you enter are saved

--- a/scripts/docker-build.mjs
+++ b/scripts/docker-build.mjs
@@ -23,7 +23,7 @@ const config = JSON.parse(
   readFileSync(join(projectRoot, "config", "defaults.json"), "utf-8"),
 );
 
-const agentServerImage = `${config.images.agentServer}:${config.versions.agentServer}-python`;
+const agentServerImage = `${config.images.agentServer}:${config.versions.agentServer}-${config.variants.agentServer}`;
 const automationVersion = config.versions.automation;
 const canvasBasePath = config.paths.canvasBasePath;
 

--- a/tests/e2e/live-acp/harness.mts
+++ b/tests/e2e/live-acp/harness.mts
@@ -37,7 +37,10 @@ export function registerDockerBackend(): void {
       id: "acp-docker",
       name: "ACP Docker",
       host: BASE,
-      apiKey: "",
+      // Canvas-built images generate a LOCAL_BACKEND_API_KEY and reject
+      // unauthenticated calls with 401; a bare agent-server does not. Allow the
+      // key to be supplied so the same e2e can run against either.
+      apiKey: process.env.ACP_E2E_API_KEY ?? "",
       kind: "local",
     },
   ]);
@@ -160,9 +163,14 @@ export function getProviderPlan(id: string): ProviderPlan | undefined {
 }
 
 export async function postJson(url: string, body: unknown): Promise<any> {
+  const apiKey = process.env.ACP_E2E_API_KEY;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      // Canvas-built images require the session key; a bare agent-server ignores it.
+      ...(apiKey ? { "X-Session-API-Key": apiKey } : {}),
+    },
     body: JSON.stringify(body),
   });
   const text = await res.text();
@@ -173,7 +181,10 @@ export async function postJson(url: string, body: unknown): Promise<any> {
 }
 
 export async function getJson(url: string): Promise<any> {
-  const res = await fetch(url);
+  const apiKey = process.env.ACP_E2E_API_KEY;
+  const res = await fetch(url, {
+    headers: apiKey ? { "X-Session-API-Key": apiKey } : {},
+  });
   const text = await res.text();
   if (!res.ok) {
     throw new Error(`GET ${url} -> ${res.status}: ${text.slice(0, 400)}`);

--- a/tests/e2e/live-acp/vite-node.config.mts
+++ b/tests/e2e/live-acp/vite-node.config.mts
@@ -9,6 +9,13 @@ import { defineConfig } from "vite";
 const srcDir = fileURLToPath(new URL("../../../src", import.meta.url));
 
 export default defineConfig({
+  // `agent-server-adapter.ts` reads this Vite `define` (injected by the app's
+  // vite.config.ts). Without it the module throws `__EXTENSIONS_SKILLS_DIR__ is
+  // not defined` the moment the e2e imports it. Empty string is the same value
+  // library builds use, and the adapter falls back to "public" when it is falsy.
+  define: {
+    __EXTENSIONS_SKILLS_DIR__: JSON.stringify(""),
+  },
   resolve: {
     alias: [{ find: /^#\//, replacement: `${srcDir}/` }],
   },


### PR DESCRIPTION
HUMAN:

Tested on my machine: built the Canvas image on the slim agent-server variant,
logged in with my own Codex credentials, and ran a real ACP conversation
through it. The provider installed on demand and the turn completed. Details
and the full transcript are in the AGENT section below.

---

AGENT:

> [!IMPORTANT]
> **Expect the Docker build job to fail until the next SDK release.** `versions.agentServer` is `1.44.1`, and `agent-server:1.44.1-python-slim` is a **404** — the slim variant merged after that release. `latest-python-slim` and `main-python-slim` are published today, but this repo pins to releases.
>
> A commit-SHA pin is not a workaround: `scripts/check-sdk-version-sync.mjs` cross-validates `versions.agentServer` against the SDK version `openhands-automation` is built on, and rejects anything that is not the matching release (verified — it fails with *"expected a9e0a8a"*). So the release is a genuine dependency, not a formality.
>
> The code is complete and reviewable now, and **verified end to end against the real slim image** (see the comments below — a full ACP turn through the Canvas image, with the provider installed on demand). Flip `versions.agentServer` to the next release and CI goes green.

## Why

The Canvas image is built `FROM ${AGENT_SERVER_IMAGE} AS final`, so it inherits everything in the agent-server image — including the preinstalled ACP providers, whether or not a user ever selects an ACP agent.

Measured from the published ghcr manifests (amd64, compressed layer totals — what a cold pull transfers):

| Tag | Compressed |
|---|---:|
| `agent-server:latest-python` | 1279.2 MB |
| **`agent-server:latest-python-slim`** | **954.8 MB** |
| saving | **324.4 MB (25.4%)** |

This is where that saving reaches users. Until Canvas points at the slim tag, the variant is published but nothing pulls it.

When a provider is absent, the SDK falls back to a version-pinned `npx` install (OpenHands/software-agent-sdk#4805): `--prefer-offline`, an npm cache on a durable path shared across conversations, and a cache-warm step before the ACP handshake. Measured cold installs are 1–4 s, and a second run does not re-download.

## Summary

- Adds `variants.agentServer` to `config/defaults.json` as the single source of truth for the tag suffix, and sets it to `python-slim`.
- Consumes it in both places that build the tag: `scripts/docker-build.mjs` (local) and `.github/workflows/docker.yml` (CI). Both previously hardcoded `-python`, which the workflow's own comment says it is trying to avoid: *"Single source of truth for version pins — no hardcoded values in this workflow."*
- `examples/acp-docker` deliberately stays on `-python`. That fixture exists to demonstrate the **preinstalled** ACP wrappers — its README says so explicitly — so pointing it at the fallback path would defeat its purpose.

## Getting the full image, if you need it

Documented in `docs/ACP_AGENTS.md` (new **Slim vs. full images** section), because the existing text claimed the image pre-installs the ACP CLIs — true before this change, not after.

For almost everyone nothing changes: the first time an ACP agent is selected, the SDK installs that provider at its pinned version via `npx` (measured 3.8–4.3 s) and caches it under `~/.openhands`, so it happens once per machine rather than once per container.

The full image is the right choice when the machine has **no npm registry access** (air-gapped or a blocking proxy), when a byte-identical reproducible image is required, or when first-use latency is unacceptable. Two ways to get it:

```jsonc
// config/defaults.json — then `npm run docker:build`
{ "variants": { "agentServer": "python" } }
```

```bash
# or a one-off build, no config edit
docker build -f docker/Dockerfile \
  --build-arg AGENT_SERVER_IMAGE=ghcr.io/openhands/agent-server:<version>-python ... .
```

`examples/acp-docker/` already uses the full image, so it keeps working offline as-is.

## How to Test

```bash
# The tag Canvas will now build against
node -p "const c=require('./config/defaults.json'); c.images.agentServer+':'+c.versions.agentServer+'-'+c.variants.agentServer"
# ghcr.io/openhands/agent-server:1.44.1-python-slim

# The acp-docker example is unchanged
node -p "const c=require('./config/defaults.json'); c.images.agentServer+':'+c.versions.agentServer+'-python'"
# ghcr.io/openhands/agent-server:1.44.1-python

npx vitest run __tests__/scripts/
# 321 passed, 1 failed
```

The one failure is `dev-with-automation > cleans up detached services when the launcher receives SIGHUP` — a process/signal test. **It fails identically with these changes stashed** (verified: `git stash` → same failure → `git stash pop`), so it is a pre-existing local-environment issue, not a regression. CI is the authority.

## Before merging

- [ ] An SDK release publishes `<version>-python-slim`; bump `versions.agentServer` to it
- [ ] Canvas Docker E2E green against the slim base
- [x] One real ACP conversation on the slim image, exercising the `npx` fallback end to end — this is the path that replaces the preinstalled providers, so it is the thing most worth confirming by hand *(done — see How to Test)*
- [x] Sizes recorded on OpenHands/software-agent-sdk#4643 ([comment](https://github.com/OpenHands/software-agent-sdk/issues/4643#issuecomment-5497466791)). Re-measured from the manifests and the figures hold: `main-python` and `main-python-slim` share an identical config digest, so it is a same-build A/B — 1279.2 MB → 954.8 MB amd64 compressed (−324.4 MB). The Canvas figure is inherited rather than separately measured: Canvas is `FROM ${AGENT_SERVER_IMAGE}` plus a fixed layer, so the absolute saving carries over; a directly measured Canvas before/after needs CI to build both variants, which needs the tag above

## Not in this PR

- **Docker Engine stays.** It was a slimming candidate at 135.5 MB, but the agent being able to run containers is worth more than the size — see the decision and the rootless-Docker evidence in OpenHands/software-agent-sdk#4643. It is now documented for Canvas in OpenHands/docs#774.
- No change to the default `agent-server:<v>-python` tag, which enterprise, Replicated, cloud and evaluation all consume.

## Issue Number

Fixes #17080

Upstream: OpenHands/software-agent-sdk#4643 (Step 3) and OHE-3179.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore


