### PR TITLE
fix(security): stop untrusted markdown from setting rel="opener" or an arbitrary target

### DIFF
--- a/__tests__/components/features/markdown/markdown-renderer.test.tsx
+++ b/__tests__/components/features/markdown/markdown-renderer.test.tsx
@@ -317,8 +317,9 @@ describe("MARKDOWN_SANITIZE_SCHEMA", () => {
   });
 
   it("preserves rel even when it carries unusual but-safe tokens like `nofollow ugc`", () => {
-    // `rel` keywords never execute code or navigate, so allowing any
-    // value is safe. This locks that property in.
+    // Every `rel` keyword except `opener` is passed through untouched:
+    // none of them grants the linked page a capability. `opener` is the
+    // one exception and has its own tests below.
     const tree = sanitize(
       makeAnchor({
         href: "https://example.com",
@@ -331,5 +332,112 @@ describe("MARKDOWN_SANITIZE_SCHEMA", () => {
     const relProp = a?.properties?.rel;
     const rel = Array.isArray(relProp) ? relProp.join(" ") : relProp;
     expect(rel).toBe("nofollow ugc");
+  });
+
+  // `target="_blank"` implies `noopener` in current browsers, and
+  // `rel="opener"` is the documented opt-out. Left in, untrusted markdown
+  // gets a `window.opener` handle on this tab and can navigate it
+  // elsewhere while the user is looking at the page it opened.
+  it("drops a bare rel=opener", () => {
+    const tree = sanitize(
+      makeAnchor({
+        href: "https://example.com",
+        target: "_blank",
+        rel: "opener",
+      }),
+      MARKDOWN_SANITIZE_SCHEMA,
+    ) as Root;
+
+    const relProp = firstAnchor(tree)?.properties?.rel;
+    const rel = Array.isArray(relProp) ? relProp.join(" ") : relProp;
+    expect(rel ?? "").toBe("");
+  });
+
+  it("drops opener but keeps the other tokens when rel carries several", () => {
+    const tree = sanitize(
+      makeAnchor({
+        href: "https://example.com",
+        target: "_blank",
+        rel: ["noreferrer", "opener"],
+      }),
+      MARKDOWN_SANITIZE_SCHEMA,
+    ) as Root;
+
+    const relProp = firstAnchor(tree)?.properties?.rel;
+    const rel = Array.isArray(relProp) ? relProp.join(" ") : relProp;
+    expect(rel).toBe("noreferrer");
+  });
+
+  it("matches rel=opener case-insensitively", () => {
+    const tree = sanitize(
+      makeAnchor({ href: "https://example.com", rel: "OPENER" }),
+      MARKDOWN_SANITIZE_SCHEMA,
+    ) as Root;
+
+    const relProp = firstAnchor(tree)?.properties?.rel;
+    const rel = Array.isArray(relProp) ? relProp.join(" ") : relProp;
+    expect(rel ?? "").toBe("");
+  });
+
+  // An arbitrary `target` names a browsing context, so untrusted markdown
+  // could aim a link at an existing frame; `_top` replaces the app frame.
+  it.each(["frame-name", "_top", "_parent"])("drops target=%s", (target) => {
+    const tree = sanitize(
+      makeAnchor({ href: "https://example.com", target }),
+      MARKDOWN_SANITIZE_SCHEMA,
+    ) as Root;
+
+    expect(firstAnchor(tree)?.properties?.target).toBeUndefined();
+  });
+
+  it.each(["_blank", "_self"])("keeps target=%s", (target) => {
+    const tree = sanitize(
+      makeAnchor({ href: "https://example.com", target }),
+      MARKDOWN_SANITIZE_SCHEMA,
+    ) as Root;
+
+    expect(firstAnchor(tree)?.properties?.target).toBe(target);
+  });
+});
+
+// The schema is the only thing protecting call sites that do not pass
+// `includeStandard`, because the `anchor` component — which hard-codes
+// target/rel — is not mapped in for them. `collapsible-thinking`,
+// `generic-event-message` and `skill-item-expanded` all render untrusted
+// model output that way, so this asserts the rendered DOM, not just HAST.
+describe("MarkdownRenderer without includeStandard", () => {
+  it("does not let rel=opener reach the DOM", () => {
+    const { container } = render(
+      <MarkdownRenderer>
+        {`<a href="https://evil.example" target="_blank" rel="opener">x</a>`}
+      </MarkdownRenderer>,
+    );
+
+    const anchorEl = container.querySelector("a");
+    expect(anchorEl).not.toBeNull();
+    expect(anchorEl?.getAttribute("rel") ?? "").not.toContain("opener");
+  });
+
+  it("does not let an arbitrary target reach the DOM", () => {
+    const { container } = render(
+      <MarkdownRenderer>
+        {`<a href="https://evil.example" target="frame-name">x</a>`}
+      </MarkdownRenderer>,
+    );
+
+    expect(container.querySelector("a")?.getAttribute("target")).toBeNull();
+  });
+
+  it("still renders an ordinary external link", () => {
+    const { container } = render(
+      <MarkdownRenderer>
+        {`<a href="https://example.com" target="_blank" rel="noopener noreferrer">x</a>`}
+      </MarkdownRenderer>,
+    );
+
+    const anchorEl = container.querySelector("a");
+    expect(anchorEl?.getAttribute("href")).toBe("https://example.com");
+    expect(anchorEl?.getAttribute("target")).toBe("_blank");
+    expect(anchorEl?.getAttribute("rel")).toBe("noopener noreferrer");
   });
 });

--- a/src/components/features/markdown/markdown-renderer.tsx
+++ b/src/components/features/markdown/markdown-renderer.tsx
@@ -49,13 +49,35 @@ export const MARKDOWN_SANITIZE_SCHEMA: Schema = {
   attributes: {
     ...defaultSchema.attributes,
     "*": [...(defaultSchema.attributes?.["*"] ?? []), "className", "id"],
-    // `["rel", "noopener", "noreferrer", "nofollow"]` (rehype-sanitize's
-    // "[attrName, ...allowed-values]" form) requires `rel` to be EXACTLY
-    // one of those tokens — it would strip the standard, space-separated
-    // `rel="noopener noreferrer"` and reintroduce a reverse-tabnabbing
-    // vector on `target="_blank"` links. None of the `rel` keywords
-    // execute code or navigate, so allowing any rel value is safe.
-    a: ["href", "title", "target", "rel"],
+    // `rel` and `target` are attacker-controlled here: this schema is what
+    // stands between untrusted markdown (agent output, thinking blocks,
+    // skill bodies) and the DOM, and the `anchor` component that would
+    // otherwise normalise them is only mapped in when a call site passes
+    // `includeStandard` — several do not.
+    //
+    // `rel` cannot use a plain allow list. rehype-sanitize's
+    // "[attrName, ...allowed-values]" form compares whole values, and a
+    // hand-built HAST tree can carry `rel` as the single string
+    // "noopener noreferrer", which no token list matches — that would strip
+    // the canonical safe-link value. A regexp is checked against each token
+    // of a parsed (array-valued) `rel` and against the whole string
+    // otherwise, so it covers both shapes. Everything is allowed except
+    // `opener`: `target="_blank"` implies `noopener` in current browsers,
+    // and `rel="opener"` is the documented way to opt back *in*, handing
+    // the opened page a `window.opener` it can use to navigate this tab
+    // somewhere else (reverse tabnabbing). No other `rel` keyword grants a
+    // capability.
+    //
+    // `target` is restricted to the two values a document legitimately
+    // needs. An arbitrary value names a browsing context, so untrusted
+    // markdown could aim a link at an existing frame, and `_top` /
+    // `_parent` let it replace the whole app frame.
+    a: [
+      "href",
+      "title",
+      ["target", "_blank", "_self"],
+      ["rel", /^(?!opener$)/i],
+    ],
     img: [
       ...(defaultSchema.attributes?.img ?? []),
       "src",


### PR DESCRIPTION
HUMAN:

  I did not run the desktop app or a live agent for this. The finding came out
  of a static read of the sanitize schema plus dynamic probing of the real
  `rehype-raw` -> `rehype-sanitize` pipeline in jsdom, and what I verified is
  the rendered DOM for a call site that does not pass `includeStandard`. The
  eight new assertions fail against `main`'s schema and pass with this change;
  that before/after is the screenshot below. Nobody has watched a real agent
  emit one of these links.

---

AGENT:

## Why

`MARKDOWN_SANITIZE_SCHEMA` allowed `rel` and `target` on `<a>` with no value
restriction:

```ts
a: ["href", "title", "target", "rel"],
```

- **`rel="opener"` survived.** `target="_blank"` implies `noopener` in current
  browsers; `rel="opener"` is the documented way to opt back *in*. A link in
  untrusted markdown that carries it hands the opened page a live
  `window.opener` for the Agent Canvas tab, which it can then navigate
  elsewhere while the user is looking at the page it opened.
- **Any `target` survived**, including `_top`, `_parent` and arbitrary
  browsing-context names.

The schema's own comment claimed "none of the `rel` keywords execute code or
navigate, so allowing any rel value is safe". That holds for every keyword
except `opener`, which grants precisely that.

**The `anchor` component does not cover this.** It hard-codes
`target="_blank" rel="noopener noreferrer"`, but `MarkdownRenderer` maps it in
only when a call site passes `includeStandard`, which defaults to `false`.
Five call sites omit it, and they render the least trusted content in the
product — `collapsible-thinking` (the model's raw thinking), the skill body in
`skill-item-expanded`, `generic-event-message` details, `error-message`,
`tool-item`. `allowHtml` also defaults to `true`, so raw `<a>` in that content
is parsed by `rehype-raw` and reaches the sanitizer. At those sites the schema
is the only thing between the markdown and the DOM.

## Summary

- `rel` now goes through `/^(?!opener$)/i`. Every other keyword is preserved
  verbatim; only `opener` is dropped, case-insensitively.
- `target` is restricted to `_blank` / `_self`.
- Eight regression tests, six on the schema and two on the rendered DOM for a
  call site without `includeStandard`.

**Why a regexp and not a token list.** `["rel", "noopener", "noreferrer", …]`
looks like the obvious fix and is the thing that broke before. `hast-util-sanitize`
compares whole values, and `rel` reaches it in two different shapes: an array of
tokens from the real `rehype-raw` parse, but a single string
`"noopener noreferrer"` on a hand-built HAST tree — which no token list matches.
That is the fc208bc regression, and the existing test for it hand-builds exactly
that string. A regexp is checked per token in the array case and against the
whole string otherwise, so it holds in both shapes. Measured, not assumed:

| input | `main` | this branch |
|---|---|---|
| `rel="opener"` | `rel="opener"` | `rel=""` |
| `rel="noreferrer opener"` | `rel="noreferrer opener"` | `rel="noreferrer"` |
| `rel="noopener noreferrer"` | preserved | preserved |
| hand-built HAST, `rel` as one string | preserved | preserved |
| `target="frame-name"` | `target="frame-name"` | dropped |
| `target="_blank"` | kept | kept |

## Issue Number

Fixes #17161

## How to Test

```bash
npx vitest run __tests__/components/features/markdown/markdown-renderer.test.tsx
```

37 pass on this branch. Against `main`'s schema, the eight new assertions fail.

To see it by hand, render this through `MarkdownRenderer` without
`includeStandard` — which is what all five call sites above do — and inspect
the anchor:

```html
<a href="https://evil.example" target="_blank" rel="opener">click me</a>
```

## Video/Screenshots

Not a UI change, so this is the test evidence rather than a screenshot of the
app: `main`'s schema on top, this branch below.

![markdown sanitizer rel=opener and arbitrary target, before and after](https://raw.githubusercontent.com/lzhan011/OpenHands/pr-assets/markdown-rel-opener-reproduction.png)

What it establishes: the eight assertions fail against the current schema and
pass with this change, and two of them read the rendered DOM rather than the
HAST tree. What it does not establish: that a real agent has emitted such a
link, or that a browser was observed navigating the opener tab — the
`rel="opener"` semantics are taken from the HTML standard, not measured here.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Behaviour change to be aware of: authored markdown that relied on
`target="_top"` or a named frame will now render the link without `target`.
Nothing in the repo does; for untrusted content losing it is the point.

A second layer worth considering separately: `includeStandard` gating the
`anchor` component means every future call site starts out unprotected by
default. Making `a: anchor` unconditional would fix that class rather than
this instance, but it changes link styling at the five sites above, so it does
not belong in a security fix.

