### PR TITLE
docs: pin live-acp docker example to defaults agentServer

### DIFF
--- a/tests/e2e/live-acp/README.md
+++ b/tests/e2e/live-acp/README.md
@@ -8,9 +8,12 @@ provider API calls. It's the "it actually works" companion to the unit tests in
 `__tests__/api/agent-server-adapter.test.ts` — those assert the request shape;
 this asserts a real agent reply.
 
-> **Requires `agent-server:1.25.0-python` or newer** (software-agent-sdk#3510):
-> the ACP credentials ride as loopback LookupSecrets, and only #3510 resolves
-> them off the event loop. An older image deadlocks the first turn.
+> **Requires `agent-server:1.28.0-python` or newer** (`config/defaults.json`
+> `compatibility.minimumAgentServer`; software-agent-sdk#3510 + client_tools):
+> ACP credentials ride as loopback LookupSecrets (resolved off the event loop),
+> and Canvas needs the client_tools API. Prefer the pin
+> `versions.agentServer` (`1.44.1-python`). An older image deadlocks the first
+> turn or lacks client_tools.
 
 It is **not** part of `npm test` (it lives under `tests/`, which Vitest excludes,
 and needs a running container + real host credentials).
@@ -18,12 +21,13 @@ and needs a running container + real host credentials).
 ## Run it
 
 ```bash
-# 1. Agent-server container. v1.28.0 adds the client_tools API used by Canvas.
+# 1. Agent-server container. Recommended pin: config/defaults.json
+#    versions.agentServer (1.44.1-python). Compatibility floor: 1.28.0-python.
 #    The Python mount keeps pre-migration conversation state loadable.
 docker run -d --name oh-acp -p 8010:8000 \
   -v oh-acp-data:/workspace \
   -v "$(pwd)/tools:/canvas-tools:ro" -e OH_EXTRA_PYTHON_PATH=/canvas-tools \
-  ghcr.io/openhands/agent-server:1.28.0-python
+  ghcr.io/openhands/agent-server:1.44.1-python
 
 # 2. Run the e2e (all providers, or a subset).
 npx vite-node -c tests/e2e/live-acp/vite-node.config.mts \

--- a/tests/e2e/live-acp/acp-docker-e2e.mts
+++ b/tests/e2e/live-acp/acp-docker-e2e.mts
@@ -10,7 +10,8 @@
  * LookupSecrets Canvas emits resolve back from the store and authenticate the
  * CLI end-to-end (including the SDK's acp_file_secrets materialisation).
  *
- * Requires agent-server v1.28.0: it includes both software-agent-sdk#3510 for
+ * Requires agent-server >= v1.28.0 (defaults.json minimumAgentServer); example pin is versions.agentServer:
+ * it includes both software-agent-sdk#3510 for
  * off-loop LookupSecret resolution and the client_tools API used by
  * canvas_ui_control. Older images either deadlock resolving ACP credentials or
  * omit the Canvas UI tool.
@@ -20,7 +21,7 @@
  *
  *   docker run -d --name oh-acp -p 8010:8000 -v oh-acp-data:/workspace \
  *     -v "$(pwd)/tools:/canvas-tools:ro" -e OH_EXTRA_PYTHON_PATH=/canvas-tools \
- *     ghcr.io/openhands/agent-server:1.28.0-python
+ *     ghcr.io/openhands/agent-server:1.44.1-python
  *   npx vite-node -c tests/e2e/live-acp/vite-node.config.mts \
  *     tests/e2e/live-acp/acp-docker-e2e.mts -- codex claude gemini
  *


### PR DESCRIPTION
## Summary
- Update `tests/e2e/live-acp/README.md` run instructions to recommend `ghcr.io/openhands/agent-server:1.44.1-python` from `config/defaults.json` `versions.agentServer`, and correct the compatibility floor callout to `1.28.0-python` (`compatibility.minimumAgentServer`) instead of the stale `1.25.0-python` note.
- Mirror the same recommended image pin in the `acp-docker-e2e.mts` JSDoc example.

Matches the same defaults.json source of truth used by the Canvas launchers / ACP docs.

## Test plan
- [x] Diff-only docs/JSDoc; no runtime behavior change
- [ ] Confirm `config/defaults.json` still has `versions.agentServer: "1.44.1"` and `compatibility.minimumAgentServer: "1.28.0"` on merge