### PR TITLE
fix(launch): only shorten source to a repo coordinate when the host is GitHub

### DIFF
--- a/__tests__/components/features/launch/plugin-launch-modal.test.tsx
+++ b/__tests__/components/features/launch/plugin-launch-modal.test.tsx
@@ -423,4 +423,32 @@ describe("PluginLaunchModal", () => {
       expect(input1).toHaveValue("new-val1");
     });
   });
+
+  describe("source display in the trust prompt (launch URL spoofing)", () => {
+    it("shortens a real github.com URL to its repo coordinate", () => {
+      const modal = renderModal([{ source: "https://github.com/owner/repo-name.git" }]);
+      expect(screen.getByText(/owner\/repo-name/)).toBeTruthy();
+    });
+
+    it("shortens github: shorthand", () => {
+      const modal = renderModal([{ source: "github:owner/plugin1" }]);
+      const elements = screen.getAllByText(/owner\/plugin1/);
+      expect(elements.length).toBeGreaterThan(0);
+    });
+
+    it("shows the whole URL when the host only looks like GitHub", () => {
+      const spoofed = "https://evil.example/github.com/All-Hands-AI/openhands-plugin";
+      const modal = renderModal([{ source: spoofed }]);
+      // The real host must be visible in the trust prompt, not hidden behind a
+      // repo coordinate the attacker placed in their own path.
+      expect(screen.getByText(/evil\.example/)).toBeTruthy();
+    });
+
+    it("shows the whole URL for non-GitHub git hosts", () => {
+      const source = "https://gitlab.com/owner/repo";
+      const modal = renderModal([{ source }]);
+      expect(screen.getByText(/gitlab\.com/)).toBeTruthy();
+    });
+  });
+
 });

--- a/src/components/features/launch/plugin-launch-modal.tsx
+++ b/src/components/features/launch/plugin-launch-modal.tsx
@@ -106,8 +106,21 @@ export function PluginLaunchModal({
     if (source.startsWith("github:")) {
       return source.replace("github:", "");
     }
-    if (source.includes("github.com/")) {
-      return source.split("github.com/")[1]?.replace(".git", "") || source;
+    // Only shorten a real github.com URL to its repo coordinate: the host is
+    // parsed, not substring-matched, so `github.com/` appearing in the path of
+    // another host (e.g. https://evil.example/github.com/owner/repo) is
+    // displayed whole and the fetching host stays visible in the trust prompt.
+    try {
+      const url = new URL(source);
+      if (
+        (url.hostname === "github.com" || url.hostname === "www.github.com") &&
+        url.pathname.length > 1
+      ) {
+        const coordinate = url.pathname.replace(/^\//, "").replace(/\.git$/, "");
+        if (coordinate) return coordinate;
+      }
+    } catch {
+      // not a parseable URL — display whole
     }
     return source;
   };


### PR DESCRIPTION
## Description

The `/launch` trust prompt decided a source was a GitHub repo by substring: `source.includes("github.com/")`. An attacker-controlled host with `github.com` in its path — e.g. `https://evil.example/github.com/All-Hands-AI/openhands-plugin` — displayed as `All-Hands-AI/openhands-plugin`, and the real fetching host appeared nowhere in the sentence asking the user to trust the skill with their account secrets.

This parses the URL with `new URL()` and only shortens when the hostname actually is `github.com` or `www.github.com`. Everything else displays whole, keeping the host visible in the trust prompt.

Fixes #17157

## Testing

New regression tests in `plugin-launch-modal.test.tsx`:

- shortens a real `github.com` URL to its repo coordinate
- shortens `github:` shorthand
- **shows the whole URL when the host only looks like GitHub** (the spoofing vector from the issue)
- shows the whole URL for non-GitHub git hosts (gitlab.com)

Red/green: on unpatched `main` the spoofing test fails (the attacker's host is hidden); with this change all 33 tests in the file pass.

The display-name helper (`getPluginDisplayName`) is unchanged: it shows the last path segment, which is the plugin name regardless of host — the trust-relevant surface is the source line, which is what this fixes.