### PR TITLE
feat(conversations): toggle grouped folders from header

### DIFF
--- a/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
+++ b/__tests__/components/features/conversation-panel/conversation-panel.test.tsx
@@ -2332,6 +2332,48 @@ describe("ConversationPanel", () => {
     });
   });
 
+  it("toggles all grouped workspace folders from the Conversations header", async () => {
+    useConversationPanelPreferencesStore.setState({ organizeMode: "grouped" });
+    vi.spyOn(
+      AgentServerConversationService,
+      "searchConversations",
+    ).mockResolvedValue({
+      items: [
+        createMockConversation({
+          id: "alpha-chat",
+          title: "Alpha Chat",
+          selected_workspace: "/workspace/alpha",
+        }),
+        createMockConversation({
+          id: "beta-chat",
+          title: "Beta Chat",
+          selected_workspace: "/workspace/beta",
+        }),
+      ],
+      next_page_id: null,
+    });
+
+    const user = userEvent.setup();
+    renderConversationPanel();
+
+    const toggle = await screen.findByTestId("conversations-folder-toggle");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Alpha Chat")).toBeInTheDocument();
+    expect(screen.getByText("Beta Chat")).toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Alpha Chat")).not.toBeInTheDocument();
+    expect(screen.queryByText("Beta Chat")).not.toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Alpha Chat")).toBeInTheDocument();
+    expect(screen.getByText("Beta Chat")).toBeInTheDocument();
+  });
+
   it("reorders grouped folders via drag and drop", async () => {
     useConversationPanelPreferencesStore.setState({
       organizeMode: "grouped",

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -537,6 +537,16 @@ export function ConversationPanel({
     [conversationGroups],
   );
 
+  const hasExpandedConversationGroups = conversationGroupIds.some(
+    (groupId) => !collapsedGroupIds.has(groupId),
+  );
+
+  const toggleAllConversationGroups = React.useCallback(() => {
+    setCollapsedGroupIds(
+      () => new Set(hasExpandedConversationGroups ? conversationGroupIds : []),
+    );
+  }, [conversationGroupIds, hasExpandedConversationGroups]);
+
   const compactVisibleConversations = React.useMemo(
     () =>
       sortConversationsByField(
@@ -1037,9 +1047,21 @@ export function ConversationPanel({
             data-testid="older-conversations-summary"
             className="flex min-w-0 flex-nowrap items-center gap-x-2 py-2 pl-4 pr-2.5 text-[var(--oh-muted)]"
           >
-            <span className="min-w-0 truncate text-sm font-medium text-[var(--oh-muted)]">
-              {t(I18nKey.SIDEBAR$CONVERSATIONS)}
-            </span>
+            {organizeMode === "grouped" && conversationGroupIds.length > 0 ? (
+              <button
+                type="button"
+                data-testid="conversations-folder-toggle"
+                aria-expanded={hasExpandedConversationGroups}
+                onClick={toggleAllConversationGroups}
+                className="min-w-0 truncate text-left text-sm font-medium text-[var(--oh-muted)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--oh-border)]"
+              >
+                {t(I18nKey.SIDEBAR$CONVERSATIONS)}
+              </button>
+            ) : (
+              <span className="min-w-0 truncate text-sm font-medium text-[var(--oh-muted)]">
+                {t(I18nKey.SIDEBAR$CONVERSATIONS)}
+              </span>
+            )}
             <div className="ml-auto flex shrink-0 items-center gap-0.5">
               <ConversationPanelNewThreadPicker
                 backendKind={activeBackend.kind}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN: 

Tested locally as part of creating august blog post.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
Write a concise summary of what changed and link any reviewer artifacts, such
as files under `.pr/`. For HTML artifacts, include a rendered preview link:
https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/.pr/<file>.html
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->
Implemented the grouped-conversation folder toggle in commit `f81e044d6`.

Verification evidence:
- Ran `npm test -- --run __tests__/components/features/conversation-panel/conversation-panel.test.tsx` — **60 tests passed**.
- Ran `npx eslint src/components/features/conversation-panel/conversation-panel.tsx` — passed.
- Ran `npm run typecheck` — passed.
- The new interaction test renders two workspace groups, clicks **Conversations** to confirm both groups collapse, then clicks it again to confirm both expand.

## Why

<!-- Describe problem, motivation, etc. -->
Fixes https://github.com/OpenHands/OpenHands/issues/17102 which became frustrating trying to capture some marketing content. I didn't want all my workspace folders open for every recording/screenshot. I just needed a quick way to toggle everything closed and open to find a conversation.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Make the **Conversations** header a grouped-folder toggle when conversation groups are visible.
- Collapse all visible groups when any group is expanded; expand all groups when every group is collapsed.
- Add regression coverage for the collapse-all and expand-all interaction.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->

Fixes #17102

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->
You can test by running npm build dev locally then use the filter to show By Workspace. Now the Conversations should clickable to open/close all visible workspace folders. Switching back to Chronological list should allow you to click Conversations and see nothing happen.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

https://github.com/user-attachments/assets/99f6cb65-2fc0-4d7b-b0f6-0c364fe34e8d


## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
