### PR TITLE
docs: correct OH_*_GIT_REF defaults in DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -51,8 +51,8 @@ it instead.
 | Variable                  | Description                    | Default |
 | ------------------------- | ------------------------------ | ------- |
 | `PORT`                    | Ingress port                   | `8000`  |
-| `OH_AUTOMATION_GIT_REF`   | Git ref for automation backend | `main`  |
-| `OH_AGENT_SERVER_GIT_REF` | Git ref for agent-server       | `main`  |
+| `OH_AUTOMATION_GIT_REF`   | Optional git ref for automation backend (overrides the version pin) | unset (uses `config/defaults.json` `versions.automation`) |
+| `OH_AGENT_SERVER_GIT_REF` | Optional git ref for agent-server (overrides the version pin)       | unset (uses `config/defaults.json` `versions.agentServer`) |
 
 ### Alternative: Minimal Mode (without Automation)
 


### PR DESCRIPTION
## Summary
- The recommended-workflow env table listed `OH_AGENT_SERVER_GIT_REF` / `OH_AUTOMATION_GIT_REF` defaults as `main`.
- Launchers leave both unset and pin PyPI versions from `config/defaults.json` (`versions.agentServer` / `versions.automation`); a git ref is an optional override.
- Docs now say unset + pin path instead of implying `main` is the default.

## Test plan
- [x] Cross-checked `scripts/dev-safe.mjs` `buildAgentServerCommand` and `scripts/dev-with-automation.mjs` `buildAutomationCommand` (GIT_REF only when set; else version pin).
- [x] Cross-checked `config/defaults.json` pins (`agentServer` / `automation`).
- [x] Confirmed change is limited to `docs/DEVELOPMENT.md` env table rows.