### PR TITLE
fix(ci): name the Windows lane after the steps it runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,16 @@ jobs:
       - name: Build test matrix
         id: matrix
         run: |
-          echo 'matrix={"include":[{"name":"ubuntu","os":"ubuntu-24.04","full_checks":true},{"name":"windows","os":"windows-latest","full_checks":false}]}' >> "$GITHUB_OUTPUT"
+          # `job_label` names each lane after the steps it actually runs. Only the
+          # `full_checks` lane runs lint, tests, the library build and the package
+          # check, so the lane without them is named `build`, not `test-and-build`.
+          # Keep `test-and-build (ubuntu)` stable: the Release Tag ruleset and
+          # release.yml both wait on that exact check name.
+          echo 'matrix={"include":[{"name":"ubuntu","os":"ubuntu-24.04","full_checks":true,"job_label":"test-and-build"},{"name":"windows","os":"windows-latest","full_checks":false,"job_label":"build"}]}' >> "$GITHUB_OUTPUT"
 
   test-and-build:
     needs: prepare-test-matrix
-    name: test-and-build (${{ matrix.name }})
+    name: ${{ matrix.job_label }} (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:


### PR DESCRIPTION
HUMAN:

Ran the matrix template locally and got test-and-build (ubuntu) and build (windows). Confirmed release.yml still waits on the unchanged ubuntu name, so the release gate is unaffected.


AGENT:

## Why

`test-and-build (windows)` appears on every PR and goes green, but every step that checks anything is gated off on that lane.

The matrix marks Windows `full_checks: false`, and `Lint`, `Test`, `Build library` and `Verify package contents` are each guarded by `if: matrix.full_checks`. So the Windows lane installs dependencies and runs `npm run build` — no lint, no typecheck, and none of the repository's test files — while carrying "test" in its name and a green tick.

Reading the checks list, Windows looks covered. It is not.

## Summary

- Add a `job_label` field to the test matrix and use it for the job name, so each lane is named after the steps it actually runs: `test-and-build (ubuntu)` and `build (windows)`.
- Document in the matrix step why the two lanes are named differently, so the naming is not "corrected" back later.
- No change to which steps run on either lane.

## Issue Number

Fixes #17148

## How to Test

The rename is visible on this PR's own checks list: the Windows lane now reports as `build (windows)` instead of `test-and-build (windows)`, while `test-and-build (ubuntu)` is unchanged.

To verify the templating locally without waiting for CI:

```bash
python3 -c "
import yaml, json, re
d = yaml.safe_load(open('.github/workflows/ci.yml'))
run = d['jobs']['prepare-test-matrix']['steps'][0]['run']
line = [l for l in run.splitlines() if l.strip().startswith('echo')][0]
mx = json.loads(re.search(r\"matrix=(\{.*\})' >>\", line).group(1))
name = d['jobs']['test-and-build']['name']
for inc in mx['include']:
    print(name.replace('\${{ matrix.job_label }}', inc['job_label'])
              .replace('\${{ matrix.name }}', inc['name']))
"
```

Prints:

```
test-and-build (ubuntu)
build (windows)
```

## Video/Screenshots

Not applicable — this changes a CI job's display name and touches no application code. The evidence is this PR's own checks list, where the Windows lane reports under its new name.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

**The ubuntu lane's name is deliberately unchanged.** `.github/workflows/release.yml` waits on the literal check name `test-and-build (ubuntu)` (`REQUIRED_CHECK: test-and-build (ubuntu)`), and the concurrency comment in `ci.yml` records that the "Release Tag" ruleset requires that same name on the tagged commit. Renaming that lane would break the release gate. I grepped the repo: nothing references the Windows lane's name, so `build (windows)` is safe to change. If `test-and-build (windows)` is configured as a required check in branch protection — which I cannot see from outside — that rule needs updating to `build (windows)` alongside this merge.

**On the `Type` checkbox:** #17148 carries the `bug` label, but this change alters no behavior — only a display name — so I marked it `Docs / chore` rather than `Bug fix`, which also avoids inventing a "reproduction screenshot" for a rename. Happy to re-check it as `Bug fix` if you would rather the PR type mirror the issue label.

**Scope.** This is option 1 from the issue (the rename). It leaves the decision in #11694 / #11696 untouched and does not re-enable Windows test execution. The issue also floats adding `npm run typecheck` to the Windows lane as an optional extra; the issue author notes it would not have caught any of the eight Windows bugs they list, so I left it out. Happy to add it if wanted.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.64s · commit 6729f2f  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 1/1 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 6.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 16.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 5.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 75.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 796d822953c617300f42004872b1cd7722113022324786ecee3787be5458eb15 -->
<!-- jev-fast-audit:end -->
