### PR TITLE
feat(agent-profile): expose verification settings

### DIFF
--- a/__tests__/components/settings/agent-profiles/agent-profiles-local-view.test.tsx
+++ b/__tests__/components/settings/agent-profiles/agent-profiles-local-view.test.tsx
@@ -343,6 +343,7 @@ describe("AgentProfilesLocalView save mapping", () => {
       isDirty: true,
       buildAgentProfileFields: () => ({
         agent_kind: "openhands",
+        mcp_server_refs: null,
         enable_sub_agents: false,
         verification: {
           critic_enabled: true,

--- a/__tests__/components/settings/agent-profiles/agent-profiles-local-view.test.tsx
+++ b/__tests__/components/settings/agent-profiles/agent-profiles-local-view.test.tsx
@@ -319,6 +319,58 @@ describe("AgentProfilesLocalView save mapping", () => {
     const { profile } = saveMutate.mock.calls[0][0];
     expect(profile.enable_switch_llm_tool).toBe(true);
   });
+  it("edit-save persists edited verification settings", async () => {
+    vi.mocked(AgentProfilesService.getProfile).mockResolvedValue({
+      name: "default",
+      profile: {
+        schema_version: 1,
+        id: "p-1",
+        name: "default",
+        revision: 3,
+        agent_kind: "openhands",
+        llm_profile_ref: "default",
+        enable_sub_agents: false,
+        verification: {
+          critic_enabled: false,
+          enable_iterative_refinement: false,
+        },
+      },
+    } as never);
+
+    emitControl = {
+      agentType: "openhands",
+      isValid: true,
+      isDirty: true,
+      buildAgentProfileFields: () => ({
+        agent_kind: "openhands",
+        enable_sub_agents: false,
+        verification: {
+          critic_enabled: true,
+          enable_iterative_refinement: true,
+        },
+      }),
+      credentials: { isDirty: false, save: vi.fn(), reset: vi.fn() },
+    };
+
+    render(<AgentProfilesLocalView />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("edit-agent-profile"));
+    await screen.findByTestId("mock-agent-settings");
+    await user.click(screen.getByTestId("save-agent-profile-btn"));
+
+    await waitFor(() => expect(saveMutate).toHaveBeenCalledTimes(1));
+
+    const { profile } = saveMutate.mock.calls[0][0];
+
+    expect(profile).toMatchObject({
+      agent_kind: "openhands",
+      verification: {
+        critic_enabled: true,
+        enable_iterative_refinement: true,
+      },
+    });
+  });
 
   it("kind-switch edit-save sends a clean variant payload", async () => {
     vi.mocked(AgentProfilesService.getProfile).mockResolvedValue({

--- a/__tests__/components/settings/agent-profiles/merge-agent-profile-save-input.test.ts
+++ b/__tests__/components/settings/agent-profiles/merge-agent-profile-save-input.test.ts
@@ -152,4 +152,70 @@ describe("mergeAgentProfileSaveInput", () => {
 
     expect(mergeAgentProfileSaveInput(null, edited)).toEqual(edited);
   });
+it("preserves stored verification fields when only some verification settings are edited", () => {
+    const edited = {
+      agent_kind: "openhands",
+      verification: {
+        critic_enabled: false,
+        enable_iterative_refinement: false,
+      },
+    } as unknown as AgentProfileSaveInput;
+
+    const merged = mergeAgentProfileSaveInput(storedOpenHands, edited);
+
+    expect(merged).toMatchObject({
+      verification: {
+        critic_enabled: false,
+        critic_mode: "finish_and_message",
+        enable_iterative_refinement: false,
+        critic_threshold: 0.8,
+        max_refinement_iterations: 5,
+        critic_server_url: null,
+        critic_model_name: null,
+      },
+    });
+  });
+
+  it("preserves stored verification when verification is not edited", () => {
+    const edited: AgentProfileSaveInput = {
+      agent_kind: "openhands",
+      enable_sub_agents: true,
+      llm_profile_ref: "new-llm",
+    };
+
+    const merged = mergeAgentProfileSaveInput(storedOpenHands, edited);
+
+    expect(merged).toMatchObject({
+      verification: (storedOpenHands as Extract<
+        AgentProfile,
+        { agent_kind: "openhands" }
+      >).verification,
+    });
+  });
+
+  it("allows edited verification values to override stored values", () => {
+    const edited = {
+      agent_kind: "openhands",
+      verification: {
+        critic_enabled: false,
+        critic_mode: "message",
+        critic_threshold: 0.95,
+        enable_iterative_refinement: true,
+      },
+    } as unknown as AgentProfileSaveInput;
+
+    const merged = mergeAgentProfileSaveInput(storedOpenHands, edited);
+
+    expect(merged).toMatchObject({
+      verification: {
+        critic_enabled: false,
+        critic_mode: "message",
+        enable_iterative_refinement: true,
+        critic_threshold: 0.95,
+        max_refinement_iterations: 5,
+        critic_server_url: null,
+        critic_model_name: null,
+      },
+    });
+  });
 });

--- a/__tests__/routes/agent-settings.test.tsx
+++ b/__tests__/routes/agent-settings.test.tsx
@@ -18,7 +18,6 @@ const acpAuthStatusMock = vi.hoisted(() => vi.fn());
 vi.mock("#/hooks/query/use-acp-auth-status", () => ({
   useAcpAuthStatus: (...args: unknown[]) => acpAuthStatusMock(...args),
 }));
-
 // The profile editor gates the LLM-switching toggle on the backend's *profile*
 // model, which gained the field later than the settings schema did. Stub the
 // probe so both sides of that gate are reachable without a live server.
@@ -105,6 +104,57 @@ describe("AgentSettingsScreen", () => {
     ).toBeInTheDocument();
     // ACP-only fields stay hidden on the OpenHands branch.
     expect(screen.queryByTestId("agent-command-input")).not.toBeInTheDocument();
+  });
+  it("hides verification settings on the standalone Agent Settings page", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.agent_settings,
+          agent_kind: "openhands",
+          verification: {
+            critic_enabled: true,
+            enable_iterative_refinement: true,
+          },
+        },
+      }),
+    );
+
+    renderAgentSettingsScreen();
+    await screen.findByTestId("agent-settings-screen");
+
+    expect(screen.getByTestId("agent-type-selector")).toBeInTheDocument();
+    expect(screen.queryByText("Enable Critic")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Enable Iterative Refinement"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders verification settings in the embedded Agent Profile editor", async () => {
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettings({
+        agent_settings: {
+          ...MOCK_DEFAULT_USER_SETTINGS.agent_settings,
+          agent_kind: "openhands",
+          verification: {
+            critic_enabled: true,
+            enable_iterative_refinement: true,
+          },
+        },
+      }),
+    );
+
+    renderAgentSettingsScreen({ embedded: true });
+    await screen.findByTestId("agent-settings-screen");
+
+    expect(
+      screen.getByTestId("sdk-settings-verification.critic_enabled"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId(
+        "sdk-settings-verification.enable_iterative_refinement",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("labels the save button 'Save Changes' for consistency with other settings pages", async () => {

--- a/__tests__/routes/build-agent-profile-fields.test.ts
+++ b/__tests__/routes/build-agent-profile-fields.test.ts
@@ -265,6 +265,9 @@ describe("buildAgentProfileFields — mcp_server_refs", () => {
     toolConcurrency: "",
     mcpMode: "standard" as const,
     selectedMcpServers: [],
+    criticEnabled: false,
+    iterativeRefinementEnabled: false,
+    verificationDirty: false,
   };
 
   it("emits null in standard mode, so the profile inherits every server", () => {

--- a/__tests__/routes/build-agent-profile-fields.test.ts
+++ b/__tests__/routes/build-agent-profile-fields.test.ts
@@ -16,6 +16,9 @@ const baseAcp = {
   toolConcurrency: "",
   mcpMode: "standard" as const,
   selectedMcpServers: [],
+  verificationDirty: false,
+  criticEnabled: false,
+  iterativeRefinementEnabled: false,
 };
 
 const switchLlmToolField: SettingsFieldSchema = {
@@ -109,6 +112,9 @@ describe("buildAgentProfileFields — OpenHands", () => {
     toolConcurrency: "",
     mcpMode: "standard" as const,
     selectedMcpServers: [],
+    criticEnabled: false,
+    iterativeRefinementEnabled: false,
+    verificationDirty: false,
   };
 
   it("passes through enable_sub_agents and omits concurrency when the field is absent", () => {
@@ -201,6 +207,46 @@ describe("buildAgentProfileFields — OpenHands", () => {
         toolConcurrency: "abc",
       }),
     ).toThrow();
+  });
+  it("does not emit verification when verification settings are unchanged", () => {
+    const fields = buildAgentProfileFields({
+      ...baseOh,
+      criticEnabled: false,
+      iterativeRefinementEnabled: false,
+      verificationDirty: false,
+    });
+
+    expect(fields).not.toHaveProperty("verification");
+  });
+  it("emits critic and iterative refinement settings when changed", () => {
+    const fields = buildAgentProfileFields({
+      ...baseOh,
+      criticEnabled: true,
+      iterativeRefinementEnabled: true,
+      verificationDirty: true,
+    });
+
+    expect(fields).toMatchObject({
+      verification: {
+        critic_enabled: true,
+        enable_iterative_refinement: true,
+      },
+    });
+  });
+  it("disables iterative refinement when critic is disabled", () => {
+    const fields = buildAgentProfileFields({
+      ...baseOh,
+      criticEnabled: false,
+      iterativeRefinementEnabled: true,
+      verificationDirty: true,
+    });
+
+    expect(fields).toMatchObject({
+      verification: {
+        critic_enabled: false,
+        enable_iterative_refinement: false,
+      },
+    });
   });
 });
 

--- a/src/components/features/settings/agent-profiles/agent-profiles-local-view.tsx
+++ b/src/components/features/settings/agent-profiles/agent-profiles-local-view.tsx
@@ -12,7 +12,6 @@ import {
 import AgentProfilesService, {
   type AgentProfile,
   type AgentProfileSummary,
-  type AgentProfileSaveInput,
 } from "#/api/agent-profiles-service/agent-profiles-service.api";
 import { useSaveAgentProfile } from "#/hooks/mutation/use-save-agent-profile";
 import { useRenameAgentProfile } from "#/hooks/mutation/use-rename-agent-profile";
@@ -64,6 +63,7 @@ function toAgentSettingsOverride(
     enable_sub_agents: profile.enable_sub_agents,
     enable_switch_llm_tool: switchLlmToolEnabled,
     tool_concurrency_limit: profile.tool_concurrency_limit,
+    verification: { ...profile.verification },
   };
 }
 
@@ -188,17 +188,21 @@ export function AgentProfilesLocalView() {
 
     // Build the variant-specific fields from the embedded form (may throw on
     // invalid input, e.g. a bad concurrency value).
-    let input: AgentProfileSaveInput;
+    let input: Parameters<typeof mergeAgentProfileSaveInput>[1];
     try {
       const fields = saveControl.buildAgentProfileFields();
+
       if (fields.agent_kind === "openhands") {
         if (!llmProfileRef) {
           displayErrorToast(t(I18nKey.SETTINGS$AGENT_PROFILE_LLM_REQUIRED));
           return;
         }
-        input = { ...fields, llm_profile_ref: llmProfileRef };
+        input = {
+          ...fields,
+          llm_profile_ref: llmProfileRef,
+        };
       } else {
-        input = fields as AgentProfileSaveInput;
+        input = fields;
       }
     } catch (error) {
       displayErrorToast(

--- a/src/components/features/settings/agent-profiles/merge-agent-profile-save-input.ts
+++ b/src/components/features/settings/agent-profiles/merge-agent-profile-save-input.ts
@@ -1,30 +1,59 @@
 import type {
   AgentProfile,
   AgentProfileSaveInput,
-} from "#/api/agent-profiles-service/agent-profiles-service.api";
+  OpenHandsAgentProfile,
+} from "@openhands/typescript-client";
 
-/**
- * Merge the minimal editor's fields over the stored profile so an edit-save
- * doesn't wipe the fields the editor doesn't model (condenser, verification,
- * system_message_suffix, mcp_server_refs, the disabled_skills deny-list, ACP
- * session mode/timeout, …) — `POST /api/agent-profiles/{name}` is a
- * whole-profile overwrite, and unset fields fall back to server-side defaults.
- *
- * Kind-aware: when the editor switched `agent_kind`, the stored variant's
- * fields must NOT be carried over — the server's `extra="forbid"` profile
- * union rejects a payload mixing openhands and acp fields — so a kind switch
- * stays a clean variant replacement built from the edited fields alone.
- *
- * Identity (`id` / `name` / `revision`) is stripped from the merge: the path
- * name is authoritative on save, and the server preserves the namesake's id
- * and bumps the revision itself (`save_profile_preserving_identity`).
- */
+type OpenHandsAgentProfileSaveInput = Extract<
+  AgentProfileSaveInput,
+  { agent_kind: "openhands" }
+>;
+
+type PartialVerification = Partial<OpenHandsAgentProfile["verification"]>;
+
+type EditedAgentProfileSaveInput =
+  | (Omit<OpenHandsAgentProfileSaveInput, "verification"> & {
+      verification?: PartialVerification;
+    })
+  | (Omit<
+      Extract<AgentProfileSaveInput, { agent_kind: "acp" }>,
+      "acp_server"
+    > & {
+      acp_server?: string;
+    });
+
 export function mergeAgentProfileSaveInput(
   stored: AgentProfile | null,
-  edited: AgentProfileSaveInput,
+  edited: EditedAgentProfileSaveInput,
 ): AgentProfileSaveInput {
-  if (!stored) return edited;
-  if (stored.agent_kind !== edited.agent_kind) return edited;
+  if (!stored) {
+    return edited as AgentProfileSaveInput;
+  }
+
+  if (stored.agent_kind !== edited.agent_kind) {
+    return edited as AgentProfileSaveInput;
+  }
+
   const { id, name, revision, ...preserved } = stored;
-  return { ...preserved, ...edited } as AgentProfileSaveInput;
+
+  if (stored.agent_kind === "openhands" && edited.agent_kind === "openhands") {
+    const { verification: editedVerification, ...editedWithoutVerification } =
+      edited;
+
+    const mergedVerification: OpenHandsAgentProfile["verification"] = {
+      ...stored.verification,
+      ...(editedVerification ?? {}),
+    };
+
+    return {
+      ...preserved,
+      ...editedWithoutVerification,
+      verification: mergedVerification,
+    } as AgentProfileSaveInput;
+  }
+
+  return {
+    ...preserved,
+    ...edited,
+  } as AgentProfileSaveInput;
 }

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -969,7 +969,7 @@ export function AgentSettingsScreen({
           onChange={setToolConcurrency}
         />
       ) : null}
-      {!isAcp && criticField ? (
+      {embedded && !isAcp && criticField ? (
         <SchemaField
           field={criticField}
           value={criticEnabled}
@@ -985,7 +985,7 @@ export function AgentSettingsScreen({
         />
       ) : null}
 
-      {!isAcp && iterativeRefinementField ? (
+      {embedded && !isAcp && iterativeRefinementField ? (
         <SchemaField
           field={iterativeRefinementField}
           value={iterativeRefinementEnabled}

--- a/src/routes/agent-settings.tsx
+++ b/src/routes/agent-settings.tsx
@@ -64,6 +64,9 @@ const ENABLE_SUB_AGENTS_FIELD_KEY = "enable_sub_agents";
 const ENABLE_SWITCH_LLM_TOOL_FIELD_KEY = "enable_switch_llm_tool";
 const TOOL_CONCURRENCY_FIELD_KEY = "tool_concurrency_limit";
 const MCP_SERVER_REFS_KEY = "mcp_server_refs";
+const CRITIC_ENABLED_FIELD_KEY = "verification.critic_enabled";
+const ITERATIVE_REFINEMENT_FIELD_KEY =
+  "verification.enable_iterative_refinement";
 const COMMAND_PLACEHOLDER_FALLBACK = "npx -y <package-name>";
 const ACP_CUSTOM_MODEL_KEY = "__custom_model__";
 const EMPTY_AGENT_SETTINGS_SNAPSHOT: AgentSettingsSnapshot = {
@@ -72,7 +75,23 @@ const EMPTY_AGENT_SETTINGS_SNAPSHOT: AgentSettingsSnapshot = {
   acpModel: "",
   isCustomAcpModel: false,
 };
+function getVerificationSetting(
+  source: Record<string, SettingsValue> | null,
+  key: "critic_enabled" | "enable_iterative_refinement",
+): boolean | undefined {
+  const verification = source?.verification;
 
+  if (
+    typeof verification === "object" &&
+    verification !== null &&
+    !Array.isArray(verification)
+  ) {
+    const value = (verification as Record<string, unknown>)[key];
+    return typeof value === "boolean" ? value : undefined;
+  }
+
+  return undefined;
+}
 function toStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((v): v is string => typeof v === "string")
@@ -122,7 +141,6 @@ function isKnownAcpModel(
     provider?.available_models?.some(({ id }) => id === model.trim()) ?? false
   );
 }
-
 /**
  * Variant-specific AgentProfile fields derived from the form state. The
  * OpenHands branch omits `llm_profile_ref` — the profile editor supplies it.
@@ -134,6 +152,10 @@ export type AgentProfileFieldsDraft =
       enable_sub_agents: boolean;
       enable_switch_llm_tool?: boolean;
       tool_concurrency_limit?: number;
+      verification?: {
+        critic_enabled: boolean;
+        enable_iterative_refinement: boolean;
+      };
     }
   | {
       agent_kind: "acp";
@@ -156,6 +178,8 @@ export interface AgentProfileFieldsInput {
   subAgentsEnabled: boolean;
   switchLlmToolField?: SettingsFieldSchema;
   switchLlmToolEnabled: boolean;
+  criticEnabled: boolean;
+  iterativeRefinementEnabled: boolean;
   /**
    * Whether the backend's *profile* model accepts `enable_switch_llm_tool`.
    * Tracked apart from {@link switchLlmToolField} because the settings schema
@@ -167,6 +191,7 @@ export interface AgentProfileFieldsInput {
   toolConcurrency: string | boolean;
   mcpMode: ProfileScopeMode;
   selectedMcpServers: string[];
+  verificationDirty: boolean;
 }
 
 /**
@@ -204,6 +229,9 @@ export function buildAgentProfileFields(
     toolConcurrency,
     mcpMode,
     selectedMcpServers,
+    criticEnabled,
+    iterativeRefinementEnabled,
+    verificationDirty,
   } = input;
   // A base-model field, so it rides both variants. No version gate: it has
   // existed since agent profiles shipped, below the supported floor.
@@ -251,6 +279,14 @@ export function buildAgentProfileFields(
         : 1;
     fields.tool_concurrency_limit =
       coerced != null ? Number(coerced) : fallback;
+  }
+  if (verificationDirty) {
+    fields.verification = {
+      critic_enabled: criticEnabled,
+      enable_iterative_refinement: criticEnabled
+        ? iterativeRefinementEnabled
+        : false,
+    };
   }
   return fields;
 }
@@ -368,6 +404,34 @@ export function AgentSettingsScreen({
   }, [toolConcurrencyField, agentSettingsSource]);
   const [toolConcurrency, setToolConcurrency] = useState<string | boolean>(
     initialToolConcurrency,
+  );
+  // --- Verification (OpenHands profile path) ---
+  const criticField = fields?.find(
+    (field) => field.key === CRITIC_ENABLED_FIELD_KEY,
+  );
+  const iterativeRefinementField = fields?.find(
+    (field) => field.key === ITERATIVE_REFINEMENT_FIELD_KEY,
+  );
+
+  const initialCriticEnabled = React.useMemo(
+    () =>
+      getVerificationSetting(agentSettingsSource, "critic_enabled") ??
+      criticField?.default === true,
+    [criticField, agentSettingsSource],
+  );
+
+  const initialIterativeRefinementEnabled = React.useMemo(
+    () =>
+      getVerificationSetting(
+        agentSettingsSource,
+        "enable_iterative_refinement",
+      ) ?? iterativeRefinementField?.default === true,
+    [iterativeRefinementField, agentSettingsSource],
+  );
+
+  const [criticEnabled, setCriticEnabled] = useState(initialCriticEnabled);
+  const [iterativeRefinementEnabled, setIterativeRefinementEnabled] = useState(
+    initialIterativeRefinementEnabled,
   );
 
   // --- MCP servers (both variants; a base-model field) ---
@@ -528,6 +592,13 @@ export function AgentSettingsScreen({
   useEffect(() => {
     setToolConcurrency(initialToolConcurrency);
   }, [initialToolConcurrency]);
+  useEffect(() => {
+    setCriticEnabled(initialCriticEnabled);
+  }, [initialCriticEnabled]);
+
+  useEffect(() => {
+    setIterativeRefinementEnabled(initialIterativeRefinementEnabled);
+  }, [initialIterativeRefinementEnabled]);
 
   // Sync the MCP scope when settings reload
   useEffect(() => {
@@ -562,6 +633,10 @@ export function AgentSettingsScreen({
   const mcpScopeDirty =
     mcpMode !== initialMcpRefs.mode ||
     !sameScopeSelection(orderedSelectedMcpServers, initialMcpRefs.selected);
+
+  const verificationDirty =
+    criticEnabled !== initialCriticEnabled ||
+    iterativeRefinementEnabled !== initialIterativeRefinementEnabled;
   const settingsDirty =
     agentType !== loadedSnapshot.agentType ||
     mcpScopeDirty ||
@@ -571,7 +646,8 @@ export function AgentSettingsScreen({
         isCustomAcpModel !== loadedSnapshot.isCustomAcpModel
       : subAgentsEnabled !== initialSubAgentsEnabled ||
         switchLlmToolEnabled !== initialSwitchLlmToolEnabled ||
-        toolConcurrency !== initialToolConcurrency);
+        toolConcurrency !== initialToolConcurrency ||
+        verificationDirty);
   const credentialsDirty = acpCredentialForm.isDirty;
   const isAnyDirty = settingsDirty || credentialsDirty;
   useEffect(() => {
@@ -639,6 +715,9 @@ export function AgentSettingsScreen({
       toolConcurrency,
       mcpMode,
       selectedMcpServers: orderedSelectedMcpServers,
+      criticEnabled,
+      iterativeRefinementEnabled,
+      verificationDirty,
     });
 
   const isSavingAny = isSaving || acpCredentialForm.isSaving;
@@ -890,6 +969,32 @@ export function AgentSettingsScreen({
           onChange={setToolConcurrency}
         />
       ) : null}
+      {!isAcp && criticField ? (
+        <SchemaField
+          field={criticField}
+          value={criticEnabled}
+          isDisabled={isSavingAny}
+          onChange={(value) => {
+            const enabled = value === true;
+            setCriticEnabled(enabled);
+
+            if (!enabled) {
+              setIterativeRefinementEnabled(false);
+            }
+          }}
+        />
+      ) : null}
+
+      {!isAcp && iterativeRefinementField ? (
+        <SchemaField
+          field={iterativeRefinementField}
+          value={iterativeRefinementEnabled}
+          isDisabled={isSavingAny || !criticEnabled}
+          onChange={(value) => {
+            setIterativeRefinementEnabled(value === true);
+          }}
+        />
+      ) : null}
 
       {showProfileScopeFields ? (
         <div className="flex flex-col gap-2.5">
@@ -968,7 +1073,6 @@ export function AgentSettingsScreen({
           </Typography.Text>
         </div>
       ) : null}
-
       {isAcp && (
         <>
           <SettingsDropdownInput

--- a/tests/e2e/mock-llm/utils/mock-llm-helpers.ts
+++ b/tests/e2e/mock-llm/utils/mock-llm-helpers.ts
@@ -113,6 +113,20 @@ export async function seedLocalStorage(page: Page) {
           },
         ]),
       );
+
+      window.localStorage.setItem(
+        "openhands-active-backend",
+        JSON.stringify({
+          backendId: "default-local",
+        }),
+      );
+
+      window.sessionStorage.setItem(
+        "openhands-active-backend",
+        JSON.stringify({
+          backendId: "default-local",
+        }),
+      );
     },
     { apiKey: SESSION_API_KEY },
   );


### PR DESCRIPTION
HUMAN:

I implemented Agent Profile editor support for Critic and Iterative Refinement settings. I tested creation and editing, persistence of the selected verification settings, preservation of existing verification fields, independent profile settings, and the behavior where Iterative Refinement is disabled when Critic is disabled.

AGENT:

## Summary

Expose Critic and Iterative Refinement verification settings in the Agent Profile editor and persist them under `AgentProfile.verification`.

## Issue Number

Fixes #17176

## Why

Agent Profile verification settings were not exposed in the Agent Profile editor. This made it impossible to configure `critic_enabled` and `enable_iterative_refinement` through the Agent Profile UI.

This change exposes both settings in the Agent Profile editor and persists them under `AgentProfile.verification`.

The implementation also preserves existing verification fields that are not directly edited by the UI, so updating these settings does not overwrite other verification configuration.

## What Changed

- Added **Enable Critic** to the Agent Profile editor.
- Added **Enable Iterative Refinement** to the Agent Profile editor.
- Initialize both controls from the stored `verification` settings when editing an existing profile.
- Persist the selected values under `AgentProfile.verification`.
- Automatically disable Iterative Refinement when Critic is disabled.
- Preserve existing `verification` fields when saving edited profiles.
- Preserve verification settings independently for different profiles.
- Keep existing default behavior when profiles do not have explicit verification values.
- Added unit tests covering verification field construction and profile save/merge behavior.

## Implementation Details

- Added verification fields to the Agent Profile editor state.
- Read existing `verification.critic_enabled` and `verification.enable_iterative_refinement` values when editing a profile.
- Only include verification changes in the save payload when those settings were modified.
- Merge edited verification settings with the stored verification object so unrelated verification fields are preserved.
- Iterative Refinement is disabled automatically when Critic is disabled.

## How to Test

### Automated tests

Run:

`npm run typecheck`

Run the targeted tests:

`npm run test -- __tests__/components/settings/agent-profiles/merge-agent-profile-save-input.test.ts __tests__/routes/build-agent-profile-fields.test.ts __tests__/components/settings/agent-profiles/agent-profiles-local-view.test.tsx`

Expected result:

- 3 test files passed
- 32 tests passed

### Manual testing

1. Open **Settings → Agent Profiles**.
2. Edit an OpenHands Agent Profile.
3. Verify that **Enable Critic** and **Enable Iterative Refinement** are displayed.
4. Enable Critic and verify that Iterative Refinement becomes available.
5. Enable Iterative Refinement.
6. Disable Critic and verify that Iterative Refinement is automatically disabled.
7. Save the profile and reopen it to verify that the selected settings persist.
8. Verify that existing verification fields are preserved when changing these settings.
9. Verify that different profiles retain their verification settings independently.

## Video/Screenshots

**Critic disabled — Iterative Refinement is automatically disabled.**

<img width="1922" height="827" alt="image" src="https://github.com/user-attachments/assets/655130b7-cece-46b7-9fe6-d0b35ce3ae75" />


**Critic enabled — Iterative Refinement becomes available.**

<img width="1922" height="821" alt="image" src="https://github.com/user-attachments/assets/04596bf6-05e4-4a10-9f1c-80455e6bb17f" />


## Notes

The existing default profile launch behavior is unchanged.