### PR TITLE
chore: bump automation default to 1.11.0 and agent-server to 1.45.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,10 +581,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.44.1")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.45.0")
   - `OH_SECRET_KEY` — secret key for settings encryption; auto-generated and persisted to `~/.openhands/agent-canvas/secret-key.txt` on first run (same file Docker uses), ensuring dev mode and Docker share the same key when both mount the same `~/.openhands` directory. Override with the env var to pin a specific key.
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.44.1` for agent-server SDK libraries
+  - Default: released PyPI version `1.45.0` for agent-server SDK libraries
 
 - Security: launchers generate and persist a 64-character session API key at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden. The agent-server and automation backend share that session key. `OH_SECRET_KEY` protects settings encryption and is persisted separately at `~/.openhands/agent-canvas/secret-key.txt`.
 - `scripts/dev-safe.mjs` should fail fast if `uvx` cannot be spawned (for example missing PATH entries).

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -468,13 +468,13 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.44.1",
+      "openhands-agent-server==1.45.0",
       "--with",
-      "openhands-sdk==1.44.1",
+      "openhands-sdk==1.45.0",
       "--with",
-      "openhands-tools==1.44.1",
+      "openhands-tools==1.45.0",
       "--with",
-      "openhands-workspace==1.44.1",
+      "openhands-workspace==1.45.0",
       "--with",
       "agent-client-protocol<0.11",
       "--with",
@@ -483,7 +483,7 @@ describe("buildAgentServerCommand", () => {
       "--import-modules",
       "canvas_ui_tool",
     ]);
-    expect(cmd.source).toBe("PyPI (1.44.1, default)");
+    expect(cmd.source).toBe("PyPI (1.45.0, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
   "versions": {
-    "agentServer": "1.44.1",
+    "agentServer": "1.45.0",
     "agentCanvas": "1.16.0",
-    "automation": "1.10.0"
+    "automation": "1.11.0"
   },
   "compatibility": {
     "minimumAgentServer": "1.28.0"

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.44.1 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.45.0 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -78,7 +78,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/OpenHands/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.44.1"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.45.0"}}'
 `);
   process.exit(0);
 }
@@ -260,9 +260,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.44.1,<2.0.0"
- *   "openhands-tools==1.44.1"
- *   "openhands-workspace (>=1.44.1)"
+ *   "openhands-sdk>=1.45.0,<2.0.0"
+ *   "openhands-tools==1.45.0"
+ *   "openhands-workspace (>=1.45.0)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -276,7 +276,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.44.1", "==1.44.1", "(>=1.44.1)", "~=1.44.1"
+      // ">=1.45.0", "==1.45.0", "(>=1.45.0)", "~=1.45.0"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -421,7 +421,7 @@ export const AGENT_SERVER_IMPORT_MODULES = "canvas_ui_tool";
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.44.1")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.45.0")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

I verified the changes.

AGENT:

---

## Why

`openhands-automation==1.11.0` was released on 2026-09-08 (https://github.com/OpenHands/automation/releases/tag/1.11.0). Agent Canvas still pins `versions.automation` to `1.10.0`, so `npm run dev`, the npm launcher and the Docker image all start the older automation backend by default.

`openhands-automation==1.11.0` declares `openhands-sdk==1.45.0` / `openhands-workspace==1.45.0`, so `versions.agentServer` has to move to `1.45.0` with it: `scripts/check-sdk-version-sync.mjs` (run by `.github/workflows/sdk-version-sync.yml` on every PR touching `config/defaults.json`) fails when the two differ, and the Docker image installs the automation package into the agent-server base image, so a mismatched pair would pull two SDK versions into the same environment.

## Summary

- `config/defaults.json`: `versions.automation` 1.10.0 → **1.11.0**, `versions.agentServer` 1.44.1 → **1.45.0**. The npm launchers, `npm run dev`, the Docker build and CI all derive their pins from this file.
- Documented default-version examples in `AGENTS.md`, `scripts/dev-safe.mjs` and `scripts/check-sdk-version-sync.mjs`, plus the `buildAgentServerCommand` expectation in `__tests__/scripts/dev-safe.test.ts`, follow the new agent-server pin (enforced by `__tests__/scripts/docs-version-sync.test.ts`).
- No other change: the mock-LLM automation lifecycle trajectory budget did not need adjusting for 1.11.0.

## Issue Number

Fixes #17202

## How to Test

| Command | Result |
| --- | --- |
| `node scripts/check-sdk-version-sync.mjs` | `openhands-automation==1.11.0` → `openhands-sdk ✓ 1.45.0`, `openhands-workspace ✓ 1.45.0`, **All SDK versions are in sync!** |
| `npm test -- __tests__/scripts/check-sdk-version-sync.test.ts __tests__/scripts/docs-version-sync.test.ts __tests__/scripts/dev-with-automation.test.ts __tests__/scripts/dev-safe.test.ts` | **4 files, 143 tests passed** |
| `npm run lint` | exit 0 — `tsc` clean, ESLint 0 errors (1 pre-existing warning in an untouched `src/` file), Prettier clean |
| `npm run build` | exit 0 |
| `docker manifest inspect ghcr.io/openhands/agent-server:1.45.0-python` | image exists on GHCR, so the Docker build can use it as base |
| `npm run test:e2e:mock-llm -- tests/e2e/mock-llm/automations` on a local stack running agent-server **1.45.0** + automation **1.11.0** via `bin/agent-canvas.mjs` | **4 passed, 1 failed.** `mock-llm-automation.spec.ts` steps 1–3 pass (automation created and dispatched through the real 1.11.0 backend, `Run … → COMPLETED`, run visible on the automations page). `mock-llm-preset-automation.spec.ts › automation card sends the correct slash command` passes. `› direct slash command from home page triggers skill activation` **fails** — see Notes. |
| Same preset spec, re-run | same single failure (deterministic, not a flake) |
| Same preset spec with `OH_AGENT_SERVER_VERSION=1.44.1 OH_AUTOMATION_VERSION=1.10.0` (the pins on `main`) | **2 passed**, zero secret lookups in the agent-server log |

## Video/Screenshots

Not applicable — config/doc pin change. The failing E2E test's screenshot shows the conversation page stuck on "Starting / Connecting" with no user message rendered; the agent-server log excerpt below is the actual evidence.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.45.0-python` |
| **Automation** | `openhands-automation==1.11.0` |
| **Commit** | `c94e8cf2bca1ffeae5384b75b9908e16c1b95b32` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-c94e8cf
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-c94e8cf
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-c94e8cf-amd64
ghcr.io/openhands/agent-canvas:chore-bump-automation-1.11.0-amd64
ghcr.io/openhands/agent-canvas:pr-17203-amd64
ghcr.io/openhands/agent-canvas:sha-c94e8cf-arm64
ghcr.io/openhands/agent-canvas:chore-bump-automation-1.11.0-arm64
ghcr.io/openhands/agent-canvas:pr-17203-arm64
ghcr.io/openhands/agent-canvas:sha-c94e8cf
ghcr.io/openhands/agent-canvas:chore-bump-automation-1.11.0
ghcr.io/openhands/agent-canvas:pr-17203
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-c94e8cf`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-c94e8cf-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->