### PR TITLE
docs: correct VITE_WORKING_DIR default in DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -197,7 +197,7 @@ You can create a `.env` file in the project directory with these variables based
 | `VITE_BACKEND_BASE_URL`     | Full base URL for the agent server used by direct browser requests                        | current browser origin |
 | `VITE_BACKEND_HOST`         | Backend host used by the Vite dev proxy                                                   | `127.0.0.1:8000`       |
 | `VITE_SESSION_API_KEY`      | (Internal) Session API key injected by the launcher — set `LOCAL_BACKEND_API_KEY` instead | -                      |
-| `VITE_WORKING_DIR`          | Workspace path sent when starting new conversations                                       | `workspace/project`    |
+| `VITE_WORKING_DIR`          | Workspace path sent when starting new conversations                                       | `<stateDir>/workspaces`    |
 | `VITE_ENABLE_BROWSER_TOOLS` | Set to `false` to omit `BrowserToolSet` from new conversation payloads                    | `true`                 |
 | `VITE_BASE_PATH`            | Build/serve the SPA under a subpath such as `/canvas`                                     | `/`                    |
 | `VITE_MOCK_API`             | Enable/disable API mocking with MSW                                                       | `false`                |


### PR DESCRIPTION
## Summary

The Environment variables table in `docs/DEVELOPMENT.md` listed `VITE_WORKING_DIR` default as `workspace/project`. Launchers default an unset `VITE_WORKING_DIR` to `<stateDir>/workspaces` (see `scripts/dev-safe.mjs` `workingDir: env.VITE_WORKING_DIR || workspacesPath` with `workspacesPath = path.join(stateDir, "workspaces")`).

Docs-only; no runtime change.

## How to Test

1. Diff `docs/DEVELOPMENT.md` against main.
2. Confirm `scripts/dev-safe.mjs` sets `workingDir` to `env.VITE_WORKING_DIR || workspacesPath` and `workspacesPath` is `path.join(stateDir, "workspaces")`.

## Type

- [x] Docs / chore