### PR TITLE
feat(conversation-panel): group by container and workspace independently

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel-filter-menu.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel-filter-menu.test.tsx
@@ -21,8 +21,10 @@ function renderFilterMenu(
     setFilterMenuOpen: vi.fn(),
     menuRef: createRef<HTMLDivElement>(),
     backendKind: "local",
-    organizeMode: "grouped",
-    setOrganizeMode: vi.fn(),
+    groupByContainer: false,
+    toggleGroupByContainer: vi.fn(),
+    groupByWorkspace: true,
+    toggleGroupByWorkspace: vi.fn(),
     conversationSort: "created",
     setConversationSort: vi.fn(),
     threadScope: "all",
@@ -66,6 +68,50 @@ describe("ConversationPanelFilterMenu", () => {
       screen.getByTestId("toggle-older-conversations"),
     ).toBeInTheDocument();
     expect(screen.getByTestId("delete-all-conversations")).toBeInTheDocument();
+  });
+
+  it("renders the two grouping rows as independent checkboxes, not a mutually exclusive radio pair (#15607)", () => {
+    renderFilterMenu({ groupByWorkspace: true, groupByContainer: false });
+
+    const workspaceRow = screen.getByTestId("organize-group-by-workspace");
+    const containerRow = screen.getByTestId("organize-group-by-container");
+
+    expect(workspaceRow).toHaveAttribute("role", "menuitemcheckbox");
+    expect(workspaceRow).toHaveAttribute("aria-checked", "true");
+    expect(containerRow).toHaveAttribute("role", "menuitemcheckbox");
+    expect(containerRow).toHaveAttribute("aria-checked", "false");
+
+    // There is no third "Chronological list" row any more — unchecking both
+    // boxes is what produces the flat/chronological list.
+    expect(
+      screen.queryByText("CONVERSATION_PANEL$CHRONOLOGICAL"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("toggles each grouping checkbox independently without closing the menu", async () => {
+    const user = userEvent.setup();
+    const toggleGroupByContainer = vi.fn();
+    const toggleGroupByWorkspace = vi.fn();
+    const setFilterMenuOpen = vi.fn();
+    renderFilterMenu({
+      groupByWorkspace: true,
+      groupByContainer: true,
+      toggleGroupByContainer,
+      toggleGroupByWorkspace,
+      setFilterMenuOpen,
+    });
+
+    await user.click(screen.getByTestId("organize-group-by-container"));
+
+    // Only the clicked toggle fires, and — unlike the old radio rows — the
+    // menu is not asked to close, since a user flipping one grouping
+    // checkbox is very likely about to flip the other one too.
+    expect(toggleGroupByContainer).toHaveBeenCalledTimes(1);
+    expect(toggleGroupByWorkspace).not.toHaveBeenCalled();
+    expect(setFilterMenuOpen).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("organize-group-by-workspace"));
+    expect(toggleGroupByWorkspace).toHaveBeenCalledTimes(1);
   });
 
   it("orders metadata toggles as repo/branch, model, then tags", () => {

--- a/__tests__/components/features/conversation-panel/conversation-panel-list-helpers.test.ts
+++ b/__tests__/components/features/conversation-panel/conversation-panel-list-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyAutomationConversationFilter,
   applyGroupFolderOrder,
+  buildConversationGroups,
   collectAutomationNameFacets,
   getGroupConversationPreview,
   getGroupDiscoveryConversationIds,
@@ -292,17 +293,18 @@ describe("conversation-panel-list-helpers", () => {
     ]);
 
     expect([
+      ...getGroupDiscoveryConversationIds(items, pageByConversationId, "local"),
+    ]).toEqual(["none-1", "alpha-1"]);
+
+    expect([
       ...getGroupDiscoveryConversationIds(
         items,
         pageByConversationId,
         "local",
+        {
+          forceIncludeConversationId: "none-2",
+        },
       ),
-    ]).toEqual(["none-1", "alpha-1"]);
-
-    expect([
-      ...getGroupDiscoveryConversationIds(items, pageByConversationId, "local", {
-        forceIncludeConversationId: "none-2",
-      }),
     ]).toEqual(["none-1", "alpha-1", "none-2"]);
 
     const grouped = groupConversations(items, "local", "updated", {
@@ -713,5 +715,293 @@ describe("conversation-panel-list-helpers", () => {
       knownWorkspaces,
     );
     expect(groups).toHaveLength(0);
+  });
+
+  describe("buildConversationGroups (#15607 independent container/workspace grouping)", () => {
+    const labels = {
+      emptyWorkspace: "No workspace",
+      emptyRepository: "No repository",
+      emptyContainer: "No container",
+    };
+
+    it("returns no sections when neither grouping toggle is enabled", () => {
+      const convo: AppConversation = {
+        ...base,
+        id: "c1",
+        title: "c1",
+        selected_workspace: "/workspace/alpha",
+        sandbox_id: "sandbox-a",
+      };
+      const sections = buildConversationGroups([convo], "local", "updated", {
+        groupByContainer: false,
+        groupByWorkspace: false,
+        labels,
+      });
+      expect(sections).toEqual([]);
+    });
+
+    it("only workspace enabled: one headerless section, identical in shape to groupConversations", () => {
+      const alpha: AppConversation = {
+        ...base,
+        id: "c1",
+        title: "c1",
+        selected_workspace: "/workspace/alpha",
+        sandbox_id: "sandbox-a",
+        updated_at: "2024-01-02T00:00:00.000Z",
+      };
+      const beta: AppConversation = {
+        ...base,
+        id: "c2",
+        title: "c2",
+        selected_workspace: "/workspace/beta",
+        sandbox_id: "sandbox-b",
+        updated_at: "2024-01-03T00:00:00.000Z",
+      };
+      const sections = buildConversationGroups(
+        [alpha, beta],
+        "local",
+        "updated",
+        {
+          groupByContainer: false,
+          groupByWorkspace: true,
+          labels,
+        },
+      );
+
+      expect(sections).toHaveLength(1);
+      expect(sections[0]?.container).toBeNull();
+      // Same ids/order groupConversations alone would produce (most-recently
+      // touched workspace first): container grouping plays no part here.
+      expect(sections[0]?.groups.map((g) => g.id)).toEqual([
+        "ws:/workspace/beta",
+        "ws:/workspace/alpha",
+      ]);
+    });
+
+    it("only container enabled: one headerless section keyed by sandbox_id, with no launch target", () => {
+      const inSandboxA: AppConversation = {
+        ...base,
+        id: "c1",
+        title: "c1",
+        sandbox_id: "sandbox-a",
+        updated_at: "2024-01-02T00:00:00.000Z",
+      };
+      const inSandboxB: AppConversation = {
+        ...base,
+        id: "c2",
+        title: "c2",
+        sandbox_id: "sandbox-b",
+        updated_at: "2024-01-05T00:00:00.000Z",
+      };
+      const noSandbox: AppConversation = {
+        ...base,
+        id: "c3",
+        title: "c3",
+        sandbox_id: null,
+        updated_at: "2024-01-01T00:00:00.000Z",
+      };
+      const sections = buildConversationGroups(
+        [inSandboxA, inSandboxB, noSandbox],
+        "local",
+        "updated",
+        { groupByContainer: true, groupByWorkspace: false, labels },
+      );
+
+      expect(sections).toHaveLength(1);
+      expect(sections[0]?.container).toBeNull();
+      expect(
+        sections[0]?.groups.map((g) => ({ id: g.id, label: g.label })),
+      ).toEqual([
+        { id: "container:sandbox-b", label: "sandbox-b" },
+        { id: "container:sandbox-a", label: "sandbox-a" },
+        { id: "__none_container", label: "No container" },
+      ]);
+      // A container isn't something you "start a new conversation in" the
+      // way a workspace/repo is — every group's launch target is empty.
+      expect(
+        sections[0]?.groups.every((g) => Object.keys(g.launch).length === 0),
+      ).toBe(true);
+    });
+
+    it("both enabled: nests workspace groups inside container sections, container outermost (matches the issue's tree)", () => {
+      const a1: AppConversation = {
+        ...base,
+        id: "a1",
+        title: "a1",
+        sandbox_id: "sandbox-a",
+        selected_workspace: "/workspace/alpha",
+        updated_at: "2024-01-01T00:00:00.000Z",
+      };
+      const a2: AppConversation = {
+        ...base,
+        id: "a2",
+        title: "a2",
+        sandbox_id: "sandbox-a",
+        selected_workspace: "/workspace/beta",
+        updated_at: "2024-01-02T00:00:00.000Z",
+      };
+      const b1: AppConversation = {
+        ...base,
+        id: "b1",
+        title: "b1",
+        sandbox_id: "sandbox-b",
+        selected_workspace: "/workspace/alpha",
+        updated_at: "2024-01-05T00:00:00.000Z",
+      };
+      const sections = buildConversationGroups(
+        [a1, a2, b1],
+        "local",
+        "updated",
+        {
+          groupByContainer: true,
+          groupByWorkspace: true,
+          labels,
+        },
+      );
+
+      // Two container sections, most-recently-active first (sandbox-b's b1
+      // is the newest conversation overall).
+      expect(sections.map((s) => s.container?.id)).toEqual([
+        "container:sandbox-b",
+        "container:sandbox-a",
+      ]);
+
+      const sandboxB = sections[0]!;
+      expect(sandboxB.container).toEqual({
+        id: "container:sandbox-b",
+        label: "sandbox-b",
+      });
+      expect(sandboxB.groups.map((g) => g.id)).toEqual([
+        "container:sandbox-b|ws:/workspace/alpha",
+      ]);
+      expect(sandboxB.groups[0]?.conversations.map((c) => c.id)).toEqual([
+        "b1",
+      ]);
+
+      const sandboxA = sections[1]!;
+      // Within sandbox-a, /workspace/beta (a2, newer) sorts before
+      // /workspace/alpha (a1) — nesting doesn't disturb the inner sort.
+      expect(sandboxA.groups.map((g) => g.id)).toEqual([
+        "container:sandbox-a|ws:/workspace/beta",
+        "container:sandbox-a|ws:/workspace/alpha",
+      ]);
+    });
+
+    it("qualifies inner ids by container so two containers sharing a workspace path don't collide", () => {
+      const inA: AppConversation = {
+        ...base,
+        id: "in-a",
+        title: "in-a",
+        sandbox_id: "sandbox-a",
+        selected_workspace: "/workspace/shared",
+      };
+      const inB: AppConversation = {
+        ...base,
+        id: "in-b",
+        title: "in-b",
+        sandbox_id: "sandbox-b",
+        selected_workspace: "/workspace/shared",
+      };
+      const sections = buildConversationGroups([inA, inB], "local", "updated", {
+        groupByContainer: true,
+        groupByWorkspace: true,
+        labels,
+      });
+
+      expect(sections).toHaveLength(2);
+      const allInnerIds = sections.flatMap((s) => s.groups.map((g) => g.id));
+      // Distinct qualified ids, not one shared "ws:/workspace/shared" bucket.
+      expect(new Set(allInnerIds).size).toBe(2);
+      for (const section of sections) {
+        expect(section.groups).toHaveLength(1);
+      }
+      // Each container keeps only its own conversation — no cross-container
+      // bleed from the shared workspace path. (inA/inB tie on timestamp, so
+      // section order isn't asserted here — only membership.)
+      const conversationIdsBySection = sections
+        .map((s) => s.groups[0]?.conversations.map((c) => c.id))
+        .sort();
+      expect(conversationIdsBySection).toEqual([["in-a"], ["in-b"]]);
+    });
+
+    it("does not pre-seed empty knownWorkspaces folders into every container when nesting is active", () => {
+      // If knownWorkspaces leaked into the per-container call, "alpha" would
+      // show up as an empty folder inside sandbox-b too, which it never had
+      // any conversations in.
+      const knownWorkspaces = [
+        { id: "/workspace/alpha", name: "alpha", path: "/workspace/alpha" },
+      ];
+      const onlyInA: AppConversation = {
+        ...base,
+        id: "c1",
+        title: "c1",
+        sandbox_id: "sandbox-a",
+        selected_workspace: "/workspace/alpha",
+      };
+      const onlyInB: AppConversation = {
+        ...base,
+        id: "c2",
+        title: "c2",
+        sandbox_id: "sandbox-b",
+        selected_workspace: "/workspace/beta",
+      };
+      const sections = buildConversationGroups(
+        [onlyInA, onlyInB],
+        "local",
+        "updated",
+        {
+          groupByContainer: true,
+          groupByWorkspace: true,
+          labels,
+          knownWorkspaces,
+        },
+      );
+
+      const sandboxB = sections.find(
+        (s) => s.container?.id === "container:sandbox-b",
+      );
+      expect(sandboxB?.groups.map((g) => g.id)).toEqual([
+        "container:sandbox-b|ws:/workspace/beta",
+      ]);
+      // No phantom "ws:/workspace/alpha" folder inside sandbox-b.
+      expect(
+        sandboxB?.groups.some((g) => g.id.endsWith("ws:/workspace/alpha")),
+      ).toBe(false);
+    });
+
+    it("nests repository groups (not workspace) inside containers for the cloud backend", () => {
+      const convo: AppConversation = {
+        ...base,
+        id: "c1",
+        title: "c1",
+        sandbox_id: "sandbox-a",
+        selected_repository: "org/repo",
+      };
+      const sections = buildConversationGroups([convo], "cloud", "updated", {
+        groupByContainer: true,
+        groupByWorkspace: true,
+        labels,
+      });
+
+      expect(sections).toEqual([
+        {
+          container: { id: "container:sandbox-a", label: "sandbox-a" },
+          groups: [
+            {
+              id: "container:sandbox-a|repo:org/repo",
+              label: "repo",
+              conversations: [convo],
+              launch: {
+                repository: {
+                  name: "org/repo",
+                  gitProvider: "github",
+                  branch: "main",
+                },
+              },
+            },
+          ],
+        },
+      ]);
+    });
   });
 });

--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -930,7 +930,8 @@ describe("ConversationPanel", () => {
 
     useConversationPanelPreferencesStore.setState({
       conversationSort: "updated",
-      organizeMode: "chronological",
+      groupByContainer: false,
+      groupByWorkspace: false,
       showOlderConversations: true,
     });
 
@@ -2144,7 +2145,7 @@ describe("ConversationPanel", () => {
 
     it("keeps collapsed folder previews stable while still exposing later-page conversations on expand", async () => {
       useConversationPanelPreferencesStore.setState({
-        organizeMode: "grouped",
+        groupByWorkspace: true,
       });
       const noWorkspaceConversations = Array.from({ length: 6 }, (_, index) =>
         createMockConversation({
@@ -2230,7 +2231,7 @@ describe("ConversationPanel", () => {
 
     it("caps a grouped load-more click at three pages when no new folder appears", async () => {
       useConversationPanelPreferencesStore.setState({
-        organizeMode: "grouped",
+        groupByWorkspace: true,
       });
       const deepenOnlyPage = (page: number, nextPageId: string) => ({
         items: Array.from({ length: 2 }, (_, index) =>
@@ -2275,7 +2276,7 @@ describe("ConversationPanel", () => {
 
     it("force-includes the active conversation in a folder preview even when it arrived on a later page", async () => {
       useConversationPanelPreferencesStore.setState({
-        organizeMode: "grouped",
+        groupByWorkspace: true,
       });
       vi.spyOn(AgentServerConversationService, "searchConversations")
         .mockResolvedValueOnce({
@@ -2334,7 +2335,7 @@ describe("ConversationPanel", () => {
 
   it("reorders grouped folders via drag and drop", async () => {
     useConversationPanelPreferencesStore.setState({
-      organizeMode: "grouped",
+      groupByWorkspace: true,
       groupFolderOrder: [],
     });
 
@@ -2438,7 +2439,7 @@ describe("ConversationPanel", () => {
   });
 
   it("renders pinned conversations only in the pinned section in grouped mode", async () => {
-    useConversationPanelPreferencesStore.setState({ organizeMode: "grouped" });
+    useConversationPanelPreferencesStore.setState({ groupByWorkspace: true });
     usePinnedConversationsStore
       .getState()
       .pinConversation("default-local", "2");
@@ -2510,5 +2511,138 @@ describe("ConversationPanel", () => {
     expect(
       within(pinnedSection).getByTestId("conversation-panel-pinned-view-more"),
     ).toHaveTextContent("CONVERSATION_PANEL$MORE");
+  });
+
+  describe("nested container + workspace grouping (#15607)", () => {
+    it("renders a container header per sandbox with that container's workspace folders nested underneath", async () => {
+      useConversationPanelPreferencesStore.setState({
+        groupByContainer: true,
+        groupByWorkspace: true,
+      });
+      vi.spyOn(
+        AgentServerConversationService,
+        "searchConversations",
+      ).mockResolvedValue({
+        items: [
+          createMockConversation({
+            id: "a1",
+            title: "Alpha in Sandbox A",
+            sandbox_id: "sandbox-a",
+            selected_workspace: "/workspace/alpha",
+          }),
+          createMockConversation({
+            id: "b1",
+            title: "Alpha in Sandbox B",
+            sandbox_id: "sandbox-b",
+            selected_workspace: "/workspace/alpha",
+          }),
+        ],
+        next_page_id: null,
+      });
+
+      renderConversationPanel();
+
+      const headers = await screen.findAllByTestId(
+        "conversation-group-section-header",
+      );
+      expect(headers.map((h) => h.textContent)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("sandbox-a"),
+          expect.stringContaining("sandbox-b"),
+        ]),
+      );
+      expect(headers).toHaveLength(2);
+
+      // Both containers happen to share the workspace name "alpha", but the
+      // qualified folder ids keep them as two distinct, independently
+      // collapsible folders rather than one merged "alpha" folder.
+      expect(
+        screen.getByTestId(
+          "thread-folder-container-sandbox-a-ws--workspace-alpha",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(
+          "thread-folder-container-sandbox-b-ws--workspace-alpha",
+        ),
+      ).toBeInTheDocument();
+      expect(await screen.findByText("Alpha in Sandbox A")).toBeInTheDocument();
+      expect(await screen.findByText("Alpha in Sandbox B")).toBeInTheDocument();
+    });
+
+    it("scopes drag-and-drop folder reordering to its own container, leaving other containers' order untouched", async () => {
+      useConversationPanelPreferencesStore.setState({
+        groupByContainer: true,
+        groupByWorkspace: true,
+        groupFolderOrder: [],
+      });
+      vi.spyOn(
+        AgentServerConversationService,
+        "searchConversations",
+      ).mockResolvedValue({
+        items: [
+          createMockConversation({
+            id: "a1",
+            title: "A1",
+            sandbox_id: "sandbox-a",
+            selected_workspace: "/workspace/alpha",
+          }),
+          createMockConversation({
+            id: "a2",
+            title: "A2",
+            sandbox_id: "sandbox-a",
+            selected_workspace: "/workspace/beta",
+          }),
+          createMockConversation({
+            id: "b1",
+            title: "B1",
+            sandbox_id: "sandbox-b",
+            selected_workspace: "/workspace/gamma",
+          }),
+        ],
+        next_page_id: null,
+      });
+
+      renderConversationPanel();
+
+      const betaFolder = await screen.findByTestId(
+        "thread-folder-container-sandbox-a-ws--workspace-beta",
+      );
+      const dragHandle = screen.getByTestId(
+        "thread-folder-drag-container-sandbox-a-ws--workspace-alpha",
+      );
+
+      const dataTransfer = {
+        effectAllowed: "move",
+        dropEffect: "move",
+        data: {} as Record<string, string>,
+        setData(format: string, value: string) {
+          this.data[format] = value;
+        },
+        getData(format: string) {
+          return this.data[format];
+        },
+      };
+      fireEvent.dragStart(dragHandle, { dataTransfer });
+      fireEvent.dragOver(betaFolder, { dataTransfer });
+      fireEvent.drop(betaFolder, { dataTransfer });
+
+      await waitFor(() => {
+        const order =
+          useConversationPanelPreferencesStore.getState().groupFolderOrder;
+        expect(order).toEqual([
+          "container:sandbox-a|ws:/workspace/beta",
+          "container:sandbox-a|ws:/workspace/alpha",
+        ]);
+      });
+      // sandbox-b's single folder was never part of the drag and is not
+      // dropped from the persisted order (it just has nothing to reorder
+      // against yet, since it's the only folder in its container).
+      expect(
+        screen.getByTestId(
+          "thread-folder-container-sandbox-b-ws--workspace-gamma",
+        ),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/__tests__/stores/conversation-panel-preferences-store.test.ts
+++ b/__tests__/stores/conversation-panel-preferences-store.test.ts
@@ -8,13 +8,14 @@ describe("conversation-panel-preferences store", () => {
     window.localStorage.clear();
   });
 
-  it("defaults to showing older conversations, chronological list, and expected toggles", () => {
+  it("defaults to showing older conversations, chronological list (both grouping toggles off), and expected toggles", () => {
     const state = useConversationPanelPreferencesStore.getState();
     expect(state.showOlderConversations).toBe(true);
     expect(state.showRepoBranchMetadata).toBe(false);
     expect(state.showLlmProfiles).toBe(false);
     expect(state.showTagsMetadata).toBe(false);
-    expect(state.organizeMode).toBe("chronological");
+    expect(state.groupByContainer).toBe(false);
+    expect(state.groupByWorkspace).toBe(false);
     expect(state.conversationSort).toBe("updated");
     expect(state.threadScope).toBe("all");
     expect(state.automationFilterMode).toBe("all");
@@ -75,8 +76,9 @@ describe("conversation-panel-preferences store", () => {
     expect(Object.keys(persisted.state).sort()).toEqual([
       "automationFilterMode",
       "conversationSort",
+      "groupByContainer",
+      "groupByWorkspace",
       "groupFolderOrder",
-      "organizeMode",
       "selectedAutomationNames",
       "showArchivedConversations",
       "showHoverMetadata",
@@ -100,21 +102,41 @@ describe("conversation-panel-preferences store", () => {
     ).toBe(false);
   });
 
-  it("updates organize, sort, and thread-scope preferences via their setters", () => {
+  it("updates the grouping toggles, sort, and thread-scope preferences via their setters", () => {
     const store = useConversationPanelPreferencesStore.getState();
-    store.setOrganizeMode("grouped");
+    store.setGroupByWorkspace(true);
     store.setConversationSort("created");
     store.setThreadScope("relevant");
 
     const next = useConversationPanelPreferencesStore.getState();
     expect({
-      organizeMode: next.organizeMode,
+      groupByContainer: next.groupByContainer,
+      groupByWorkspace: next.groupByWorkspace,
       conversationSort: next.conversationSort,
       threadScope: next.threadScope,
     }).toEqual({
-      organizeMode: "grouped",
+      // groupByContainer is untouched by setGroupByWorkspace — the two
+      // toggles are independent (#15607), not a mutually exclusive mode.
+      groupByContainer: false,
+      groupByWorkspace: true,
       conversationSort: "created",
       threadScope: "relevant",
+    });
+
+    // toggleGroupByContainer flips only its own field, leaving
+    // groupByWorkspace (just set above) untouched.
+    store.toggleGroupByContainer();
+    expect({
+      groupByContainer:
+        useConversationPanelPreferencesStore.getState().groupByContainer,
+      groupByWorkspace:
+        useConversationPanelPreferencesStore.getState().groupByWorkspace,
+    }).toEqual({ groupByContainer: true, groupByWorkspace: true });
+
+    // Restore defaults so later tests in this file see a pristine store.
+    useConversationPanelPreferencesStore.setState({
+      groupByContainer: false,
+      groupByWorkspace: false,
     });
   });
 
@@ -164,19 +186,44 @@ describe("conversation-panel-preferences store", () => {
       showOlderConversations: state.showOlderConversations,
       showRepoBranchMetadata: state.showRepoBranchMetadata,
       showLlmProfiles: state.showLlmProfiles,
-      organizeMode: state.organizeMode,
+      groupByContainer: state.groupByContainer,
+      groupByWorkspace: state.groupByWorkspace,
       conversationSort: state.conversationSort,
       threadScope: state.threadScope,
     }).toEqual({
       // Preserved from the legacy payload.
       showOlderConversations: false,
       showRepoBranchMetadata: true,
-      // Filled with defaults for missing fields.
+      // Filled with defaults for missing fields — including a payload from
+      // before #15607 that still carries the old `organizeMode` key: it's
+      // simply ignored (an unknown field to `persist`) rather than migrated.
       showLlmProfiles: false,
-      organizeMode: "chronological",
+      groupByContainer: false,
+      groupByWorkspace: false,
       conversationSort: "updated",
       threadScope: "all",
     });
+  });
+
+  it("does not migrate a pre-#15607 organizeMode payload — grouping resets to off", async () => {
+    // Known, deliberate limitation: a user who had the old single "grouped"
+    // mode enabled sees a flat/chronological list once after upgrading,
+    // rather than automatically mapping to groupByWorkspace=true. Documented
+    // here so a future change to add that migration doesn't silently
+    // contradict this test.
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: { organizeMode: "grouped" },
+        version: 0,
+      }),
+    );
+
+    await useConversationPanelPreferencesStore.persist.rehydrate();
+
+    const state = useConversationPanelPreferencesStore.getState();
+    expect(state.groupByContainer).toBe(false);
+    expect(state.groupByWorkspace).toBe(false);
   });
 
   it("preserves an explicitly enabled LLM-profiles preference from persisted storage", async () => {

--- a/src/components/features/conversation-panel/conversation-group-section-header.tsx
+++ b/src/components/features/conversation-panel/conversation-group-section-header.tsx
@@ -1,0 +1,29 @@
+import { Box } from "lucide-react";
+
+interface ConversationGroupSectionHeaderProps {
+  label: string;
+}
+
+/**
+ * Non-interactive heading rendered above a container's folders when both
+ * "Group by container" and "Group by workspace" are active (#15607).
+ *
+ * Only the nested (both-toggles-on) view renders this — the single-axis
+ * grouped views keep rendering their existing flat folder list unchanged,
+ * with no header at all.
+ */
+export function ConversationGroupSectionHeader({
+  label,
+}: ConversationGroupSectionHeaderProps) {
+  return (
+    <div
+      data-testid="conversation-group-section-header"
+      className="flex min-w-0 items-center gap-1.5 px-2 pb-1 pt-3 first:pt-1"
+    >
+      <Box className="h-3 w-3 shrink-0 text-[var(--oh-muted)]" aria-hidden />
+      <span className="min-w-0 truncate text-[11px] font-semibold uppercase tracking-wide text-[var(--oh-muted)]">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/features/conversation-panel/conversation-panel-filter-menu.tsx
+++ b/src/components/features/conversation-panel/conversation-panel-filter-menu.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next";
 import {
   Archive,
   Bot,
+  Box,
   CalendarArrowDown,
-  Clock3,
   ClockArrowDown,
   Eye,
   EyeOff,
@@ -30,7 +30,6 @@ import {
   UNNAMED_AUTOMATION_FACET,
   type AutomationFilterMode,
   type ConversationSortField,
-  type OrganizeMode,
   type ThreadScope,
 } from "./conversation-panel-list-helpers";
 import { MenuHeading } from "./menu-heading";
@@ -45,8 +44,10 @@ export interface ConversationPanelFilterMenuProps {
   setFilterMenuOpen: (open: boolean) => void;
   menuRef: React.RefObject<HTMLDivElement | null>;
   backendKind: BackendKind;
-  organizeMode: OrganizeMode;
-  setOrganizeMode: (mode: OrganizeMode) => void;
+  groupByContainer: boolean;
+  toggleGroupByContainer: () => void;
+  groupByWorkspace: boolean;
+  toggleGroupByWorkspace: () => void;
   conversationSort: ConversationSortField;
   setConversationSort: (sort: ConversationSortField) => void;
   threadScope: ThreadScope;
@@ -77,8 +78,10 @@ export function ConversationPanelFilterMenu({
   setFilterMenuOpen,
   menuRef,
   backendKind,
-  organizeMode,
-  setOrganizeMode,
+  groupByContainer,
+  toggleGroupByContainer,
+  groupByWorkspace,
+  toggleGroupByWorkspace,
   conversationSort,
   setConversationSort,
   threadScope,
@@ -105,7 +108,7 @@ export function ConversationPanelFilterMenu({
 }: ConversationPanelFilterMenuProps) {
   const { t } = useTranslation("openhands");
 
-  const groupedLabel =
+  const groupByWorkspaceLabel =
     backendKind === "local"
       ? t(I18nKey.CONVERSATION_PANEL$BY_WORKSPACE)
       : t(I18nKey.CONVERSATION_PANEL$BY_REPOSITORY);
@@ -213,23 +216,29 @@ export function ConversationPanelFilterMenu({
           )}
         >
           <MenuHeading>{t(I18nKey.CONVERSATION_PANEL$ORGANIZE)}</MenuHeading>
+          {/*
+            Two independent checkboxes (#15607) rather than the previous
+            grouped/chronological radio pair: either, both, or neither can be
+            on. Unlike the old radio rows, toggling one of these does not
+            close the menu — a checkbox is meant to be flipped alongside its
+            sibling, and a menu that closes on the first click would make
+            enabling both an extra re-open.
+          */}
           <MenuRow
             icon={Folder}
-            label={groupedLabel}
-            selected={organizeMode === "grouped"}
-            onClick={() => {
-              setOrganizeMode("grouped");
-              setFilterMenuOpen(false);
-            }}
+            label={groupByWorkspaceLabel}
+            variant="checkbox"
+            selected={groupByWorkspace}
+            onClick={toggleGroupByWorkspace}
+            testId="organize-group-by-workspace"
           />
           <MenuRow
-            icon={Clock3}
-            label={t(I18nKey.CONVERSATION_PANEL$CHRONOLOGICAL)}
-            selected={organizeMode === "chronological"}
-            onClick={() => {
-              setOrganizeMode("chronological");
-              setFilterMenuOpen(false);
-            }}
+            icon={Box}
+            label={t(I18nKey.CONVERSATION_PANEL$BY_CONTAINER)}
+            variant="checkbox"
+            selected={groupByContainer}
+            onClick={toggleGroupByContainer}
+            testId="organize-group-by-container"
           />
 
           <MenuSeparator />

--- a/src/components/features/conversation-panel/conversation-panel-list-helpers.ts
+++ b/src/components/features/conversation-panel/conversation-panel-list-helpers.ts
@@ -9,7 +9,6 @@ import {
 
 export type ConversationSortField = "created" | "updated";
 export type ThreadScope = "all" | "relevant";
-export type OrganizeMode = "grouped" | "chronological";
 export type AutomationFilterMode =
   | "all"
   | "hide-automations"
@@ -487,6 +486,204 @@ export function groupConversations(
 
   groups.sort((a, b) => groupOrderKey(b) - groupOrderKey(a));
   return groups;
+}
+
+/**
+ * Facet bucket for a conversation with no `sandbox_id` (mirrors the
+ * `__none_workspace` / `__none_repo` idiom above).
+ */
+export const UNKNOWN_CONTAINER_GROUP_ID = "__none_container";
+
+/**
+ * Resolves the "container" grouping key for #15607.
+ *
+ * `sandbox_id` is currently the only per-conversation field that could match
+ * the issue's "Container" concept (there is no `container_id` on
+ * `AppConversation`) — flagged as an open question on the issue for a
+ * maintainer to confirm. `sandbox_id` is an opaque id with no friendlier
+ * display name available today, so the label is the id itself; swap this for
+ * a nicer name if/when one becomes available on the conversation model.
+ */
+function containerGroup(conversation: AppConversation): {
+  id: string;
+  label: string;
+} {
+  const sandboxId = conversation.sandbox_id?.trim();
+  if (!sandboxId) {
+    return { id: UNKNOWN_CONTAINER_GROUP_ID, label: "" };
+  }
+  return { id: `container:${sandboxId}`, label: sandboxId };
+}
+
+function bucketByContainer(
+  items: readonly AppConversation[],
+  emptyContainerLabel: string,
+): Map<string, { label: string; conversations: AppConversation[] }> {
+  const byId = new Map<
+    string,
+    { label: string; conversations: AppConversation[] }
+  >();
+  for (const c of items) {
+    const { id, label: rawLabel } = containerGroup(c);
+    const label =
+      id === UNKNOWN_CONTAINER_GROUP_ID ? emptyContainerLabel : rawLabel;
+    const bucket = byId.get(id);
+    if (bucket) {
+      bucket.conversations.push(c);
+    } else {
+      byId.set(id, { label, conversations: [c] });
+    }
+  }
+  return byId;
+}
+
+/** Most-recent activity across a bucket's conversations, for section/group ordering. */
+function bucketOrderKey(
+  conversations: readonly AppConversation[],
+  sortField: ConversationSortField,
+): number {
+  return conversations.reduce(
+    (max, c) =>
+      Math.max(
+        max,
+        parseConversationTimeMs(
+          sortField === "created" ? c.created_at : c.updated_at,
+        ),
+      ),
+    0,
+  );
+}
+
+export interface ConversationLeafGroup {
+  id: string;
+  label: string;
+  conversations: AppConversation[];
+  launch: ConversationGroupLaunch;
+}
+
+export interface ConversationGroupSection {
+  /**
+   * Present only when both grouping axes are active — the outer "container"
+   * level of the nested view. `null` for the single-axis (or ungrouped)
+   * cases, which render as one section with no header, identical to today's
+   * flat `groupConversations` output.
+   */
+  container: { id: string; label: string } | null;
+  groups: ConversationLeafGroup[];
+}
+
+export interface ConversationGroupLabels {
+  emptyWorkspace: string;
+  emptyRepository: string;
+  emptyContainer: string;
+}
+
+/**
+ * Builds the sidebar's grouped view for #15607's two independent grouping
+ * toggles ("Group by Container" and "Group by Workspace").
+ *
+ * - Neither on: returns `[]` (callers render the plain chronological list
+ *   instead of calling this at all).
+ * - Exactly one on: returns a single section (`container: null`) whose
+ *   `groups` are identical in shape to today's `groupConversations` output —
+ *   the existing single-axis rendering path is unaffected.
+ * - Both on: containers are the outer level, workspace/repository is the
+ *   inner level (matching the Container > Workspace tree in the issue).
+ *   Inner group ids are qualified with their container id
+ *   (`${containerId}|${innerId}`) so two containers that happen to share a
+ *   workspace path or repository can't collide into one rendered/ordered
+ *   group.
+ *
+ * `knownWorkspaces` pre-seeding (empty local-workspace folders with no
+ * loaded conversations yet) only applies to the workspace-only axis, exactly
+ * as it does today — it is intentionally NOT forwarded when containers are
+ * also grouped, since that would inject an empty workspace folder into every
+ * container section rather than just the workspaces the user actually has.
+ */
+export function buildConversationGroups(
+  items: readonly AppConversation[],
+  backendKind: BackendKind,
+  sortField: ConversationSortField,
+  options: {
+    groupByContainer: boolean;
+    groupByWorkspace: boolean;
+    labels: ConversationGroupLabels;
+    knownWorkspaces?: readonly LocalWorkspace[];
+  },
+): ConversationGroupSection[] {
+  const { groupByContainer, groupByWorkspace, labels, knownWorkspaces } =
+    options;
+
+  if (!groupByContainer && !groupByWorkspace) {
+    return [];
+  }
+
+  if (groupByWorkspace && !groupByContainer) {
+    // Exactly today's single-axis behavior, wrapped in one headerless section.
+    const groups = groupConversations(
+      items,
+      backendKind,
+      sortField,
+      {
+        emptyWorkspace: labels.emptyWorkspace,
+        emptyRepository: labels.emptyRepository,
+      },
+      knownWorkspaces,
+    );
+    return [{ container: null, groups }];
+  }
+
+  if (groupByContainer && !groupByWorkspace) {
+    // Container-only: same single-level shape, keyed by container instead.
+    const byId = bucketByContainer(items, labels.emptyContainer);
+    const groups: ConversationLeafGroup[] = [...byId.entries()]
+      .map(([id, bucket]) => ({
+        id,
+        label: bucket.label,
+        conversations: sortConversationsByField(
+          bucket.conversations,
+          sortField,
+        ),
+        // Container folders have no "start a new conversation here" target —
+        // unlike a workspace/repo, a sandbox isn't something you launch into.
+        launch: {} as ConversationGroupLaunch,
+      }))
+      .sort(
+        (a, b) =>
+          bucketOrderKey(b.conversations, sortField) -
+          bucketOrderKey(a.conversations, sortField),
+      );
+    return [{ container: null, groups }];
+  }
+
+  // Both on: nest workspace/repository groups inside each container.
+  const byContainer = bucketByContainer(items, labels.emptyContainer);
+  const sections = [...byContainer.entries()].map(([containerId, bucket]) => {
+    const innerGroups = groupConversations(
+      bucket.conversations,
+      backendKind,
+      sortField,
+      {
+        emptyWorkspace: labels.emptyWorkspace,
+        emptyRepository: labels.emptyRepository,
+      },
+      // See the doc comment above: known-workspace pre-seeding is deliberately
+      // not forwarded here.
+    ).map((g) => ({ ...g, id: `${containerId}|${g.id}` }));
+    return {
+      container: { id: containerId, label: bucket.label },
+      groups: innerGroups,
+      _conversations: bucket.conversations,
+    };
+  });
+
+  sections.sort(
+    (a, b) =>
+      bucketOrderKey(b._conversations, sortField) -
+      bucketOrderKey(a._conversations, sortField),
+  );
+
+  return sections.map(({ container, groups }) => ({ container, groups }));
 }
 
 export function applyGroupFolderOrder<T extends { id: string }>(

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -36,14 +36,15 @@ import { cn } from "#/utils/utils";
 import { ConversationPanelFilterMenu } from "./conversation-panel-filter-menu";
 import { ConversationPanelNewThreadPicker } from "./conversation-panel-new-thread-picker";
 import { ConversationGroupFolderList } from "./conversation-group-folder-list";
+import { ConversationGroupSectionHeader } from "./conversation-group-section-header";
 import { ConversationPanelPinnedSection } from "./conversation-panel-pinned-section";
 import {
   applyAutomationConversationFilter,
   applyGroupFolderOrder,
+  buildConversationGroups,
   collectAutomationNameFacets,
   filterOutPinnedConversations,
   getGroupDiscoveryConversationIds,
-  groupConversations,
   MAX_PAGES_PER_LOAD_MORE_CLICK,
   resolvePinnedConversations,
   sortConversationsByField,
@@ -152,12 +153,22 @@ export function ConversationPanel({
   const toggleShowHoverMetadata = useConversationPanelPreferencesStore(
     (state) => state.toggleShowHoverMetadata,
   );
-  const organizeMode = useConversationPanelPreferencesStore(
-    (state) => state.organizeMode,
+  const groupByContainer = useConversationPanelPreferencesStore(
+    (state) => state.groupByContainer,
   );
-  const setOrganizeMode = useConversationPanelPreferencesStore(
-    (state) => state.setOrganizeMode,
+  const toggleGroupByContainer = useConversationPanelPreferencesStore(
+    (state) => state.toggleGroupByContainer,
   );
+  const groupByWorkspace = useConversationPanelPreferencesStore(
+    (state) => state.groupByWorkspace,
+  );
+  const toggleGroupByWorkspace = useConversationPanelPreferencesStore(
+    (state) => state.toggleGroupByWorkspace,
+  );
+  // Either toggle puts the list into "grouped" rendering; both together
+  // additionally nest workspace/repository folders inside container folders
+  // (see `buildConversationGroups`). Neither is the plain chronological list.
+  const isGrouped = groupByContainer || groupByWorkspace;
   const conversationSort = useConversationPanelPreferencesStore(
     (state) => state.conversationSort,
   );
@@ -254,11 +265,11 @@ export function ConversationPanel({
   }, []);
 
   React.useEffect(() => {
-    if (organizeMode !== "grouped") {
+    if (!isGrouped) {
       setCollapsedGroupIds(new Set());
       setExpandedGroupPreviewIds(new Set());
     }
-  }, [organizeMode]);
+  }, [isGrouped]);
 
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
 
@@ -345,14 +356,14 @@ export function ConversationPanel({
     [conversations],
   );
 
+  // Pre-seeds empty known-workspace folders (see `groupConversations`). Only
+  // meaningful for the workspace grouping axis — computed whenever that
+  // toggle is on, but deliberately NOT forwarded to `buildConversationGroups`
+  // when container grouping is also active (see that function's doc comment).
   const allWorkspacesForGrouping = React.useMemo<
     readonly LocalWorkspace[]
   >(() => {
-    if (
-      compact ||
-      organizeMode !== "grouped" ||
-      activeBackend.kind !== "local"
-    ) {
+    if (compact || !groupByWorkspace || activeBackend.kind !== "local") {
       return [];
     }
     const normalize = (p: string) => p.trim().replace(/\/+$/, "");
@@ -381,8 +392,8 @@ export function ConversationPanel({
     activeBackend.kind,
     compact,
     conversations,
+    groupByWorkspace,
     knownWorkspaces,
-    organizeMode,
   ]);
 
   const automationFilteredConversations = React.useMemo(
@@ -466,50 +477,62 @@ export function ConversationPanel({
     () => ({
       emptyWorkspace: t(I18nKey.CONVERSATION_PANEL$NO_WORKSPACE),
       emptyRepository: t(I18nKey.CONVERSATION_PANEL$NO_REPOSITORY),
+      emptyContainer: t(I18nKey.CONVERSATION_PANEL$NO_CONTAINER),
     }),
     [t],
   );
 
   const groupedSourceConversations = React.useMemo(() => {
-    if (compact || organizeMode !== "grouped") {
+    if (compact || !isGrouped) {
       return null;
     }
-    // Use the unsorted partitions: groupConversations sorts each bucket
+    // Use the unsorted partitions: the grouping helpers sort each bucket
     // internally by `sortField`, so pre-sorting the merged input is wasted
     // work in grouped mode (the per-group sort overrides any global order).
     return [...recentScoped, ...(showOlderConversations ? olderScoped : [])];
-  }, [
-    compact,
-    olderScoped,
-    organizeMode,
-    recentScoped,
-    showOlderConversations,
-  ]);
+  }, [compact, isGrouped, olderScoped, recentScoped, showOlderConversations]);
 
-  const conversationGroups = React.useMemo(() => {
+  const conversationSections = React.useMemo(() => {
     if (!groupedSourceConversations) {
       return null;
     }
     // Keep every loaded conversation in the group model. Folder discovery only
     // freezes the collapsed preview — expanding a folder must reach later-page
     // rows for that same workspace/repo.
-    return groupConversations(
+    return buildConversationGroups(
       groupedSourceConversations,
       activeBackend.kind,
       conversationSort,
-      groupLabels,
-      allWorkspacesForGrouping,
+      {
+        groupByContainer,
+        groupByWorkspace,
+        labels: groupLabels,
+        // Deliberately omitted when container grouping is also active — see
+        // `buildConversationGroups`'s doc comment.
+        knownWorkspaces: groupByContainer
+          ? undefined
+          : allWorkspacesForGrouping,
+      },
     );
   }, [
     activeBackend.kind,
+    allWorkspacesForGrouping,
     conversationSort,
+    groupByContainer,
+    groupByWorkspace,
     groupLabels,
     groupedSourceConversations,
-    allWorkspacesForGrouping,
   ]);
 
+  // Discovery-page freezing (the recently-merged folder-pagination fix) is
+  // only wired up for the pre-existing single-axis workspace/repository
+  // grouping, which is the exact scenario it was built and reviewed against.
+  // Container-only and nested grouping fall back to the plain
+  // most-recent-N-conversations preview (`getGroupConversationPreview` with
+  // no discovery pool) instead of extending that pagination machinery to
+  // axes it wasn't designed for — see the PR notes for why.
   const groupDiscoveryConversationIds = React.useMemo(() => {
-    if (!groupedSourceConversations) {
+    if (!groupedSourceConversations || groupByContainer) {
       return null;
     }
     return getGroupDiscoveryConversationIds(
@@ -522,19 +545,33 @@ export function ConversationPanel({
     activeBackend.kind,
     conversationPageById,
     currentConversationId,
+    groupByContainer,
     groupedSourceConversations,
   ]);
 
-  const orderedConversationGroups = React.useMemo(() => {
-    if (!conversationGroups) {
+  const orderedConversationSections = React.useMemo(() => {
+    if (!conversationSections) {
       return null;
     }
-    return applyGroupFolderOrder(conversationGroups, groupFolderOrder);
-  }, [conversationGroups, groupFolderOrder]);
+    // Drag-and-drop reordering (`groupFolderOrder`) is intentionally scoped
+    // within each section: applying the same persisted order independently
+    // per container means a folder can be reordered among its container's
+    // siblings, but not dragged across containers. That matches today's
+    // single-level behavior when nesting is off (there is only one section),
+    // and is a deliberately narrow limitation when nesting is on.
+    return conversationSections.map((section) => ({
+      ...section,
+      groups: applyGroupFolderOrder(section.groups, groupFolderOrder),
+    }));
+  }, [conversationSections, groupFolderOrder]);
 
-  const conversationGroupIds = React.useMemo(
-    () => conversationGroups?.map((group) => group.id) ?? [],
-    [conversationGroups],
+  const visibleGroupCount = React.useMemo(
+    () =>
+      orderedConversationSections?.reduce(
+        (count, section) => count + section.groups.length,
+        0,
+      ) ?? 0,
+    [orderedConversationSections],
   );
 
   const compactVisibleConversations = React.useMemo(
@@ -550,12 +587,8 @@ export function ConversationPanel({
 
   const visibleFlatCount = sortedVisibleConversations.length;
 
-  const visibleGroupCount = orderedConversationGroups?.length ?? 0;
-
   const listIsEffectivelyEmpty =
-    organizeMode === "grouped" && !compact
-      ? visibleGroupCount === 0
-      : visibleFlatCount === 0;
+    isGrouped && !compact ? visibleGroupCount === 0 : visibleFlatCount === 0;
 
   // Attribution is exact: the automation filter step itself produced zero
   // rows out of a non-empty loaded set (not merely threadScope/older-cutoff
@@ -572,9 +605,7 @@ export function ConversationPanel({
   // driver walks past them (bounded by the per-click page cap) so a single
   // click can still reach a folder hiding behind deepen-only pages.
   const visibleCount =
-    organizeMode === "grouped" && !compact
-      ? visibleGroupCount
-      : visibleFlatCount;
+    isGrouped && !compact ? visibleGroupCount : visibleFlatCount;
   const loadedPageCount = data?.pages.length ?? 0;
 
   // KNOWN ISSUE (unresolved as of 2026-05-29): users still report that the
@@ -634,7 +665,7 @@ export function ConversationPanel({
     // Chronological mode keeps its pre-existing behavior: fetch until a
     // visible row appears or pages run out.
     if (
-      organizeMode === "grouped" &&
+      isGrouped &&
       !compact &&
       loadMorePageFloor != null &&
       loadedPageCount >= loadMorePageFloor + MAX_PAGES_PER_LOAD_MORE_CLICK
@@ -661,7 +692,7 @@ export function ConversationPanel({
     loadMorePageFloor,
     visibleCount,
     loadedPageCount,
-    organizeMode,
+    isGrouped,
     hasNextPage,
     isFetching,
     isFetchingNextPage,
@@ -1002,11 +1033,7 @@ export function ConversationPanel({
   const showInitialSkeleton = isLoading || !isFetched;
   const showPinnedSection =
     !compact && !showInitialSkeleton && pinnedConversations.length > 0;
-  const hasVisibleGroups =
-    organizeMode === "grouped" &&
-    !compact &&
-    orderedConversationGroups != null &&
-    orderedConversationGroups.length > 0;
+  const hasVisibleGroups = isGrouped && !compact && visibleGroupCount > 0;
   const showEmptyState =
     isFetched &&
     !isLoading &&
@@ -1049,8 +1076,10 @@ export function ConversationPanel({
                 setFilterMenuOpen={setFilterMenuOpen}
                 menuRef={filterMenuRef}
                 backendKind={activeBackend.kind}
-                organizeMode={organizeMode}
-                setOrganizeMode={setOrganizeMode}
+                groupByContainer={groupByContainer}
+                toggleGroupByContainer={toggleGroupByContainer}
+                groupByWorkspace={groupByWorkspace}
+                toggleGroupByWorkspace={toggleGroupByWorkspace}
                 conversationSort={conversationSort}
                 setConversationSort={setConversationSort}
                 threadScope={threadScope}
@@ -1118,7 +1147,7 @@ export function ConversationPanel({
               setExpandedPinnedPreview((current) => !current)
             }
             activeConversationId={currentConversationId}
-            showDivider={!compact && organizeMode === "chronological"}
+            showDivider={!compact && !isGrouped}
             renderConversationCard={(conversation) =>
               renderConversationCard(conversation, { inPinnedSection: true })
             }
@@ -1147,31 +1176,56 @@ export function ConversationPanel({
 
         {!showInitialSkeleton &&
         !compact &&
-        organizeMode === "grouped" &&
-        orderedConversationGroups &&
-        orderedConversationGroups.length > 0 ? (
-          <ConversationGroupFolderList
-            groups={orderedConversationGroups}
-            groupIds={conversationGroupIds}
-            groupFolderOrder={groupFolderOrder}
-            setGroupFolderOrder={setGroupFolderOrder}
-            collapsedGroupIds={collapsedGroupIds}
-            expandedGroupPreviewIds={expandedGroupPreviewIds}
-            discoveryConversationIds={groupDiscoveryConversationIds}
-            onToggleGroupCollapsed={toggleGroupCollapsed}
-            onToggleGroupPreviewExpanded={toggleGroupPreviewExpanded}
-            isCreatingConversationFlow={isCreatingConversationFlow}
-            activeConversationId={currentConversationId}
-            onLaunchFromGroup={launchFromGroup}
-            renderConversationCard={(conversation) =>
-              renderConversationCard(conversation)
-            }
-          />
-        ) : null}
+        isGrouped &&
+        orderedConversationSections &&
+        visibleGroupCount > 0
+          ? orderedConversationSections.map((section) => {
+              const sectionGroupIds = section.groups.map((group) => group.id);
+              // Each section reorders independently: a drag only rearranges
+              // folders within their own container (or within the single
+              // implicit section when only one axis is grouped). Merging the
+              // scoped result back into the full persisted order keeps other
+              // sections' custom orders intact instead of the write
+              // silently dropping them.
+              const setSectionGroupFolderOrder = (order: readonly string[]) => {
+                const sectionIdSet = new Set(sectionGroupIds);
+                setGroupFolderOrder([
+                  ...groupFolderOrder.filter((id) => !sectionIdSet.has(id)),
+                  ...order,
+                ]);
+              };
+              return (
+                <React.Fragment
+                  key={section.container?.id ?? "__ungrouped_section"}
+                >
+                  {section.container ? (
+                    <ConversationGroupSectionHeader
+                      label={section.container.label}
+                    />
+                  ) : null}
+                  <ConversationGroupFolderList
+                    groups={section.groups}
+                    groupIds={sectionGroupIds}
+                    groupFolderOrder={groupFolderOrder}
+                    setGroupFolderOrder={setSectionGroupFolderOrder}
+                    collapsedGroupIds={collapsedGroupIds}
+                    expandedGroupPreviewIds={expandedGroupPreviewIds}
+                    discoveryConversationIds={groupDiscoveryConversationIds}
+                    onToggleGroupCollapsed={toggleGroupCollapsed}
+                    onToggleGroupPreviewExpanded={toggleGroupPreviewExpanded}
+                    isCreatingConversationFlow={isCreatingConversationFlow}
+                    activeConversationId={currentConversationId}
+                    onLaunchFromGroup={launchFromGroup}
+                    renderConversationCard={(conversation) =>
+                      renderConversationCard(conversation)
+                    }
+                  />
+                </React.Fragment>
+              );
+            })
+          : null}
 
-        {!showInitialSkeleton &&
-        !compact &&
-        organizeMode === "chronological" ? (
+        {!showInitialSkeleton && !compact && !isGrouped ? (
           <div className="space-y-0.5">
             {sortedVisibleConversations.map((conversation) =>
               renderConversationCard(conversation),

--- a/src/components/features/conversation-panel/menu-row.tsx
+++ b/src/components/features/conversation-panel/menu-row.tsx
@@ -10,6 +10,7 @@ export function MenuRow({
   icon: Icon,
   label,
   selected,
+  variant = "radio",
   onClick,
   testId,
   disabled,
@@ -17,17 +18,27 @@ export function MenuRow({
   icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
   label: string;
   selected?: boolean;
+  /**
+   * `"radio"` (default) is a row that's part of a mutually exclusive group
+   * (picking one clears the others — e.g. Sort by). `"checkbox"` is an
+   * independently toggleable row (e.g. the #15607 grouping toggles) that
+   * doesn't imply anything about sibling rows.
+   */
+  variant?: "radio" | "checkbox";
   onClick: () => void;
   testId?: string;
   disabled?: boolean;
 }) {
-  // Rows that show a selection checkmark are toggleable preferences, so
-  // they get `role="menuitemradio"` when they're part of a selectable
-  // group and `role="menuitemcheckbox"` when they're a standalone toggle.
-  // For simplicity we use `menuitemradio` whenever `selected` is provided
-  // (every selectable row in this menu is part of a mutually exclusive
-  // group in practice) and fall back to plain `menuitem` otherwise.
-  const role = selected === undefined ? "menuitem" : "menuitemradio";
+  // Rows that show a selection checkmark are toggleable preferences, so they
+  // get `role="menuitemradio"` when they're part of a mutually exclusive
+  // group and `role="menuitemcheckbox"` when each row toggles independently.
+  // A row with no `selected` state at all falls back to plain `menuitem`.
+  const role =
+    selected === undefined
+      ? "menuitem"
+      : variant === "checkbox"
+        ? "menuitemcheckbox"
+        : "menuitemradio";
   return (
     <button
       type="button"

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -17834,6 +17834,23 @@
     "tr": "Depoya göre",
     "uk": "За репозиторієм"
   },
+  "CONVERSATION_PANEL$BY_CONTAINER": {
+    "en": "By container",
+    "ja": "コンテナ別",
+    "zh-CN": "按容器",
+    "zh-TW": "依容器",
+    "ko-KR": "컨테이너별",
+    "no": "Etter container",
+    "ar": "حسب الحاوية",
+    "de": "Nach Container",
+    "fr": "Par conteneur",
+    "it": "Per container",
+    "pt": "Por container",
+    "es": "Por contenedor",
+    "ca": "Per contenidor",
+    "tr": "Konteynere göre",
+    "uk": "За контейнером"
+  },
   "CONVERSATION_PANEL$CHRONOLOGICAL": {
     "en": "Chronological list",
     "ja": "時系列リスト",
@@ -18224,6 +18241,23 @@
     "ca": "Sense repositori",
     "tr": "Depo yok",
     "uk": "Немає репозиторію"
+  },
+  "CONVERSATION_PANEL$NO_CONTAINER": {
+    "en": "No container",
+    "ja": "コンテナなし",
+    "zh-CN": "无容器",
+    "zh-TW": "無容器",
+    "ko-KR": "컨테이너 없음",
+    "no": "Ingen container",
+    "ar": "لا توجد حاوية",
+    "de": "Kein Container",
+    "fr": "Aucun conteneur",
+    "it": "Nessun container",
+    "pt": "Sem container",
+    "es": "Sin contenedor",
+    "ca": "Sense contenidor",
+    "tr": "Konteyner yok",
+    "uk": "Немає контейнера"
   },
   "CONVERSATION_PANEL$NEW_THREAD_FOLDER_ARIA": {
     "en": "Create thread folder — choose workspace or repository",

--- a/src/stores/conversation-panel-preferences-store.ts
+++ b/src/stores/conversation-panel-preferences-store.ts
@@ -3,7 +3,6 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import {
   type AutomationFilterMode,
   type ConversationSortField,
-  type OrganizeMode,
   type ThreadScope,
 } from "#/components/features/conversation-panel/conversation-panel-list-helpers";
 
@@ -27,7 +26,15 @@ interface ConversationPanelPreferencesState {
   showLlmProfiles: boolean;
   showTagsMetadata: boolean;
   showHoverMetadata: boolean;
-  organizeMode: OrganizeMode;
+  /**
+   * Independent grouping toggles (#15607). Both may be active at once, in
+   * which case the sidebar nests container folders around workspace/
+   * repository folders (see `buildConversationGroups`). Neither active is
+   * the pre-existing "chronological" list — there is no longer a distinct
+   * persisted mode for it, it's just the all-off state.
+   */
+  groupByContainer: boolean;
+  groupByWorkspace: boolean;
   conversationSort: ConversationSortField;
   threadScope: ThreadScope;
   automationFilterMode: AutomationFilterMode;
@@ -48,7 +55,10 @@ interface ConversationPanelPreferencesActions {
   toggleShowTagsMetadata: () => void;
   setShowHoverMetadata: (value: boolean) => void;
   toggleShowHoverMetadata: () => void;
-  setOrganizeMode: (value: OrganizeMode) => void;
+  setGroupByContainer: (value: boolean) => void;
+  toggleGroupByContainer: () => void;
+  setGroupByWorkspace: (value: boolean) => void;
+  toggleGroupByWorkspace: () => void;
   setConversationSort: (value: ConversationSortField) => void;
   setThreadScope: (value: ThreadScope) => void;
   setAutomationFilterMode: (value: AutomationFilterMode) => void;
@@ -66,7 +76,8 @@ const initialState: ConversationPanelPreferencesState = {
   showLlmProfiles: false,
   showTagsMetadata: false,
   showHoverMetadata: true,
-  organizeMode: "chronological",
+  groupByContainer: false,
+  groupByWorkspace: false,
   conversationSort: "updated",
   threadScope: "all",
   automationFilterMode: "all",
@@ -121,7 +132,16 @@ export const useConversationPanelPreferencesStore =
             showHoverMetadata: !state.showHoverMetadata,
           })),
 
-        setOrganizeMode: (value) => set(() => ({ organizeMode: value })),
+        setGroupByContainer: (value) =>
+          set(() => ({ groupByContainer: value })),
+        toggleGroupByContainer: () =>
+          set((state) => ({ groupByContainer: !state.groupByContainer })),
+
+        setGroupByWorkspace: (value) =>
+          set(() => ({ groupByWorkspace: value })),
+        toggleGroupByWorkspace: () =>
+          set((state) => ({ groupByWorkspace: !state.groupByWorkspace })),
+
         setConversationSort: (value) =>
           set(() => ({ conversationSort: value })),
         setThreadScope: (value) => set(() => ({ threadScope: value })),
@@ -151,7 +171,8 @@ export const useConversationPanelPreferencesStore =
           showLlmProfiles: state.showLlmProfiles,
           showTagsMetadata: state.showTagsMetadata,
           showHoverMetadata: state.showHoverMetadata,
-          organizeMode: state.organizeMode,
+          groupByContainer: state.groupByContainer,
+          groupByWorkspace: state.groupByWorkspace,
           conversationSort: state.conversationSort,
           threadScope: state.threadScope,
           automationFilterMode: state.automationFilterMode,


### PR DESCRIPTION
HUMAN:

I manually verified the conversation grouping controls in the local app. I tested Group by Workspace, Group by Container, and both enabled together.

Validation:
- 270 targeted tests passed
- ESLint: 0 errors
- npm run build:app succeeded
- TypeScript reports only the 2 pre-existing route typegen errors on clean main

## Why

Issue #15607 requests independent conversation grouping by workspace and container in the conversation panel.

This change makes those grouping options independent so users can enable either one by itself or use both together.

## Summary

AGENT:

Implemented independent conversation grouping controls for workspace and container grouping.

Changes:
- replaced the mutually exclusive grouping mode with separate workspace/container toggles
- added nested container → workspace grouping when both are enabled
- preserved scoped drag-and-drop ordering
- added container section rendering and i18n updates
- added regression tests for grouping behavior and toggle state

Closes #15607

## How to Test

1. Start the app locally.
2. Open the conversation panel.
3. Open the grouping/filter menu.
4. Enable Group by Workspace and verify conversations are grouped by workspace.
5. Disable it, enable Group by Container, and verify conversations are grouped by container.
6. Enable both together and verify container grouping contains nested workspace grouping.
7. Confirm the UI does not crash and the grouping controls remain independently toggleable.

Automated validation:
- 270 targeted tests passed
- ESLint: 0 errors
- npm run build:app succeeded
- TypeScript reports only the 2 pre-existing route typegen errors on clean main

## Video/Screenshots

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.49s · commit 0a55442  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** ⚠️ reduced context — partial coverage; 24/53 hunks, 12/12 files (context budget: 24, hunk budget: 29).

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 4.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 7.0% | No direct hunk selected |
| Contract regression | 28.0% | [F005H002 · \_\_tests\_\_/stores/conversation-panel-preferences-store.test.ts:93–102](https://github.com/OpenHands/OpenHands/blob/0a554426ab4e923b08a95772c22a75fcab70b0ae/__tests__/stores/conversation-panel-preferences-store.test.ts#L93-L102) |
| Data loss | 9.0% | No direct hunk selected |
| Sensitive data disclosure | 4.0% | No direct hunk selected |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 4.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 67.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 8bf12d6eddfc0e3cdc358812d3e4b6ad63b4bbc1622cf47b847c536ef83f22b8 -->
<!-- jev-fast-audit:end -->
