### PR TITLE
fix(home): drop repository search results for input the user has replaced

### DIFF
--- a/__tests__/components/features/home/use-url-search.test.tsx
+++ b/__tests__/components/features/home/use-url-search.test.tsx
@@ -278,4 +278,174 @@ describe("useUrlSearch", () => {
     // the non-matching HTTPS URL must not issue a second request.
     expect(mockSearchGitRepositories).toHaveBeenCalledTimes(1);
   });
+
+  describe("superseded requests", () => {
+    type SearchResult = Awaited<
+      ReturnType<typeof GitService.searchGitRepositories>
+    >;
+
+    const repo = (fullName: string) => ({
+      id: "1",
+      full_name: fullName,
+      git_provider: "github" as const,
+      is_public: true,
+    });
+
+    const pending = () => {
+      const resolvers: ((value: SearchResult) => void)[] = [];
+      const rejecters: ((reason: unknown) => void)[] = [];
+      mockSearchGitRepositories.mockImplementation(
+        () =>
+          new Promise<SearchResult>((resolve, reject) => {
+            resolvers.push(resolve);
+            rejecters.push(reject);
+          }),
+      );
+      return { resolvers, rejecters };
+    };
+
+    it("should not list a result for input the user has already cleared", async () => {
+      const { resolvers } = pending();
+
+      type TestProps = { inputValue: string };
+      const { result, rerender } = renderHook(
+        ({ inputValue }: TestProps) => useUrlSearch(inputValue, "github"),
+        {
+          initialProps: {
+            inputValue: "https://github.com/owner/repo-119",
+          } as TestProps,
+        },
+      );
+
+      await waitFor(() => {
+        expect(mockSearchGitRepositories).toHaveBeenCalledTimes(1);
+      });
+
+      // The user clears the field while that request is still in flight.
+      rerender({ inputValue: "" });
+
+      // Only now does the earlier request come back.
+      await act(async () => {
+        resolvers[0]({ items: [repo("owner/repo-119")], next_page_id: null });
+      });
+
+      expect(result.current.urlSearchResults).toEqual([]);
+      expect(result.current.isUrlSearchLoading).toBe(false);
+    });
+
+    it("should stop the spinner when the field is cleared mid-request", async () => {
+      pending();
+
+      type TestProps = { inputValue: string };
+      const { result, rerender } = renderHook(
+        ({ inputValue }: TestProps) => useUrlSearch(inputValue, "github"),
+        {
+          initialProps: {
+            inputValue: "https://github.com/owner/repo-119",
+          } as TestProps,
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isUrlSearchLoading).toBe(true);
+      });
+
+      rerender({ inputValue: "" });
+
+      await waitFor(() => {
+        expect(result.current.isUrlSearchLoading).toBe(false);
+      });
+    });
+
+    it("should stop the spinner when the provider is cleared mid-request", async () => {
+      pending();
+
+      type TestProps = { provider: "github" | null };
+      const { result, rerender } = renderHook(
+        ({ provider }: TestProps) =>
+          useUrlSearch("https://github.com/owner/repo-119", provider),
+        { initialProps: { provider: "github" } as TestProps },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isUrlSearchLoading).toBe(true);
+      });
+
+      rerender({ provider: null });
+
+      await waitFor(() => {
+        expect(result.current.isUrlSearchLoading).toBe(false);
+      });
+    });
+
+    it("should ignore an earlier request that resolves after a newer one started", async () => {
+      const { resolvers } = pending();
+
+      type TestProps = { inputValue: string };
+      const { result, rerender } = renderHook(
+        ({ inputValue }: TestProps) => useUrlSearch(inputValue, "github"),
+        {
+          initialProps: {
+            inputValue: "https://github.com/owner/repo-119",
+          } as TestProps,
+        },
+      );
+
+      await waitFor(() => {
+        expect(mockSearchGitRepositories).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ inputValue: "https://github.com/owner/repo-200" });
+
+      await waitFor(() => {
+        expect(mockSearchGitRepositories).toHaveBeenCalledTimes(2);
+      });
+
+      // The first request finishes late, after the second one is already out.
+      await act(async () => {
+        resolvers[0]({ items: [repo("owner/repo-119")], next_page_id: null });
+      });
+
+      expect(result.current.urlSearchResults).toEqual([]);
+      // The second request is still pending, so the spinner stays on.
+      expect(result.current.isUrlSearchLoading).toBe(true);
+    });
+
+    it("should not let an earlier failure clear a newer request's results", async () => {
+      const { resolvers, rejecters } = pending();
+
+      type TestProps = { inputValue: string };
+      const { result, rerender } = renderHook(
+        ({ inputValue }: TestProps) => useUrlSearch(inputValue, "github"),
+        {
+          initialProps: {
+            inputValue: "https://github.com/owner/repo-119",
+          } as TestProps,
+        },
+      );
+
+      await waitFor(() => {
+        expect(mockSearchGitRepositories).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ inputValue: "https://github.com/owner/repo-200" });
+
+      await waitFor(() => {
+        expect(mockSearchGitRepositories).toHaveBeenCalledTimes(2);
+      });
+
+      await act(async () => {
+        resolvers[1]({ items: [repo("owner/repo-200")], next_page_id: null });
+      });
+
+      expect(result.current.urlSearchResults).toEqual([repo("owner/repo-200")]);
+
+      // The superseded request now fails. It must not wipe the current results.
+      await act(async () => {
+        rejecters[0](new Error("superseded request failed"));
+      });
+
+      expect(result.current.urlSearchResults).toEqual([repo("owner/repo-200")]);
+    });
+  });
 });

--- a/__tests__/components/features/home/use-url-search.test.tsx
+++ b/__tests__/components/features/home/use-url-search.test.tsx
@@ -378,6 +378,41 @@ describe("useUrlSearch", () => {
       });
     });
 
+    it("should stop the spinner when the input becomes a non-matching URL mid-request", async () => {
+      const { resolvers } = pending();
+
+      type TestProps = { inputValue: string };
+      const { result, rerender } = renderHook(
+        ({ inputValue }: TestProps) => useUrlSearch(inputValue, "github"),
+        {
+          initialProps: {
+            inputValue: "https://github.com/owner/repo-119",
+          } as TestProps,
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isUrlSearchLoading).toBe(true);
+      });
+
+      // Still an https:// value, but no longer owner/repo, so this run issues
+      // no request of its own and must clear the spinner itself.
+      rerender({ inputValue: "https://example.com/" });
+
+      await waitFor(() => {
+        expect(result.current.isUrlSearchLoading).toBe(false);
+      });
+      expect(mockSearchGitRepositories).toHaveBeenCalledTimes(1);
+
+      // The superseded request completes late and must be ignored.
+      await act(async () => {
+        resolvers[0]({ items: [repo("owner/repo-119")], next_page_id: null });
+      });
+
+      expect(result.current.urlSearchResults).toEqual([]);
+      expect(result.current.isUrlSearchLoading).toBe(false);
+    });
+
     it("should ignore an earlier request that resolves after a newer one started", async () => {
       const { resolvers } = pending();
 

--- a/src/components/features/home/git-repo-dropdown/use-url-search.tsx
+++ b/src/components/features/home/git-repo-dropdown/use-url-search.tsx
@@ -11,11 +11,17 @@ export function useUrlSearch(
   const [isUrlSearchLoading, setIsUrlSearchLoading] = useState(false);
 
   useEffect(() => {
+    // Set when a newer input value supersedes this run. Without it, a
+    // request that resolves after the user has edited or cleared the field
+    // still writes its results, listing a repository for text that is gone.
+    let superseded = false;
+
     const handleUrlSearch = async () => {
       // Guard against null/undefined provider to prevent sending
       // requests via the cloud proxy before providers have loaded
       if (!provider) {
         setUrlSearchResults([]);
+        setIsUrlSearchLoading(false);
         return;
       }
 
@@ -32,21 +38,33 @@ export function useUrlSearch(
               3,
             );
 
-            setUrlSearchResults(repositories.items);
+            if (!superseded) {
+              setUrlSearchResults(repositories.items);
+            }
           } catch {
-            setUrlSearchResults([]);
+            if (!superseded) {
+              setUrlSearchResults([]);
+            }
           } finally {
-            setIsUrlSearchLoading(false);
+            if (!superseded) {
+              setIsUrlSearchLoading(false);
+            }
           }
         } else {
           setUrlSearchResults([]);
+          setIsUrlSearchLoading(false);
         }
       } else {
         setUrlSearchResults([]);
+        setIsUrlSearchLoading(false);
       }
     };
 
     handleUrlSearch();
+
+    return () => {
+      superseded = true;
+    };
   }, [inputValue, provider]);
 
   return { urlSearchResults, isUrlSearchLoading };


### PR DESCRIPTION
HUMAN:

I reproduced this by pasting a GitHub URL into the repository picker and clearing the box before the search returned. The old result stayed in the dropdown under an empty input. I had to slow the request down to hit it by hand. After the change, the dropdown says No Repository.

---

AGENT:

## Why

`useUrlSearch` starts a repository search whenever the input changes, but the effect has no cleanup, so nothing marks an earlier run as superseded. A request that resolves after the field has changed still calls `setUrlSearchResults`, leaving a repository listed under an input that no longer asks for it.

Related but distinct: #16663, fixed by #16700 (commit `49812ee20`), added `else { setUrlSearchResults([]); }` so a non-matching HTTPS URL clears the previous results. That is the synchronous path. This is the in-flight one, where the input has already changed by the time the request returns, which that `else` never sees.

## Summary

- Set a `superseded` flag in the effect cleanup and gate the result, error and loading writes on it.
- Every branch that does not issue a search now stops the spinner itself: no provider, cleared input, and a URL that does not match. They previously relied on a `finally` that a superseded run must no longer reach.
- Six tests covering a cleared field, a cleared provider, an input that becomes a non-matching URL, an older request resolving after a newer one, and an earlier failure arriving after a newer success.

`GitService.searchGitRepositories` takes no `AbortSignal`, and neither does `searchCloudRepositories`, `CloudProxyRequest`, or `CloudRequestOptions` in `@openhands/typescript-client`. Aborting rather than ignoring would mean plumbing a signal through four layers plus a change to that package, so this keeps to the hook.

## Issue Number

Fixes #17108

## How to Test

`npm ci && npx vitest run __tests__/components/features/home/use-url-search.test.tsx` gives 16 passing, 10 of them pre-existing.

Each new test was checked against the unfixed hook and against four partial fixes, since a test that passes under a wrong implementation guards nothing. I swapped the implementation and re-ran each time:

| implementation | result |
| --- | --- |
| `main` | 6 failed, every new test |
| success write left ungated | 3 failed, stale results are written |
| `catch` write left ungated | 1 failed, an earlier failure wipes a newer result |
| `finally` write left ungated | 1 failed, the spinner drops while a newer request is pending |
| no-provider branch not clearing the spinner | 1 failed |
| cleared-input branch not clearing the spinner | 2 failed |
| non-matching-URL branch not clearing the spinner | 1 failed |
| this branch | 16 passed |

Each of the three branch-level spinner resets is covered on its own. Deleting only the
non-matching-URL one previously left the suite green, because the cleared-input test caught that
line only when both resets went at once; `d102b1d88` adds the case that isolates it.

Also ran: the five suites that mount this hook (use-url-search, git-repo-dropdown, repo-selection-form, open-repository-modal, manifest-form-field) at 47 passing, plus `npm run typecheck` clean. Run `npm run make-i18n` first or the component suites cannot resolve `#/i18n/declaration`.

The test file diff is insertions only. It is not prettier-clean on `main`, and `lint-staged` covers `src/**` only, so reformatting it would have added unrelated churn to this PR.

## Video/Screenshots

Captured with `npm run dev:mock`, a seeded provider, and `searchGitRepositories` temporarily replaced with a fixed `user/repo-119` response delayed by 3000 ms, then the field cleared 250 ms in. The delay widens an existing window; it is not production timing. Both captures used identical settings and differ only by the hook change.

**Before.** The input is empty, showing only its `user/repo` placeholder, and the superseded result is listed under it:

![Open Repository dialog with an empty input and a stale user/repo-119 result listed below it](https://github.com/user-attachments/assets/03064b09-f40f-4fb2-8d3c-5d59e1dd2184)

**After.** Same steps, and the completed request no longer writes. The dropdown falls back to the account's own repositories, which in this mock account is none:

![The same dialog with an empty input and the dropdown showing No Repository](https://github.com/user-attachments/assets/38ff92e5-11f3-4270-8542-e005e9c60141)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Out of scope, noticed while working here: `git-repo-dropdown.tsx` passes the undebounced `inputValue` to this hook while the sibling react-query search gets the 300 ms debounced value, so every keystroke of a URL fires a request. This change makes those extra responses harmless rather than fewer.

