### PR TITLE
docs: pin ACP docker example to defaults agentServer

### DIFF
--- a/docs/ACP_AGENTS.md
+++ b/docs/ACP_AGENTS.md
@@ -148,11 +148,11 @@ point Canvas at it). In short:
 #    canvas_ui_control calls use client_tools; the Python mount keeps
 #    pre-migration conversations loadable when persisted metadata imports
 #    canvas_ui_tool.
-# Minimum image: 1.28.0-python (first compatible ACP provider/model protocol
-# surface for current Canvas). Override SHA with a newer build.
+# Recommended pin: config/defaults.json versions.agentServer (1.44.1-python).
+# Compatibility floor: compatibility.minimumAgentServer (1.28.0-python).
 docker run -d --name oh-acp -p 8010:8000 -v acp-data:/workspace \
   -v "$(pwd)/tools:/canvas-tools:ro" -e OH_EXTRA_PYTHON_PATH=/canvas-tools \
-  ghcr.io/openhands/agent-server:1.28.0-python
+  ghcr.io/openhands/agent-server:1.44.1-python
 
 # 2. Canvas pointed at the container.
 VITE_BACKEND_BASE_URL=http://localhost:8010 npm run dev:frontend


### PR DESCRIPTION
## Summary

`docs/ACP_AGENTS.md` used `ghcr.io/openhands/agent-server:1.28.0-python` as the copy-paste `docker run` image. That tag is the compatibility floor (`config/defaults.json` `compatibility.minimumAgentServer`), not the recommended pin (`versions.agentServer` = `1.44.1`). Update the example to the defaults pin and clarify floor vs recommended in the comment.

## Repro

```bash
jq '.versions.agentServer, .compatibility.minimumAgentServer' config/defaults.json
# "1.44.1"
# "1.28.0"
rg -n 'agent-server:1\.28\.0-python' docs/ACP_AGENTS.md
```

Docs-only; no runtime change. Does not touch DEVELOPMENT.md / AGENTS.md.