### PR TITLE
docs: align live-acp app e2e agent-server floor with defaults

### DIFF
--- a/tests/e2e/live-acp/acp-docker-app-e2e.mts
+++ b/tests/e2e/live-acp/acp-docker-app-e2e.mts
@@ -13,8 +13,10 @@
  * credentials round-trip through the backend store and the orchestrator emits
  * the right LookupSecrets, end-to-end, against a real container.
  *
- * Requires an agent-server with software-agent-sdk#3510 (first in v1.25.0) —
- * ACP credentials resolve off the event loop; an older image deadlocks.
+ * Requires agent-server >= v1.28.0 (config/defaults.json
+ * compatibility.minimumAgentServer); prefer versions.agentServer
+ * (1.44.1-python). Needs software-agent-sdk#3510 for off-loop
+ * LookupSecret resolution. An older image deadlocks.
  *
  *   npx vite-node -c tests/e2e/live-acp/vite-node.config.mts \
  *     tests/e2e/live-acp/acp-docker-app-e2e.mts -- codex


### PR DESCRIPTION
## Summary

`tests/e2e/live-acp/acp-docker-app-e2e.mts` still documented agent-server `v1.25.0` as the requirement for the live ACP app-path e2e. Canvas's compatibility floor is `config/defaults.json` `compatibility.minimumAgentServer` (`1.28.0`), and the recommended pin is `versions.agentServer` (`1.44.1`). Update the file header to match that source of truth (same alignment already applied to the sibling request-builder e2e / README in #17187).

## Repro

```bash
jq '.versions.agentServer, .compatibility.minimumAgentServer' config/defaults.json
# "1.44.1"
# "1.28.0"
rg -n 'v1\.25\.0' tests/e2e/live-acp/acp-docker-app-e2e.mts
```

Docs/JSDoc only; no runtime change.