### PR TITLE
fix: encode branch names in constructBranchUrl (#17106)

### DIFF
--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getStatusText } from "#/utils/utils";
+import { constructBranchUrl, getStatusText } from "#/utils/utils";
 import { AgentState } from "#/types/agent-state";
 import { I18nKey } from "#/i18n/declaration";
 
@@ -166,5 +166,62 @@ describe("getStatusText", () => {
     });
 
     expect(result).toBe(t(I18nKey.COMMON$RUNNING));
+  });
+});
+
+describe("constructBranchUrl", () => {
+  it("encodes # and % while preserving slashes for path-based providers", () => {
+    const branchWithHash = "feature/ui#123";
+    const branchWithPercent = "100%2Fdone";
+
+    // GitHub
+    expect(constructBranchUrl("github", "owner/repo", branchWithHash)).toBe(
+      "https://github.com/owner/repo/tree/feature/ui%23123",
+    );
+    expect(constructBranchUrl("github", "owner/repo", branchWithPercent)).toBe(
+      "https://github.com/owner/repo/tree/100%252Fdone",
+    );
+
+    // GitLab
+    expect(constructBranchUrl("gitlab", "owner/repo", branchWithHash)).toBe(
+      "https://gitlab.com/owner/repo/-/tree/feature/ui%23123",
+    );
+
+    // Bitbucket
+    expect(constructBranchUrl("bitbucket", "owner/repo", branchWithHash)).toBe(
+      "https://bitbucket.org/owner/repo/src/feature/ui%23123",
+    );
+
+    // Forgejo
+    expect(constructBranchUrl("forgejo", "owner/repo", branchWithHash)).toBe(
+      "https://codeberg.org/owner/repo/src/branch/feature/ui%23123",
+    );
+  });
+
+  it("encodes entire branch name including slashes for query-based providers", () => {
+    const branchWithSlashAndHash = "feature/ui#123";
+
+    // Bitbucket Data Center
+    expect(
+      constructBranchUrl(
+        "bitbucket_data_center",
+        "PROJECT/repo",
+        branchWithSlashAndHash,
+        "server.com",
+      ),
+    ).toBe(
+      "https://server.com/projects/PROJECT/repos/repo/browse?at=refs/heads/feature%2Fui%23123",
+    );
+
+    // Azure DevOps
+    expect(
+      constructBranchUrl(
+        "azure_devops",
+        "org/project/repo",
+        branchWithSlashAndHash,
+      ),
+    ).toBe(
+      "https://dev.azure.com/org/project/_git/repo?version=GBfeature%2Fui%23123",
+    );
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -354,21 +354,30 @@ export const constructBranchUrl = (
 ): string => {
   const baseUrl = getGitProviderBaseUrl(provider, host);
 
+  // Path-based providers: preserve '/' for nested branch paths, encode characters like '#', '%', '?'
+  const pathEncodedBranch = branchName
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  // Query-based providers: encode the entire branch string including '/'
+  const queryEncodedBranch = encodeURIComponent(branchName);
+
   switch (provider) {
     case "github":
-      return `${baseUrl}/${repositoryName}/tree/${branchName}`;
+      return `${baseUrl}/${repositoryName}/tree/${pathEncodedBranch}`;
     case "forgejo":
-      return `${baseUrl}/${repositoryName}/src/branch/${branchName}`;
+      return `${baseUrl}/${repositoryName}/src/branch/${pathEncodedBranch}`;
     case "gitlab":
-      return `${baseUrl}/${repositoryName}/-/tree/${branchName}`;
+      return `${baseUrl}/${repositoryName}/-/tree/${pathEncodedBranch}`;
     case "bitbucket":
-      return `${baseUrl}/${repositoryName}/src/${branchName}`;
+      return `${baseUrl}/${repositoryName}/src/${pathEncodedBranch}`;
     case "bitbucket_data_center": {
       // Bitbucket Server format: /projects/{PROJECT}/repos/{repo}/browse?at=refs/heads/{branch}
       const parts = repositoryName.split("/");
       if (parts.length >= 2) {
         const [project, repo] = parts;
-        return `${baseUrl}/projects/${project}/repos/${repo}/browse?at=refs/heads/${branchName}`;
+        return `${baseUrl}/projects/${project}/repos/${repo}/browse?at=refs/heads/${queryEncodedBranch}`;
       }
       return "";
     }
@@ -377,7 +386,7 @@ export const constructBranchUrl = (
       const parts = repositoryName.split("/");
       if (parts.length === 3) {
         const [org, project, repo] = parts;
-        return `${baseUrl}/${org}/${project}/_git/${repo}?version=GB${branchName}`;
+        return `${baseUrl}/${org}/${project}/_git/${repo}?version=GB${queryEncodedBranch}`;
       }
       return "";
     }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I tested this locally by adding unit tests covering branch names with `#` and `%` across all six git providers (GitHub, Forgejo, GitLab, Bitbucket, Bitbucket Data Center, and Azure DevOps) and verified they all pass via Vitest.

---

AGENT:

## Why

`constructBranchUrl` interpolated raw branch names directly into provider URLs without URL encoding. Characters that are valid in git branch refs such as `#` (which denotes a URL fragment and gets dropped by browsers) and `%` (which decodes prematurely) caused branch chips in the git control bar to navigate to incorrect branches or omit the branch fragment.

## Summary

- Encoded path segments with `encodeURIComponent` for path-based git providers (`github`, `gitlab`, `bitbucket`, `forgejo`) to preserve `/` for nested refs while escaping `#`, `%`, and query delimiters.
- Encoded the full branch name string with `encodeURIComponent` for query-based providers (`azure_devops`, `bitbucket_data_center`).
- Added unit tests in `__tests__/utils/utils.test.ts` verifying encoding behavior across all 6 supported git providers.

## Issue Number

Fixes #17106

## How to Test

1. Run `npx vitest run __tests__/utils/utils.test.ts --pool=threads`.
2. Observe that all 12 tests pass and special characters `#` and `%` are encoded as `%23` and `%25` respectively.

## Video/Screenshots

<img width="1210" height="150" alt="Screenshot (1228)" src="https://github.com/user-attachments/assets/49425ea2-f9bc-4df8-bd3d-efda6da9eb65" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

None.