### PR TITLE
fix(security): show the real host in the /launch skill trust prompt

### DIFF
--- a/__tests__/components/features/launch/plugin-launch-modal.test.tsx
+++ b/__tests__/components/features/launch/plugin-launch-modal.test.tsx
@@ -39,7 +39,9 @@ describe("PluginLaunchModal", () => {
 
   describe("Plugin Display Name Extraction", () => {
     it("should extract plugin name from repo_path when provided", () => {
-      renderModal([{ source: "github:owner/repo", repo_path: "plugins/my-plugin" }]);
+      renderModal([
+        { source: "github:owner/repo", repo_path: "plugins/my-plugin" },
+      ]);
 
       // Plugin name should be "my-plugin" from the path
       expect(screen.getByText("my-plugin")).toBeInTheDocument();
@@ -54,9 +56,7 @@ describe("PluginLaunchModal", () => {
     });
 
     it("should extract name from git URL", () => {
-      renderModal([
-        { source: "https://github.com/owner/repo-name.git" },
-      ]);
+      renderModal([{ source: "https://github.com/owner/repo-name.git" }]);
 
       const elements = screen.getAllByText("repo-name");
       expect(elements.length).toBeGreaterThan(0);
@@ -295,13 +295,13 @@ describe("PluginLaunchModal", () => {
 
       expect(screen.getByText("LAUNCH$ADDITIONAL_PLUGINS")).toBeInTheDocument();
       // When no repo_path, the full repo path is shown
-      expect(screen.getAllByText("owner/without-params").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText("owner/without-params").length,
+      ).toBeGreaterThan(0);
     });
 
     it("should show ref in simple plugin list", () => {
-      renderModal([
-        { source: "github:owner/plugin", ref: "main" },
-      ]);
+      renderModal([{ source: "github:owner/plugin", ref: "main" }]);
 
       expect(screen.getByText("@ main")).toBeInTheDocument();
     });
@@ -362,10 +362,9 @@ describe("PluginLaunchModal", () => {
 
     it("should call onStartConversation with message when provided", async () => {
       const user = userEvent.setup();
-      renderModal(
-        [{ source: "github:owner/repo" }],
-        { message: "/city-weather:now Tokyo" },
-      );
+      renderModal([{ source: "github:owner/repo" }], {
+        message: "/city-weather:now Tokyo",
+      });
 
       // Check the trust checkbox first
       await user.click(screen.getByTestId("trust-checkbox"));
@@ -421,6 +420,62 @@ describe("PluginLaunchModal", () => {
 
       // First plugin should have new value
       expect(input1).toHaveValue("new-val1");
+    });
+  });
+
+  // The modal's source line is what the trust checkbox names: "I trust this
+  // skill from {sources} with the agent secrets defined in my account." If a
+  // source can be displayed as a repo coordinate it does not own, that
+  // sentence is asking the user to trust the wrong party.
+  describe("Source Display", () => {
+    it("shows the whole URL when the host only looks like GitHub", () => {
+      const spoofed =
+        "https://evil.example/github.com/All-Hands-AI/openhands-plugin";
+      renderModal([{ source: spoofed }]);
+
+      expect(screen.getByText(spoofed)).toBeInTheDocument();
+      expect(
+        screen.queryByText("All-Hands-AI/openhands-plugin"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the whole URL for a host that merely starts with github.com", () => {
+      const spoofed = "https://github.com.evil.example/All-Hands-AI/plugin";
+      renderModal([{ source: spoofed }]);
+
+      expect(screen.getByText(spoofed)).toBeInTheDocument();
+      expect(screen.queryByText("All-Hands-AI/plugin")).not.toBeInTheDocument();
+    });
+
+    it("shortens a real github.com URL to its repo coordinate", () => {
+      renderModal([
+        { source: "https://github.com/All-Hands-AI/openhands-plugin.git" },
+      ]);
+
+      expect(
+        screen.getByText("All-Hands-AI/openhands-plugin"),
+      ).toBeInTheDocument();
+    });
+
+    it("shortens a github: coordinate", () => {
+      renderModal([{ source: "github:All-Hands-AI/openhands-plugin" }]);
+
+      // The display name and the source line both read as the coordinate
+      // here, so match all of them rather than expecting exactly one.
+      expect(
+        screen.getAllByText("All-Hands-AI/openhands-plugin").length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.queryByText("github:All-Hands-AI/openhands-plugin"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows a source that is not a URL unchanged", () => {
+      renderModal([{ source: "git@github.com:All-Hands-AI/plugin.git" }]);
+
+      expect(
+        screen.getByText("git@github.com:All-Hands-AI/plugin.git"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/components/features/launch/plugin-launch-modal.tsx
+++ b/src/components/features/launch/plugin-launch-modal.tsx
@@ -25,6 +25,11 @@ interface ExpandedState {
   [key: number]: boolean;
 }
 
+// Hosts whose URLs may be displayed as a bare `owner/repo` coordinate. Any
+// other host must stay visible: the modal's trust line names the source as the
+// thing the user is handing their agent secrets to.
+const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
+
 export function PluginLaunchModal({
   plugins,
   message,
@@ -103,11 +108,25 @@ export function PluginLaunchModal({
 
   const getPluginSourceInfo = (plugin: PluginSpec): string => {
     const { source } = plugin;
+    // `github:owner/repo` names GitHub in the scheme, so the prefix is the
+    // only thing worth trimming.
     if (source.startsWith("github:")) {
       return source.replace("github:", "");
     }
-    if (source.includes("github.com/")) {
-      return source.split("github.com/")[1]?.replace(".git", "") || source;
+    // Anything else is shortened only when the URL's *host* really is GitHub.
+    // A substring test (`source.includes("github.com/")`) matches
+    // "https://evil.example/github.com/All-Hands-AI/plugin" and would show it
+    // as "All-Hands-AI/plugin" — hiding the host the skill is actually fetched
+    // from, in the same sentence that asks the user to trust it with their
+    // agent secrets.
+    try {
+      const url = new URL(source);
+      if (GITHUB_HOSTS.has(url.hostname.toLowerCase())) {
+        return url.pathname.replace(/^\/+/, "").replace(/\.git$/, "") || source;
+      }
+    } catch {
+      // Not a parseable URL (a bare path, `git@host:owner/repo`, …). Show it
+      // whole rather than guessing which part is the host.
     }
     return source;
   };


### PR DESCRIPTION
HUMAN:

  Found with CodeQL (`js/incomplete-url-substring-sanitization`) and then run
  down by hand. I did not click through a real `/launch` link in a browser —
  what I verified is the rendered modal in jsdom: with a crafted source the
  dialog shows `All-Hands-AI/openhands-plugin` and the string `evil.example`
  appears nowhere in it, and after the fix the whole URL is shown. That
  before/after is the screenshot below. Someone should still try the real link
  in a browser before this is trusted for a release.

---

AGENT:

## Why

`/launch` takes the skill to install straight from the URL —
`?plugins=<base64 JSON>` or `?plugin_source=…` — and the only check on
`source` is `typeof item.source === "string"` (`src/routes/launch.tsx`). The
confirmation modal then asks:

> I trust this skill from **{{sources}}** with the agent secrets defined in my
> account.

`{{sources}}` came from a substring test:

```ts
if (source.includes("github.com/")) {
  return source.split("github.com/")[1]?.replace(".git", "") || source;
}
```

`github.com/` can appear anywhere in the URL, including the path of a host the
attacker controls. Measured, rendering the real modal:

| | displayed source |
|---|---|
| `main` | `All-Hands-AI/openhands-plugin` |
| this branch | `https://evil.example/github.com/All-Hands-AI/openhands-plugin` |

for the actual source `https://evil.example/github.com/All-Hands-AI/openhands-plugin`.
On `main` the host appears nowhere in the dialog — not in the title, not in the
plugin list, not in the trust sentence. The consent names a repo that does not
own the code being fetched, and the thing being consented to is the account's
agent secrets.

## Summary

- A source is shortened to `owner/repo` only when the parsed URL's **host** is
  `github.com` / `www.github.com`.
- Any other host is shown whole, so it is visible in the trust sentence.
- Sources that do not parse as a URL (`git@github.com:owner/repo.git`, bare
  paths) are shown unchanged rather than guessed at.
- `github:owner/repo` still shortens — that scheme names GitHub itself.
- Five regression tests on the rendered modal.

`src/utils/plugin-display.ts` already had a safe `getPluginSourceLabel()` that
returns the source unabbreviated. This modal did not use it and rolled its own
— worth a follow-up to converge them, but out of scope for a security fix.

## Issue Number

Fixes #17162

## How to Test

```bash
npx vitest run __tests__/components/features/launch/plugin-launch-modal.test.tsx
```

34 pass here; against `main` the spoofing assertion fails. In a browser, open

```
/launch?plugin_source=https%3A%2F%2Fevil.example%2Fgithub.com%2FAll-Hands-AI%2Fopenhands-plugin
```

and read the trust checkbox: it should name `evil.example`, not
`All-Hands-AI/openhands-plugin`.

## Video/Screenshots

Not a styling change, so this is the rendered-output evidence rather than a
screenshot of the app. Top half is `main`, bottom half this branch; both render
the same crafted source.

![plugin launch modal source spoofing, before and after](https://raw.githubusercontent.com/lzhan011/OpenHands/pr-assets/plugin-source-spoof-reproduction.png)

What it establishes: the modal's source line reads as the official coordinate
on `main` and shows the real host after the change. What it does not establish:
that anyone clicked such a link in a browser, or that a skill from a spoofed
host was actually fetched and given secrets — the install path itself was not
exercised.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Only the *display* changes. Nothing about which source is fetched or installed
is altered here — a user who reads the host and still consents gets the same
behaviour as before. Tightening what `/launch` will accept at all is a
separate, larger question.

The modal title still shows the last path segment (`openhands-plugin`), which
also reads like a repo name. That is a display name rather than an origin
claim, and the trust sentence is the thing that carries the security meaning,
so I left it alone rather than widening the change.

