### PR TITLE
fix(launch): validate github.com host before extracting repo coordinate

### DIFF
--- a/__tests__/components/features/launch/plugin-launch-modal.test.tsx
+++ b/__tests__/components/features/launch/plugin-launch-modal.test.tsx
@@ -39,7 +39,9 @@ describe("PluginLaunchModal", () => {
 
   describe("Plugin Display Name Extraction", () => {
     it("should extract plugin name from repo_path when provided", () => {
-      renderModal([{ source: "github:owner/repo", repo_path: "plugins/my-plugin" }]);
+      renderModal([
+        { source: "github:owner/repo", repo_path: "plugins/my-plugin" },
+      ]);
 
       // Plugin name should be "my-plugin" from the path
       expect(screen.getByText("my-plugin")).toBeInTheDocument();
@@ -54,9 +56,7 @@ describe("PluginLaunchModal", () => {
     });
 
     it("should extract name from git URL", () => {
-      renderModal([
-        { source: "https://github.com/owner/repo-name.git" },
-      ]);
+      renderModal([{ source: "https://github.com/owner/repo-name.git" }]);
 
       const elements = screen.getAllByText("repo-name");
       expect(elements.length).toBeGreaterThan(0);
@@ -67,6 +67,25 @@ describe("PluginLaunchModal", () => {
 
       const elements = screen.getAllByText("local-plugin");
       expect(elements.length).toBeGreaterThan(0);
+    });
+
+    it("does not extract a repo coordinate from a spoofed URL (#17162)", () => {
+      // An attacker embeds "github.com/" in the path of a host they control.
+      // The source display must show the full URL, not "owner/repo".
+      const attackerUrl = "https://evil.example/github.com/owner/repo";
+      renderModal([{ source: attackerUrl }]);
+
+      // The source info text must contain the full attacker URL
+      expect(screen.getByText(attackerUrl)).toBeInTheDocument();
+      // It must NOT show the misleading "owner/repo" extracted from the path
+      expect(screen.queryByText("owner/repo")).not.toBeInTheDocument();
+    });
+
+    it("extracts repo coordinate from a genuine github.com URL", () => {
+      renderModal([{ source: "https://github.com/owner/repo.git" }]);
+
+      // The source info should show "owner/repo" (without .git)
+      expect(screen.getByText("owner/repo")).toBeInTheDocument();
     });
   });
 
@@ -295,13 +314,13 @@ describe("PluginLaunchModal", () => {
 
       expect(screen.getByText("LAUNCH$ADDITIONAL_PLUGINS")).toBeInTheDocument();
       // When no repo_path, the full repo path is shown
-      expect(screen.getAllByText("owner/without-params").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText("owner/without-params").length,
+      ).toBeGreaterThan(0);
     });
 
     it("should show ref in simple plugin list", () => {
-      renderModal([
-        { source: "github:owner/plugin", ref: "main" },
-      ]);
+      renderModal([{ source: "github:owner/plugin", ref: "main" }]);
 
       expect(screen.getByText("@ main")).toBeInTheDocument();
     });
@@ -362,10 +381,9 @@ describe("PluginLaunchModal", () => {
 
     it("should call onStartConversation with message when provided", async () => {
       const user = userEvent.setup();
-      renderModal(
-        [{ source: "github:owner/repo" }],
-        { message: "/city-weather:now Tokyo" },
-      );
+      renderModal([{ source: "github:owner/repo" }], {
+        message: "/city-weather:now Tokyo",
+      });
 
       // Check the trust checkbox first
       await user.click(screen.getByTestId("trust-checkbox"));

--- a/src/components/features/launch/plugin-launch-modal.tsx
+++ b/src/components/features/launch/plugin-launch-modal.tsx
@@ -106,8 +106,19 @@ export function PluginLaunchModal({
     if (source.startsWith("github:")) {
       return source.replace("github:", "");
     }
-    if (source.includes("github.com/")) {
-      return source.split("github.com/")[1]?.replace(".git", "") || source;
+    // Only extract the owner/repo coordinate from a genuine github.com URL.
+    // A bare substring check on "github.com/" is unsafe: an attacker can
+    // embed it in the path of a host they control
+    // (e.g. https://evil.example/github.com/owner/repo) to make the trust
+    // prompt display a misleading repo coordinate (#17162).
+    try {
+      const url = new URL(source);
+      if (url.hostname === "github.com") {
+        const path = url.pathname.replace(/^\//, "").replace(/\.git$/, "");
+        return path || source;
+      }
+    } catch {
+      // source is not a URL — fall through to returning it verbatim
     }
     return source;
   };


### PR DESCRIPTION
HUMAN:

I tested the fix locally: verified that a spoofed URL (https://evil.example/github.com/owner/repo) no longer extracts "owner/repo" in the trust prompt, and that genuine github.com URLs still resolve correctly. All 31 modal tests pass including the 2 new security tests.

---

AGENT:

## Why

Issue #17162: `getPluginSourceInfo()` in the launch trust modal used an unsafe substring check on `"github.com/"` to extract the repo coordinate. An attacker could embed `github.com/` in the **path** of a host they control (e.g. `https://evil.example/github.com/All-Hands-AI/openhands-plugin`), causing the trust prompt to display `All-Hands-AI/openhands-plugin` while hiding the real source host. The user would be asked to trust a repo coordinate that doesn't own the code being fetched.

## Summary

- Replaced the unsafe `source.includes("github.com/")` substring check with `new URL(source)` parsing that verifies `url.hostname === "github.com"` before extracting the repo path.
- Non-URL sources (e.g. `github:owner/repo`, `local-plugin`) fall through unchanged.
- Added 2 regression tests: one verifying a spoofed URL shows the full URL (not the extracted coordinate), and one verifying a genuine github.com URL still extracts correctly.

## Issue Number

Fixes #17162

## How to Test

1. `npm ci && npm run make-i18n`
2. `npx vitest run __tests__/components/features/launch/plugin-launch-modal.test.tsx --reporter=verbose` — all 31 tests pass including the 2 new security tests.
3. `npm run typecheck` — passes.
4. `npx eslint src/components/features/launch/plugin-launch-modal.tsx` — clean.

## Video/Screenshots

Test output showing the 2 new security tests passing alongside existing tests:

```
$ npx vitest run __tests__/components/features/launch/plugin-launch-modal.test.tsx --reporter=verbose

 ✓ PluginLaunchModal > Plugin Display Name Extraction > does not extract a repo coordinate from a spoofed URL (#17162)
 ✓ PluginLaunchModal > Plugin Display Name Extraction > extracts repo coordinate from a genuine github.com URL

 Test Files  1 passed (1)
      Tests  31 passed (31)
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is a security fix (priority: high). The issue already carries the `ready-for-dev` label.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.44s · commit cf1be82  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 6/6 hunks, 2/2 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 7.0% | No direct hunk selected |
| Weakened authorization | 6.0% | No direct hunk selected |
| Contract regression | 11.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 3.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 3.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 5.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 92.0% | No primary concern to locate |

</details>


<!-- jev-input-signature e5403285baf870e62986a4fae387e64c505520bad9e456ccb4d39cc020d8f29c -->
<!-- jev-fast-audit:end -->
