### PR TITLE
docs: align .env.sample comments with local launchers and defaults

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,7 +9,7 @@ VITE_BACKEND_BASE_URL="http://127.0.0.1:8000" # Base URL used by browser-side di
 # e.g. VITE_BACKEND_BASE_URL="http://localhost:8010" — see examples/acp-docker/
 # and docs/ACP_AGENTS.md → "Running ACP agents in a Docker container".
 # VITE_SESSION_API_KEY="" # Set to the same value as backend SESSION_API_KEY or OH_SESSION_API_KEYS_0 when auth is enabled
-# VITE_WORKING_DIR="/workspace/project/agent-canvas" # Base dir for per-conversation working_dirs. Each conversation's working_dir is <VITE_WORKING_DIR>/<id_hex>. Defaults to <OH_CANVAS_SAFE_STATE_DIR>/workspaces, which is the sibling of the agent server's <state_dir>/conversations/ persistence dir — both share the same <id_hex> per conversation.
+# VITE_WORKING_DIR="/workspace/project/agent-canvas" # Base dir for per-conversation working_dirs. Each conversation's working_dir is <VITE_WORKING_DIR>/<id_hex>. Defaults to <OH_CANVAS_SAFE_STATE_DIR>/workspaces, which is the sibling of the agent server's <state_dir>/dev_conversations/ persistence dir — both share the same <id_hex> per conversation.
 # VITE_ENABLE_BROWSER_TOOLS="true" # Set to false to omit BrowserToolSet from new conversations
 
 # Frontend dev server
@@ -26,12 +26,12 @@ VITE_INSECURE_SKIP_VERIFY="false" # Skip TLS certificate verification for proxie
 # Mocking / test helpers
 VITE_MOCK_API="false" # Enable/disable API mocking with MSW
 
-# `npm run dev` (scripts/dev-safe.mjs) — isolated local backend via uvx
+# Local backend launchers: `npm run dev` (scripts/dev-with-automation.mjs) or `npm run dev:minimal` (scripts/dev-safe.mjs)
 # OH_CANVAS_SAFE_BACKEND_PORT="18000" # Port the spawned agent-server listens on
-# OH_CANVAS_SAFE_VSCODE_PORT="18001" # Port forwarded to the embedded VS Code (defaults to backend port + 1)
-# OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas" # Where conversations and bash events are stored (tmux sockets live under /tmp)
+# OH_CANVAS_SAFE_VSCODE_PORT="18001" # Port forwarded to embedded VS Code (defaults to backend + 1000 [19000] for `npm run dev` to avoid automation port collisions, or backend + 1 [18001] for `npm run dev:minimal`)
+# OH_CANVAS_SAFE_STATE_DIR="$HOME/.openhands/agent-canvas" # Where conversations and bash events are stored (tmux sockets live under <stateDir>/tmux unless TMUX_TMPDIR is set)
 
 # Agent server version selection (uvx) — listed in order of precedence (highest first)
 # OH_AGENT_SERVER_LOCAL_PATH="" # Absolute path to a local software-agent-sdk checkout. Runs the local checkout via uvx with editable openhands-sdk/tools/workspace installs so source edits are picked up on restart. Highest precedence.
 # OH_AGENT_SERVER_GIT_REF="" # Git commit SHA or branch name (e.g., "main", "abc1234"). Takes precedence over version.
-# OH_AGENT_SERVER_VERSION="" # Specific PyPI version (e.g., "1.18.0"). Uses latest release if unset.
+# OH_AGENT_SERVER_VERSION="" # Specific PyPI version. If unset, defaults to versions.agentServer defined in config/defaults.json.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Verified updated comments against package.json scripts, config/defaults.json, scripts/dev-safe.mjs, and scripts/dev-with-automation.mjs.

---

AGENT:

## Why

Comments in `.env.sample` drifted from actual repository scripts and configuration:
1. Documented `npm run dev` as `scripts/dev-safe.mjs` (it maps to `scripts/dev-with-automation.mjs`, while `npm run dev:minimal` runs `scripts/dev-safe.mjs`).
2. Documented `OH_AGENT_SERVER_VERSION` as defaulting to the latest PyPI release when unset (it defaults to `versions.agentServer` in `config/defaults.json`).
3. Documented tmux sockets residing under `/tmp` (they live in `<stateDir>/tmux` unless `TMUX_TMPDIR` is defined).
4. Stated VS Code port defaults to `backend + 1` (only true for `dev:minimal`; full dev defaults to `backend + 1000`).
5. Stated conversation persistence directory as `<state_dir>/conversations/` (persisted under `<state_dir>/dev_conversations/`).

## Summary

- Updated launcher documentation in `.env.sample` to distinguish `npm run dev` and `npm run dev:minimal`.
- Corrected the `OH_AGENT_SERVER_VERSION` unset fallback note to reference `config/defaults.json`.
- Updated tmux socket location to `<stateDir>/tmux`.
- Documented VS Code port defaults for both `dev` (19000) and `dev:minimal` (18001).
- Corrected persistence directory reference to `dev_conversations`.

## Issue Number

Issue: 17069 (ready-for-dev pending triage)

## How to Test

Review `.env.sample` comments against `package.json`, `config/defaults.json`, `scripts/dev-safe.mjs`, and `scripts/dev-with-automation.mjs`.

## Video/Screenshots

Not applicable (documentation-only change).

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

None.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.36s · commit 7d595b5  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 2/2 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 2.0% | No direct hunk selected |
| Contract regression | 5.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 2.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 98.0% | No primary concern to locate |

</details>


<!-- jev-input-signature aece4dfa7287c875fe2df5fc038c9a2ad4f000d9a42c48c43945d39a86a019b8 -->
<!-- jev-fast-audit:end -->
