### PR TITLE
docs: correct local-stack persistence paths in DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,11 +37,13 @@ Both modes still start the ingress proxy; the proxy only routes to the services 
 
 The dev stack uses `uvx` to run a temporary `agent-server`
 installation on `127.0.0.1:18000` and points the frontend at it. It isolates
-conversation persistence by setting separate `OH_CONVERSATIONS_PATH`,
-`OH_BASH_EVENTS_DIR`, and `OH_VSCODE_PORT` values under `.openhands-dev/`, and
-keeps its tmux sockets under `~/.openhands/agent-canvas/tmux` (via
-`TMUX_TMPDIR`), so it does not collide with other local or cloud-backed
-OpenHands sessions. If `$HOME` is on a filesystem that does not support Unix
+conversation persistence under a dedicated `stateDir` (default
+`~/.openhands/agent-canvas`, or `OH_CANVAS_SAFE_STATE_DIR` when set):
+`OH_CONVERSATIONS_PATH` → `<stateDir>/dev_conversations`,
+`OH_BASH_EVENTS_DIR` → `<stateDir>/bash_events`, and tmux sockets under
+`<stateDir>/tmux` (via `TMUX_TMPDIR`). `OH_VSCODE_PORT` is also set so the
+VS Code sidecar does not collide with other local or cloud-backed OpenHands
+sessions. If `$HOME` is on a filesystem that does not support Unix
 domain sockets (some devcontainers, NFS/CIFS homes), set the standard
 `TMUX_TMPDIR` env var to a local path such as `/tmp` and the dev stack will use
 it instead.
@@ -88,7 +90,7 @@ OH_AGENT_SERVER_VERSION=1.18.0 npm run dev
 - `OH_CANVAS_SAFE_BACKEND_PORT` — backend port for the isolated server (default `18000`)
 - `OH_CANVAS_SAFE_VSCODE_PORT` — VS Code sidecar port (default `backend port + 1`)
 - `OH_CANVAS_SAFE_STATE_DIR` — base directory for isolated server state
-- `VITE_WORKING_DIR` — repo root used for new conversations (defaults to the current checkout)
+- `VITE_WORKING_DIR` — workspace path used for new conversations (defaults to `<stateDir>/workspaces` when unset)
 
 ## Alternative development workflows
 


### PR DESCRIPTION
HUMAN:

Compared docs/DEVELOPMENT.md against scripts/dev-safe.mjs buildConfigFromPorts on current main.

---

AGENT:

Docs-only: DEVELOPMENT.md now documents the real stateDir layout used by the local stack. No runtime behavior change.

## Why

## Why

Stale docs claim .openhands-dev isolation and current-checkout VITE_WORKING_DIR.
Actual scripts/dev-safe.mjs stateDir defaults to ~/.openhands/agent-canvas or OH_CANVAS_SAFE_STATE_DIR.
Paths: stateDir/dev_conversations, stateDir/bash_events, stateDir/tmux; VITE_WORKING_DIR defaults to stateDir/workspaces when unset.

## Summary

- Correct DEVELOPMENT.md stateDir persistence paths from scripts/dev-safe.mjs.
- Correct VITE_WORKING_DIR default description to stateDir/workspaces when unset.

## Issue Number
Fixes #17094

## How to Test

Docs-only. No runtime behavior to exercise.

1. Diff docs/DEVELOPMENT.md against main.
2. Confirm scripts/dev-safe.mjs buildConfigFromPorts paths match the docs.
3. Confirm .openhands-dev is no longer claimed as the isolation root.
4. Confirm VITE_WORKING_DIR bullet mentions stateDir/workspaces.

## Video/Screenshots

N/A - docs-only path correction in DEVELOPMENT.md; no UI or runtime behavior change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Docs-only. Distinct from api-key path / .env.sample doc fixes. Linked issue #17094 still needs the maintainer ready-for-dev label for Validate to pass.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.33s · commit 351069a  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 2/2 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 6.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 96.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 786b1344c3019794b4808d0ddc3f1b0cd6511c17d9ca3ec270018c458c5a0008 -->
<!-- jev-fast-audit:end -->
