### PR TITLE
docs: correct OH_CANVAS_SAFE_VSCODE_PORT default in DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,7 +86,7 @@ OH_AGENT_SERVER_VERSION=1.18.0 npm run dev
 ### Other useful overrides
 
 - `OH_CANVAS_SAFE_BACKEND_PORT` — backend port for the isolated server (default `18000`)
-- `OH_CANVAS_SAFE_VSCODE_PORT` — VS Code sidecar port (default `backend port + 1`)
+- `OH_CANVAS_SAFE_VSCODE_PORT` — VS Code sidecar port (`dev:minimal` / `scripts/dev-safe.mjs` defaults to backend+1 and honors this override; full `npm run dev` / `scripts/dev-with-automation.mjs` uses backend+1000 so it does not collide with automation on backend+1)
 - `OH_CANVAS_SAFE_STATE_DIR` — base directory for isolated server state
 - `VITE_WORKING_DIR` — repo root used for new conversations (defaults to the current checkout)
 


### PR DESCRIPTION
## Summary
- `docs/DEVELOPMENT.md` "Other useful overrides" claimed `OH_CANVAS_SAFE_VSCODE_PORT` defaults to `backend port + 1`.
- That is only true for `npm run dev:minimal` (`scripts/dev-safe.mjs`).
- Full `npm run dev` (`scripts/dev-with-automation.mjs`) sets the VS Code sidecar to `preferredBackendPort + 1000` (e.g. 19000 when backend is 18000) so it does not collide with automation on backend+1 (18001).
- Docs now distinguish minimal vs full-dev defaults.

## Test plan / repro
- [x] `scripts/dev-safe.mjs`: `parsePort(env.OH_CANVAS_SAFE_VSCODE_PORT, backendPort + 1)` (and tests expect 18001 / override).
- [x] `scripts/dev-with-automation.mjs`: `const vscodePort = preferredBackendPort + 1000` (writes `OH_CANVAS_SAFE_VSCODE_PORT` to that value).
- [x] `package.json`: `"dev"` → `dev-with-automation.mjs`, `"dev:minimal"` → `dev-safe.mjs`.
- [x] Change limited to the one DEVELOPMENT.md bullet.
