### PR TITLE
docs: retarget canvas inventory paths to /apps after Apps rename

### DIFF
--- a/docs/CANVAS_EXTENSIONS_TESTING.md
+++ b/docs/CANVAS_EXTENSIONS_TESTING.md
@@ -27,7 +27,7 @@ extension requests in the browser. The mock also covers the settings and server
 information probes needed to mark that backend healthy, so the Agent Server
 does not need the extension endpoints and does not need to be running.
 
-Open <http://localhost:3102/extensions>. Do not use the normal ingress URL at
+Open <http://localhost:3102/apps>. Do not use the normal ingress URL at
 `http://localhost:8000` for this test because its `/api` traffic goes directly
 to the unmodified Agent Server rather than through the mock browser session.
 
@@ -37,7 +37,7 @@ reload.
 
 ## Install and enable the fixture
 
-1. In **Customize -> Extensions**, select **Add extension**.
+1. In **Customize -> Apps**, select **Add app**.
 2. Enter this exact source:
 
    ```text
@@ -79,7 +79,7 @@ bare package imports or additional output chunks.
 
 ## What still requires the Agent Server
 
-Repeat this flow against `http://localhost:8000/extensions` after the backend
+Repeat this flow against `http://localhost:8000/apps` after the backend
 contract lands. That test must additionally verify:
 
 - Git and backend-local-path installation;

--- a/specs/canvas-extensions.md
+++ b/specs/canvas-extensions.md
@@ -13,7 +13,7 @@ panels, renderers, slots, and themes. Skills and plugins change the agent;
 Canvas Extensions change the app.
 
 The Customize area remains the single inventory for Skills, Plugins, MCP, and
-Canvas Extensions. The inventory item is named **Extensions**; "addon" is an
+Canvas Extensions. The inventory item is named **Apps**; "addon" is an
 informal alias only.
 
 ## Decisions
@@ -29,7 +29,7 @@ informal alias only.
    as optional style isolation, but never as a security boundary.
 3. **Install and enable are separate.** Installation always produces a disabled
    extension. An agent may install or update an extension, but the user returns
-   to Customize -> Extensions and explicitly enables it. In v1 this is a product
+   to Customize -> Apps and explicitly enables it. In v1 this is a product
    consent invariant, not proof of human presence against an agent that can call
    the same authenticated APIs. A future backend policy may allow agent-driven
    enablement.
@@ -208,7 +208,7 @@ For each enabled installation:
    invoke the extension disposer, and remove its registry entries.
 
 The initial route shape is
-`/extensions/{extension-name}/{declared-page-path}`. `/extensions` itself is the
+`/extensions/{extension-name}/{declared-page-path}`. `/apps` itself is the
 Customize inventory. All routing goes through React Router so `VITE_BASE_PATH`
 continues to work.
 
@@ -219,7 +219,7 @@ continues to work.
 - Land this spec and shared TypeScript manifest/installation types.
 - Add a backend-keyed service and query hooks for list, install, enable/disable,
   uninstall, and authenticated bundle fetch.
-- Add Customize -> Extensions with an unsupported-backend state, source install
+- Add Customize -> Apps with an unsupported-backend state, source install
   form, source/revision/contribution review, and explicit enable control.
 - Keep the global runtime silent when the active backend returns 404.
 


### PR DESCRIPTION
## Summary

After the Apps rename (#17064), the customer-facing Canvas Extensions inventory lives at `/apps` (nav label **Apps**, action **Add app**). `docs/CANVAS_EXTENSIONS_TESTING.md` and `specs/canvas-extensions.md` still pointed testers at `/extensions` and **Customize -> Extensions**.

This PR updates only those inventory UI paths and labels. Page routes `/extensions/:name/*` and API `/api/canvas-extensions` are unchanged (still correct).

## Repro (on HEAD `c9b6ceac` after #17203)

```bash
# Inventory route is /apps
rg -n 'route\("apps"' src/routes.ts
# -> route("apps", "routes/canvas-extensions.tsx")

# Contributed pages remain under /extensions/:name/*
rg -n 'route\("extensions/' src/routes.ts
# -> route("extensions/:extensionName/*", ...)

# Stale inventory docs (before this PR)
rg -n 'localhost:.*/extensions|Customize -> Extensions|Add extension|inventory item is named'   docs/CANVAS_EXTENSIONS_TESTING.md specs/canvas-extensions.md
```

UI check from #17064: `npm run dev:mock` then open `http://localhost:<port>/apps` -> **Apps** / **Add app**.

## Files

- `docs/CANVAS_EXTENSIONS_TESTING.md` -- mock/backend inventory URLs -> `/apps`; **Customize -> Apps** / **Add app**
- `specs/canvas-extensions.md` -- inventory name **Apps**; Customize path; `/apps` as inventory route (keeps `/extensions/{name}/...` page shape and `/api/canvas-extensions`)

## Test plan

- [ ] Diff shows only inventory path/label updates (no API or `/extensions/:name` page-route changes)
- [ ] Manual: follow updated testing doc against mock frontend at `/apps`
