### PR TITLE
docs: remove duplicate OpenHands/extensions bullet in DEVELOPMENT.md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -14,7 +14,6 @@ This repository contains the Agent Canvas frontend and local-stack orchestration
 
 - [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) owns the Python SDK, Agent Server, agent/tool behavior, conversations, workspaces, events, and server API.
 - [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) owns browser-compatible typed access to that Agent Server API. Add client methods there rather than reimplementing API calls in Canvas.
-- [`OpenHands/extensions`](https://github.com/OpenHands/extensions) owns reusable skills, plugins, automations, and integrations.
 - [`OpenHands/extensions`](https://github.com/OpenHands/extensions) owns reusable skills, plugins, automations, and integrations; [`OpenHands/automation`](https://github.com/OpenHands/automation) owns automation definitions, scheduling, webhooks, run history, and dispatching; Agent Server/SDK code executes the dispatched conversations.
 
 When a feature crosses repositories, implement the backend contract in the SDK first, expose it through `typescript-client`, and consume it in Canvas. Coordinate automation lifecycle changes in `automation`. See the repository [contributor notes](../AGENTS.md) and follow the [custom code-review guide](../.agents/skills/custom-codereview-guide.md) for every pull request.


### PR DESCRIPTION
## Summary

In `docs/DEVELOPMENT.md` under **Repository boundaries**, the `OpenHands/extensions` ownership bullet was listed twice: a short bullet followed immediately by a longer bullet that already covers `extensions` and `OpenHands/automation`.

This removes the redundant short bullet and keeps the single combined bullet so the sibling-repo list matches the intended ownership split.

## Changes

- `docs/DEVELOPMENT.md`: drop the duplicate short `OpenHands/extensions` bullet.

## Test plan

- [x] Diff is docs-only (one bullet removed).
- [x] Remaining boundaries list still names `software-agent-sdk`, `typescript-client`, `extensions`, and `automation` once each.

HUMAN: Removed a duplicate OpenHands/extensions ownership bullet under Repository boundaries in docs/DEVELOPMENT.md; the following longer bullet already documents both extensions and automation ownership.

AGENT: Confirmed on OpenHands/OpenHands@4524a919 that the Repository boundaries section contains two consecutive OpenHands/extensions bullets (short then expanded with automation); removed the short duplicate only.
