### PR TITLE
fix: allow a second app instance to start on free ports

### DIFF
--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -196,8 +196,8 @@ describe("buildSafeDevConfigAsync", () => {
   }
 
   it("returns config with dynamically allocated ports", async () => {
-    // Use a high port so the assertPortsFree check passes even when a real
-    // dev stack is running on the default port (18000).
+    // Use a high port so allocation stays on the requested port even when a
+    // real dev stack is running on the default port (18000).
     const config = await buildSafeDevConfigAsync(repoRoot, {
       OH_CANVAS_SAFE_BACKEND_PORT: "19800",
       OH_SESSION_API_KEY_PATH: tempKeyPath(),
@@ -211,8 +211,7 @@ describe("buildSafeDevConfigAsync", () => {
     expect(config.backendPort).not.toBe(config.vscodePort);
   });
 
-  it("throws when preferred port is busy", async () => {
-    // Block a specific high port we'll request
+  it("falls back to a free port when the preferred one is busy", async () => {
     const busyPort = 19600;
     const server = net.createServer();
     await new Promise<void>((resolve, reject) => {
@@ -223,13 +222,17 @@ describe("buildSafeDevConfigAsync", () => {
       server.on("error", reject);
     });
 
-    // Request the busy port via env var — should throw instead of falling back
-    await expect(
-      buildSafeDevConfigAsync(repoRoot, {
-        OH_CANVAS_SAFE_BACKEND_PORT: busyPort.toString(),
-        OH_SESSION_API_KEY_PATH: tempKeyPath(),
-      }),
-    ).rejects.toThrow(/agent-server.*port 19600/i);
+    const config = await buildSafeDevConfigAsync(repoRoot, {
+      OH_CANVAS_SAFE_BACKEND_PORT: busyPort.toString(),
+      OH_SESSION_API_KEY_PATH: tempKeyPath(),
+    });
+
+    expect(config.backendPort).not.toBe(busyPort);
+    expect(config.backendPort).toBeGreaterThan(0);
+    expect(config.vscodePort).not.toBe(config.backendPort);
+    expect(config.stateDir).toBe(
+      path.join(homedir(), ".openhands", `agent-canvas-${config.backendPort}`),
+    );
   });
 });
 
@@ -946,7 +949,7 @@ describe("dev-safe CLI startup", () => {
         // Use empty PATH to ensure uvx is not found.
         PATH: "",
         // Redirect the agent-server port to a high free port so the
-        // assertPortsFree pre-flight check passes when a real dev stack is
+        // allocation stays on the requested ports even when a real dev stack is
         // running on the default port (18000) — the test is about uvx, not
         // port detection.
         OH_CANVAS_SAFE_BACKEND_PORT: "19810",

--- a/__tests__/scripts/dev-with-automation.test.ts
+++ b/__tests__/scripts/dev-with-automation.test.ts
@@ -264,8 +264,8 @@ describe("buildConfig", () => {
    * Build an env that points persisted dev API key files at a fresh temp dir,
    * so tests don't write to the user's real ~/.openhands/agent-canvas files.
    *
-   * Also redirects all service ports to high port numbers so that buildConfig's
-   * assertPortsFree check passes even when a real dev stack is running on the
+   * Also redirects all service ports to high port numbers so allocation stays
+   * on the requested ports even when a real dev stack is running on the
    * default ports (18000, 18001, 3001, 8000).
    */
   function envWithIsolatedKeyPath(
@@ -275,7 +275,7 @@ describe("buildConfig", () => {
     keyDirs.push(dir);
     return {
       OH_SESSION_API_KEY_PATH: path.join(dir, "session-api-key.txt"),
-      // High ports that are almost certainly free, so assertPortsFree passes.
+      // High ports that are almost certainly free.
       PORT: "19902",
       OH_CANVAS_SAFE_BACKEND_PORT: "19900",
       OH_CANVAS_SAFE_AUTOMATION_PORT: "19901",
@@ -344,10 +344,9 @@ describe("buildConfig", () => {
     expect(config.ingressPort).toBe(preferredPort);
   });
 
-  it("throws when ingress port is busy", async () => {
+  it("falls back to a free ingress port when the preferred one is busy", async () => {
     const busyPort = 8100;
 
-    // Block port 8100
     const server = net.createServer();
     await new Promise<void>((resolve, reject) => {
       server.listen(busyPort, "127.0.0.1", () => {
@@ -357,10 +356,39 @@ describe("buildConfig", () => {
       server.on("error", reject);
     });
 
-    // Should throw instead of falling back to a different port
-    await expect(
-      buildConfig({ port: busyPort }, envWithIsolatedKeyPath()),
-    ).rejects.toThrow(/ingress.*port 8100/i);
+    const config = await buildConfig(
+      { port: busyPort },
+      envWithIsolatedKeyPath(),
+    );
+
+    expect(config.ingressPort).not.toBe(busyPort);
+    expect(config.ingressPort).toBeGreaterThan(0);
+    expect(config.stateDir).toBe(
+      path.join(homedir(), ".openhands", `agent-canvas-${config.ingressPort}`),
+    );
+  });
+
+  it("keeps an explicit state dir when ports are remapped", async () => {
+    const busyPort = 8101;
+    const stateDir = mkdtempSync(path.join(tmpdir(), "canvas-state-"));
+    keyDirs.push(stateDir);
+
+    const server = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.listen(busyPort, "127.0.0.1", () => {
+        servers.push(server);
+        resolve();
+      });
+      server.on("error", reject);
+    });
+
+    const config = await buildConfig(
+      { port: busyPort },
+      envWithIsolatedKeyPath({ OH_CANVAS_SAFE_STATE_DIR: stateDir }),
+    );
+
+    expect(config.ingressPort).not.toBe(busyPort);
+    expect(config.stateDir).toBe(path.resolve(stateDir));
   });
 
   it("allocates valid ports for all services", async () => {

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -253,12 +253,31 @@ function tryPort(port, host = "127.0.0.1") {
 }
 
 /**
+ * Default on-disk state directory for an agent-canvas instance.
+ *
+ * Concurrent stacks that had to remap off the preferred ports get a sibling
+ * directory so two agent-servers do not fight conversation leases. An explicit
+ * `OH_CANVAS_SAFE_STATE_DIR` always wins.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @param {string | null} [instanceKey]
+ * @returns {string}
+ */
+export function defaultCanvasStateDir(env = process.env, instanceKey = null) {
+  if (env.OH_CANVAS_SAFE_STATE_DIR) {
+    return env.OH_CANVAS_SAFE_STATE_DIR;
+  }
+  const base = path.join(homedir(), ".openhands", "agent-canvas");
+  return instanceKey ? `${base}-${instanceKey}` : base;
+}
+
+/**
  * Assert that all listed ports are available, throwing a descriptive error if
  * any are already in use.
  *
- * Intended as a pre-flight check before spawning services so that a concurrent
- * agent-canvas instance is detected immediately rather than silently starting
- * on a different port.
+ * Kept for callers that still want a hard conflict (tests, one-shot probes).
+ * Launchers that start the stack should use {@link findFreePorts} instead so a
+ * second instance can bind elsewhere.
  *
  * @param {Array<{name: string, port: number}>} portConfigs - Named port list
  * @param {string} [host]
@@ -600,16 +619,20 @@ export async function buildSafeDevConfigAsync(
     preferredBackendPort + 1,
   );
 
-  // Fail fast if any required port is already in use.
-  await assertPortsFree([
-    { name: "agent-server", port: preferredBackendPort },
-    { name: "vscode", port: preferredVscodePort },
+  const ports = await findFreePorts([
+    { name: "backendPort", preferred: preferredBackendPort },
+    { name: "vscodePort", preferred: preferredVscodePort },
   ]);
+  const remapped = ports.backendPort !== preferredBackendPort;
+  const instanceKey = remapped ? String(ports.backendPort) : null;
 
   return buildConfigFromPorts(
-    { backendPort: preferredBackendPort, vscodePort: preferredVscodePort },
+    { backendPort: ports.backendPort, vscodePort: ports.vscodePort },
     cwd,
-    env,
+    {
+      ...env,
+      OH_CANVAS_SAFE_STATE_DIR: defaultCanvasStateDir(env, instanceKey),
+    },
   );
 }
 

--- a/scripts/dev-with-automation.mjs
+++ b/scripts/dev-with-automation.mjs
@@ -48,17 +48,17 @@ import { spawn, spawnSync } from "node:child_process";
 import { mkdirSync, existsSync, readFileSync } from "node:fs";
 import { join, resolve, dirname, isAbsolute } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { homedir } from "node:os";
 import { setTimeout as delay } from "node:timers/promises";
 import process from "node:process";
 
 import {
-  assertPortsFree,
   buildAgentServerCommand,
   buildSafeDevConfig,
   buildAgentServerEnv,
   buildNpmScriptCommand,
   buildRuntimeServicesInfo,
+  defaultCanvasStateDir,
+  findFreePorts,
   formatMissingUvxGuidance,
   validateFrontendDependencies,
   validateLocalAgentServerPath,
@@ -430,35 +430,65 @@ async function buildConfig(args, env = process.env) {
     parseInt(env.OH_CANVAS_SAFE_AUTOMATION_PORT, 10) || DEFAULT_AUTOMATION_PORT;
   const preferredVitePort = parseInt(env.OH_CANVAS_SAFE_VITE_PORT, 10) || 3001;
 
-  // Fail fast if any preferred port for a service in this mode is already in use.
-  const requiredPorts = [{ name: "ingress", port: preferredIngressPort }];
+  const preferredPorts = [{ name: "ingress", preferred: preferredIngressPort }];
   if (launchAgentServer) {
-    requiredPorts.push({ name: "agent-server", port: preferredBackendPort });
+    preferredPorts.push({
+      name: "agent-server",
+      preferred: preferredBackendPort,
+    });
   }
   if (launchAutomation) {
-    requiredPorts.push({ name: "automation", port: preferredAutomationPort });
+    preferredPorts.push({
+      name: "automation",
+      preferred: preferredAutomationPort,
+    });
   }
   if (launchFrontend) {
-    requiredPorts.push({ name: "frontend", port: preferredVitePort });
+    preferredPorts.push({ name: "frontend", preferred: preferredVitePort });
   }
 
   logStep("ports", "Checking ports...");
-  await assertPortsFree(requiredPorts);
+  const allocated = await findFreePorts(preferredPorts);
+  const ingressPort = allocated.ingress;
+  const agentServerPort = launchAgentServer
+    ? allocated["agent-server"]
+    : preferredBackendPort;
+  const autoBackendPort = launchAutomation
+    ? allocated.automation
+    : preferredAutomationPort;
+  const vitePort = launchFrontend ? allocated.frontend : preferredVitePort;
 
-  const vscodePort = preferredBackendPort + 1000;
+  const vscodeAllocated = await findFreePorts([
+    {
+      name: "vscode",
+      preferred: agentServerPort + 1000,
+    },
+  ]);
+  const vscodePort = vscodeAllocated.vscode;
+
+  const remapped =
+    ingressPort !== preferredIngressPort ||
+    (launchAgentServer && agentServerPort !== preferredBackendPort) ||
+    (launchAutomation && autoBackendPort !== preferredAutomationPort) ||
+    (launchFrontend && vitePort !== preferredVitePort);
+  if (remapped) {
+    logStep(
+      "ports",
+      `Preferred ports busy — using ingress http://127.0.0.1:${ingressPort}`,
+    );
+  }
 
   // API key — shared by both agent-server and automation backend.
   // Both validate it via the `X-Session-API-Key` header.
   // LOCAL_BACKEND_API_KEY is the single user-facing env var: if set it's
   // used directly; otherwise one is auto-generated and persisted.
-  const stateDir =
-    env.OH_CANVAS_SAFE_STATE_DIR ||
-    join(homedir(), ".openhands", "agent-canvas");
+  const instanceKey = remapped ? String(ingressPort) : null;
+  const stateDir = defaultCanvasStateDir(env, instanceKey);
 
   const safeConfig = buildSafeDevConfig(projectRoot, {
     ...env,
     OH_CANVAS_SAFE_STATE_DIR: stateDir,
-    OH_CANVAS_SAFE_BACKEND_PORT: preferredBackendPort.toString(),
+    OH_CANVAS_SAFE_BACKEND_PORT: agentServerPort.toString(),
     OH_CANVAS_SAFE_VSCODE_PORT: vscodePort.toString(),
   });
   const sessionApiKey = safeConfig.sessionApiKey;
@@ -478,12 +508,12 @@ async function buildConfig(args, env = process.env) {
 
   return {
     // Ingress port (main entry point)
-    ingressPort: preferredIngressPort,
+    ingressPort,
 
     // Service ports (internal)
-    agentServerPort: preferredBackendPort,
-    autoBackendPort: preferredAutomationPort,
-    vitePort: preferredVitePort,
+    agentServerPort,
+    autoBackendPort,
+    vitePort,
     vscodePort,
     // Prefix the editor is served under on the ingress origin. Carried on the
     // config so the route table and the agent-server env are built from one


### PR DESCRIPTION
HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

A second `npm run desktop` / `npm run dev` / `agent-canvas` process used to exit because preferred ports were already taken. Launchers now allocate free ports and isolate on-disk state so two agent-servers do not share conversation leases.

## Why

Opening two copies of the app should work. Failing because the first copy already bound 8000/18000 is the wrong default.

## Summary

- `buildSafeDevConfigAsync` and `buildConfig` use `findFreePorts` instead of failing closed
- Remapped stacks get `~/.openhands/agent-canvas-<ingressPort>` unless `OH_CANVAS_SAFE_STATE_DIR` is set
- Tests cover busy preferred ports and an explicit state-dir override

## How to Test

1. Start `npm run dev` (or `npm run desktop`)
2. Start a second copy without changing env
3. Confirm it prints a remapped ingress URL and the UI loads there

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

Made with [Cursor](https://cursor.com)