### PR TITLE
fix(canvas-extensions): show the install failure reason

### DIFF
--- a/__tests__/hooks/mutation/use-install-canvas-extension.test.ts
+++ b/__tests__/hooks/mutation/use-install-canvas-extension.test.ts
@@ -1,0 +1,62 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import CanvasExtensionsService from "#/api/canvas-extensions-service";
+import { useInstallCanvasExtension } from "#/hooks/mutation/use-manage-canvas-extensions";
+
+const displayErrorToast = vi.fn();
+vi.mock("#/utils/custom-toast-handlers", () => ({
+  displayErrorToast: (message: string) => displayErrorToast(message),
+  displaySuccessToast: vi.fn(),
+}));
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+};
+
+/** The shape the shared TypeScript client throws for a failed request. */
+class HttpError extends Error {
+  status: number;
+
+  response: unknown;
+
+  constructor(status: number, detail: string) {
+    super(
+      `HTTP request failed (${status} Bad Request): ${JSON.stringify({ detail })}`,
+    );
+    this.name = "HttpError";
+    this.status = status;
+    this.response = { detail };
+  }
+}
+
+describe("useInstallCanvasExtension", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("surfaces the server's reason instead of the raw HTTP message", async () => {
+    const detail =
+      "Failed to fetch canvas extension source: Subdirectory 'canvas-puls' not found in local source '/repo'";
+    vi.spyOn(CanvasExtensionsService, "install").mockRejectedValue(
+      new HttpError(400, detail),
+    );
+
+    const { result } = renderHook(() => useInstallCanvasExtension(), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate({ source: "/repo", repo_path: "canvas-puls" });
+
+    await waitFor(() => expect(displayErrorToast).toHaveBeenCalled());
+    expect(displayErrorToast).toHaveBeenCalledWith(detail);
+    expect(displayErrorToast).not.toHaveBeenCalledWith(
+      expect.stringContaining("HTTP request failed"),
+    );
+  });
+});

--- a/__tests__/hooks/mutation/use-install-canvas-extension.test.ts
+++ b/__tests__/hooks/mutation/use-install-canvas-extension.test.ts
@@ -4,6 +4,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import CanvasExtensionsService from "#/api/canvas-extensions-service";
 import { useInstallCanvasExtension } from "#/hooks/mutation/use-manage-canvas-extensions";
+import { CORS_OR_NETWORK_ERROR_MESSAGE } from "#/utils/user-facing-error";
 
 const displayErrorToast = vi.fn();
 vi.mock("#/utils/custom-toast-handlers", () => ({
@@ -57,6 +58,22 @@ describe("useInstallCanvasExtension", () => {
     expect(displayErrorToast).toHaveBeenCalledWith(detail);
     expect(displayErrorToast).not.toHaveBeenCalledWith(
       expect.stringContaining("HTTP request failed"),
+    );
+  });
+
+  it("keeps the shared disconnect wording when the request never lands", async () => {
+    vi.spyOn(CanvasExtensionsService, "install").mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+
+    const { result } = renderHook(() => useInstallCanvasExtension(), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate({ source: "/repo" });
+
+    await waitFor(() => expect(displayErrorToast).toHaveBeenCalled());
+    expect(displayErrorToast).toHaveBeenCalledWith(
+      CORS_OR_NETWORK_ERROR_MESSAGE,
     );
   });
 });

--- a/src/hooks/mutation/use-manage-canvas-extensions.ts
+++ b/src/hooks/mutation/use-manage-canvas-extensions.ts
@@ -8,7 +8,8 @@ import {
   displayErrorToast,
   displaySuccessToast,
 } from "#/utils/custom-toast-handlers";
-import { getApiErrorMessage } from "#/utils/api-error-message";
+import { getApiErrorBody, getApiErrorMessage } from "#/utils/api-error-message";
+import { retrieveAxiosErrorMessage } from "#/utils/retrieve-axios-error-message";
 
 function useInvalidateCanvasExtensions() {
   const queryClient = useQueryClient();
@@ -34,7 +35,12 @@ export function useInstallCanvasExtension() {
       );
     },
     onError: (error) => {
-      displayErrorToast(getApiErrorMessage(error, t(I18nKey.ERROR$GENERIC)));
+      // A transport failure carries no response body, so keep the shared
+      // "Disconnected" wording for it and use the server's detail otherwise.
+      const message = getApiErrorBody(error)
+        ? getApiErrorMessage(error, t(I18nKey.ERROR$GENERIC))
+        : retrieveAxiosErrorMessage(error) || t(I18nKey.ERROR$GENERIC);
+      displayErrorToast(message);
     },
   });
 }

--- a/src/hooks/mutation/use-manage-canvas-extensions.ts
+++ b/src/hooks/mutation/use-manage-canvas-extensions.ts
@@ -4,7 +4,11 @@ import CanvasExtensionsService from "#/api/canvas-extensions-service";
 import type { InstallCanvasExtensionRequest } from "#/types/canvas-extension";
 import { CANVAS_EXTENSIONS_QUERY_KEYS } from "#/hooks/query/query-keys";
 import { I18nKey } from "#/i18n/declaration";
-import { displaySuccessToast } from "#/utils/custom-toast-handlers";
+import {
+  displayErrorToast,
+  displaySuccessToast,
+} from "#/utils/custom-toast-handlers";
+import { getApiErrorMessage } from "#/utils/api-error-message";
 
 function useInvalidateCanvasExtensions() {
   const queryClient = useQueryClient();
@@ -18,6 +22,9 @@ export function useInstallCanvasExtension() {
   const invalidate = useInvalidateCanvasExtensions();
   const { t } = useTranslation("openhands");
   return useMutation({
+    // The default toast prints the client's raw `HTTP 400: {...}` message;
+    // the server's `detail` says which of Source/Ref/Path is actually wrong.
+    meta: { disableToast: true },
     mutationFn: (request: InstallCanvasExtensionRequest) =>
       CanvasExtensionsService.install(request),
     onSuccess: () => {
@@ -25,6 +32,9 @@ export function useInstallCanvasExtension() {
       displaySuccessToast(
         t(I18nKey.SETTINGS$CANVAS_EXTENSIONS_INSTALL_SUCCESS),
       );
+    },
+    onError: (error) => {
+      displayErrorToast(getApiErrorMessage(error, t(I18nKey.ERROR$GENERIC)));
     },
   });
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fix for installing extension from local

---

AGENT:

## Why

Installing a canvas extension with a wrong Source or Path gives the user nothing to
act on. The install mutation has no `onError`, so the failure falls through to the
global `MutationCache` handler in `src/query-client-config.ts`, which formats the
error with `retrieveAxiosErrorMessage()`. That helper only reads `data.error` and
`data.message`, never FastAPI's `detail`, so the user is shown the shared
TypeScript client's raw blob instead of the server's explanation.

Reported as OSS-10405.

## Summary

- `useInstallCanvasExtension` opts out of the generic toast (`meta.disableToast`)
  and handles its own error, so the server's `detail` reaches the user.
- A transport failure has no response body, so that case still routes through
  `retrieveAxiosErrorMessage()` and keeps the shared "Disconnected" wording.
- Adds `__tests__/hooks/mutation/use-install-canvas-extension.test.ts` covering
  both paths.

## Issue Number

Fixes #17048

## Video/Screenshots

Both frames come from the same browser session against a real agent-server
(PyPI 1.44.1) started with `npm run dev:minimal`. The Source, Ref and Path fields
are identical in both; the only difference is whether this branch's hook is
applied. The server answered `422 {"detail":"Invalid canvas extension. Ensure the
manifest is well-formed."}` in both cases.

Before, on `main` — the toast is the client's raw HTTP blob:

![Install error toast on main, showing the raw HTTP request failed blob](https://raw.githubusercontent.com/VascoSch92/OpenHands/assets/oss-10405/docs/assets/oss-10405/before-install-error.png)

After, on this branch — the toast is the server's own sentence:

![Install error toast on this branch, showing the server detail](https://raw.githubusercontent.com/VascoSch92/OpenHands/assets/oss-10405/docs/assets/oss-10405/after-install-error.png)

### The case this PR does not fix on its own

Reproducing #17048 exactly — a local extension at
`/repository-name/demo-extension`, Source `/repository-name`, Path
`demo-extension` — today's agent-server answers
`400 {"detail":"Failed to fetch canvas extension source. Check that the source is valid."}`,
and the toast blames the network:

![Install failure blamed on the network](https://raw.githubusercontent.com/VascoSch92/OpenHands/assets/oss-10405/docs/assets/oss-10405/misleading-network-toast.png)

That wording is unchanged by this PR, and it is worth being explicit about why.
`displayErrorToast()` rewrites *any* message matching
`isCorsOrNetworkErrorMessage()` into the "Disconnected" text, and the server's
sentence contains the substring "failed to fetch". The rewrite happens inside the
toast helper, so it applies to the message this PR routes through just as it
applied to the one the global handler produced. Only the reword in
OpenHands/software-agent-sdk#4839 ("Could not read …") clears that collision.

Every other install failure is fixed here and now, as the two frames above show.

## How to Test

1. `npm run dev:minimal`, then open Customize, Extensions, Add extension.
2. Put a valid extension manifest at `<dir>/demo-extension/canvas-extension.json`.
3. Enter Source `<dir>`, leave Ref and Path empty, click Install.
4. On `main` the toast reads
   `HTTP request failed (422 Unprocessable Content): {"detail":"…"}`.
   On this branch it reads `Invalid canvas extension. Ensure the manifest is
   well-formed.`

```
$ npx vitest run __tests__/bin/agent-canvas.test.ts \
    __tests__/hooks/mutation/use-install-canvas-extension.test.ts \
    __tests__/services/canvas-ui.test.ts __tests__/tools/canvas-ui-tool.test.ts
  Test Files  4 passed (4)
       Tests  20 passed (20)

$ npx eslint <changed files>     # clean
$ npx prettier --check           # clean
$ npx tsc --noEmit               # clean
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Depends on OpenHands/software-agent-sdk#4839 for the acceptance criteria in
  #17048 that concern the Source-plus-Path composition itself: `fetch.py` rejects
  `repo_path` for local sources outright, and the install route replaces the
  specific reason with one fixed sentence. This PR covers the third criterion,
  that an invalid combination reports a clear, actionable error.
- The substring collision between the server's wording and
  `isCorsOrNetworkErrorMessage()` affects any route whose message contains
  "failed to fetch", not just this one.
- The screenshots are hot-linked from `assets/oss-10405` on the fork
  `VascoSch92/OpenHands`. That branch has to stay alive for them to render.
