### PR TITLE
docs: correct agent-server default version in DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -67,7 +67,7 @@ Access at `http://localhost:3001/`
 
 ### Agent server version selection
 
-By default, the latest released version from PyPI is used. You can override this (highest precedence first):
+By default, launchers pin the PyPI version from [`config/defaults.json`](../config/defaults.json) (`versions.agentServer`, currently `1.44.1`), not the latest PyPI release. You can override this (highest precedence first):
 
 ```sh
 # Run against a local software-agent-sdk checkout.
@@ -78,7 +78,7 @@ OH_AGENT_SERVER_GIT_REF=main npm run dev
 OH_AGENT_SERVER_GIT_REF=abc1234 npm run dev
 
 # Use a specific PyPI version
-OH_AGENT_SERVER_VERSION=1.18.0 npm run dev
+OH_AGENT_SERVER_VERSION=1.44.1 npm run dev
 ```
 
 `OH_AGENT_SERVER_LOCAL_PATH` must be an absolute path to a `software-agent-sdk` checkout containing the `openhands-agent-server`, `openhands-sdk`, `openhands-tools`, and `openhands-workspace` workspace packages. The agent-server itself is rebuilt from local source on each start (`uvx --reinstall`); the other workspace packages are installed editable, so their source changes take effect without a rebuild.


### PR DESCRIPTION
HUMAN:

Compared docs/DEVELOPMENT.md against config/defaults.json versions.agentServer and scripts/dev-safe.mjs buildAgentServerCommand on current main.

---

AGENT:

Docs-only: DEVELOPMENT.md now documents the config/defaults.json versions.agentServer pin as the agent-server default instead of latest PyPI. No runtime behavior change.

## Why

Stale docs claim the latest released PyPI version is used by default and show OH_AGENT_SERVER_VERSION=1.18.0.
Actual scripts/dev-safe.mjs buildAgentServerCommand uses config/defaults.json versions.agentServer (currently 1.44.1) when LOCAL_PATH / GIT_REF / VERSION are unset.

## Summary

- Correct DEVELOPMENT.md agent-server default to the config/defaults.json versions.agentServer pin.
- Update the OH_AGENT_SERVER_VERSION example from 1.18.0 to 1.44.1.

## Issue Number
Fixes #17096

## How to Test

Docs-only. No runtime behavior to exercise.

1. Diff docs/DEVELOPMENT.md against main.
2. Confirm config/defaults.json versions.agentServer is 1.44.1.
3. Confirm scripts/dev-safe.mjs DEFAULT_AGENT_SERVER_VERSION reads that pin.
4. Confirm DEVELOPMENT.md no longer claims latest PyPI as the default.
5. Confirm the OH_AGENT_SERVER_VERSION example is 1.44.1, not 1.18.0.

## Video/Screenshots

N/A - docs-only version-default correction in DEVELOPMENT.md; no UI or runtime behavior change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Docs-only. Distinct from local-stack persistence path docs in #17095 (different sentences; no overlapping hunk). Related GIT_REF table defaults remain tracked in #17065. Linked issue #17096 still needs the maintainer ready-for-dev label for Validate to pass.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.38s · commit d983328  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 2/2 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 2.0% | No direct hunk selected |
| Contract regression | 5.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 2.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 98.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 6966c7f6e35d2233b3e4b350e081e0300c86bb308e7fb8daa5707ac773961fa9 -->
<!-- jev-fast-audit:end -->
