### PR TITLE
docs: add PR design document skill

### DIFF
--- a/.agents/skills/pr-design-doc/SKILL.md
+++ b/.agents/skills/pr-design-doc/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: pr-design-doc
+description: >
+  For a non-trivial pull request, write a self-contained HTML design doc under the
+  temporary `.pr/` directory and link it in the PR description via htmlpreview, so
+  maintainers grasp the proposal at a glance - code/API design, and the before/after of
+  the change, grounded to real code. Use when opening or updating a non-trivial PR, or
+  when the user says "add a design doc", "document this PR for reviewers", "show the
+  before/after", "make the design reviewable", or "write the .pr/ page".
+triggers:
+- /pr-design-doc
+- /design-doc
+license: MIT
+metadata:
+  tags: pull-request, design-doc, html, review, before-after, htmlpreview
+---
+
+# pr-design-doc - a reviewable design doc for a non-trivial PR
+
+A diff shows *what changed line by line*. It does not show *the design*: the shape of the
+change, the API before and after, and why this approach. Reviewers reconstruct that by
+hand, slowly. The scarce resource is the maintainer's attention and trust budget - not the
+agent's effort. Spend extra effort to hand them **one self-contained HTML page** that
+conveys the **big picture** and the **before → after core difference**, with every claim
+**clickable back to the real code**, then link it from the PR description.
+
+This is the same craft as a "show me this change" explainer, aimed at one job: making a
+non-trivial PR easy to review.
+
+## When to use it
+
+- Opening or updating a **non-trivial** PR: new/changed public API, a new module or
+  subsystem, a behavior change in core logic, a migration, or anything a reviewer can't
+  fully judge from the diff in a couple of minutes.
+- **Skip it** for trivial PRs - a typo, a one-line guard, a dependency bump, a docs tweak, a simple bug fix.
+  A design doc adds more to review. Use judgment; if the diff *is* the explanation, don't add a
+  page.
+
+## The `.pr/` workflow
+
+Use the temporary **`.pr/`** directory for PR-only artifacts. Before relying on automatic
+cleanup, verify that the target repository has an enabled
+`.github/workflows/pr-artifacts.yml` workflow that removes `.pr/` after approval.
+
+- Same-repository PR with verified cleanup workflow: the workflow removes `.pr/` after
+  approval.
+- Fork PR, or repository without a verified cleanup workflow: remove `.pr/` manually before
+  merge.
+
+The design doc is a review aid that lives with the branch while the PR is open. It must not
+ship in the merged tree.
+
+## Workflow
+
+1. **Check out and verify the PR head.** Do not write or commit the design doc from the base
+   branch or an unrelated checkout. Start with a clean worktree, then inspect and check out
+   the PR:
+   ```bash
+   gh pr view <n> --json title,body,baseRefName,baseRefOid,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,files,additions,deletions
+   gh pr checkout <n>
+   git rev-parse HEAD
+   gh pr view <n> --json headRefOid --jq .headRefOid
+   ```
+   The final two SHAs must match before you continue. If they do not, stop and fix the
+   checkout. Compute the merge-base SHA with
+   `git merge-base <baseRefOid> <headRefOid>`. Group changed files by area and keep both the
+   merge-base SHA and head SHA for source links.
+
+2. **Read both sides of each logical file.** Compare
+   `git show <merge-base-sha>:<path>` with the verified head. Capture the
+   **function-level** behavioral difference - what the code *did* vs *does now*.
+   - new file → no "before"; one "after" diagram + a line on the role it adds.
+   - deleted file → "before" diagram + who/what takes over.
+   - edited file → a before/after pair, with the delta highlighted.
+
+3. **Classify each file.** *Logic* change (behavior moved) → draw before/after. *Mechanical*
+   change (rename, constant, config, import move) → a one-line `before → after` row, no
+   diagram. Don't dilute the signal by drawing mechanical edits.
+
+4. **If the change is an API change, lead with the API.** Show the signature/schema/type
+   **before and after** side by side (function signature, endpoint + payload, config field,
+   event shape). Name the compatibility impact plainly: additive, breaking, or behind a flag.
+
+5. **Find the cross-file story.** If one call chain threads several files, draw a single
+   **overview** before/after at the top; per-file cards drill in.
+
+6. **Build the page** per [`references/html-craft.md`](references/html-craft.md) - one
+   self-contained, offline, editorial HTML file with hand-drawn SVG figures. Save it to
+   the repo's `.pr/` directory, e.g. `.pr/design.html` (or `.pr/<topic>.html`).
+
+7. **Commit under `.pr/`, push to the verified PR head, and link it.** Confirm that the push
+   remote resolves to `headRepository.nameWithOwner`; never push the artifact to the base
+   repository's default branch.
+   ```bash
+   git add .pr/design.html
+   git commit -m "docs(.pr): design doc for <PR topic>"
+   git push <head-repo-remote> HEAD:<headRefName>
+   ```
+   Then add the htmlpreview link near the top of the PR description, pointing at the **fork
+   and branch the PR is opened from** (it renders before merge):
+   ```
+   📄 Design doc: https://htmlpreview.github.io/?https://github.com/<fork-owner>/<repo>/blob/<pr-branch>/.pr/design.html
+   ```
+
+## What the page contains
+
+1. **What changed (decision first)** - one paragraph: the intent, net effect, and why the
+   reviewer should care. Put the highest-impact conclusion, risk, or API-compat note in a
+   `★` callout, with the most important changed `path:line` nearby. Stats (`N files ·
+   +A / −D`) are context, not the lead. If there's a cross-file flow, the **overview
+   before/after SVG** goes here.
+2. **API before → after** (when the PR changes an interface) - signatures/schemas/types side
+   by side, with the compatibility verdict stated.
+3. **Left rail / index** - changed files grouped by area, each tagged (🟢 added · 🔴 removed ·
+   ✏️ changed · ⚙️ mechanical) with +/− counts; click to jump.
+4. **Per-file cards** - for each logical file: a claim-carrying title, a one-line summary of
+   how its behavior changed, **before/after** diagrams with real symbol names + `file:line`
+   (changed nodes in orange), and the diff in a collapsed `<details>`. Mechanical files get a
+   small `before → after` table, no diagram.
+5. **(optional) Risk / follow-ups** - only if grounded in what you read.
+
+## Non-negotiable principles
+
+1. **Optimize for scarce reviewer attention.** The first screen answers, in ~15 seconds:
+   what this PR does, whether it's risky, where to look first, and what evidence backs the
+   claim. Lead with the conclusion, not your process.
+2. **Show the difference, not just the after.** For any logic or API change, draw **before**
+   and **after** and make the *delta* visually loud (color + line style). The contrast is
+   the product.
+3. **Ground everything to code, beside the claim.** Every box, node, and sentence names a
+   real symbol + `path:line`, and links to the correct source revision where possible: the
+   merge-base SHA for before-state evidence and the verified head SHA for after-state
+   evidence. One click from "this changed" to the exact code.
+4. **Hand-draw the carrying diagrams.** Prefer bespoke inline SVG for the before/after that
+   makes the argument; Mermaid is fine only for quick auxiliary graphs.
+5. **Self-contained & offline.** One HTML file, inline CSS/SVG, opens by double-click,
+   survives being copied to another machine (htmlpreview needs this).
+6. **`.pr/` only, and temporary.** The doc is a review aid, not project docs. Keep it in
+   `.pr/` and ensure it is removed before merge. Rely on automatic cleanup only when the
+   repository's workflow has been verified; otherwise remove it manually. Do not move design
+   HTML into `docs/` or ship it in the merged tree.
+
+## Anti-patterns
+
+- ❌ Dumping the raw diff / file tree and calling it a "design doc" - adds nothing over the
+  PR page.
+- ❌ Empty nodes ("process data", "handle request") - every node is a real symbol +
+  location.
+- ❌ Only the after-state when something changed - reviewers want the *contrast*.
+- ❌ A design doc on a trivial PR - noise. Skip it.
+- ❌ Committing the HTML outside `.pr/` (e.g. `docs/`), where it would merge into `main`.
+- ❌ Publishing a private-repository design doc through htmlpreview, GitHub Pages, or another
+  public host. Use the private/local preview path in the craft reference. Use GitHub Pages
+  only with explicit user authorization after verifying private Pages access control.

--- a/.agents/skills/pr-design-doc/SKILL.md
+++ b/.agents/skills/pr-design-doc/SKILL.md
@@ -2,11 +2,12 @@
 name: pr-design-doc
 description: >
   For a non-trivial pull request, write a self-contained HTML design doc under the
-  temporary `.pr/` directory and link it in the PR description via htmlpreview, so
-  maintainers grasp the proposal at a glance - code/API design, and the before/after of
-  the change, grounded to real code. Use when opening or updating a non-trivial PR, or
-  when the user says "add a design doc", "document this PR for reviewers", "show the
-  before/after", "make the design reviewable", or "write the .pr/ page".
+  temporary `.pr/` directory and link a visibility-appropriate preview in the PR
+  description, so maintainers grasp the proposal at a glance - code/API design, and the
+  before/after of the change, grounded to real code. Use when opening or updating a
+  non-trivial PR, or when the user says "add a design doc", "document this PR for
+  reviewers", "show the before/after", "make the design reviewable", or "write the .pr/
+  page".
 triggers:
 - /pr-design-doc
 - /design-doc
@@ -56,7 +57,7 @@ ship in the merged tree.
    branch or an unrelated checkout. Start with a clean worktree, then inspect and check out
    the PR:
    ```bash
-   gh pr view <n> --json title,body,baseRefName,baseRefOid,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,files,additions,deletions
+   gh pr view <n> --json title,body,url,baseRefName,baseRefOid,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,files,additions,deletions
    gh pr checkout <n>
    git rev-parse HEAD
    gh pr view <n> --json headRefOid --jq .headRefOid
@@ -86,7 +87,13 @@ ship in the merged tree.
 
 6. **Build the page** per [`references/html-craft.md`](references/html-craft.md) - one
    self-contained, offline, editorial HTML file with hand-drawn SVG figures. Save it to
-   the repo's `.pr/` directory, e.g. `.pr/design.html` (or `.pr/<topic>.html`).
+   the repo's `.pr/` directory, e.g. `.pr/design.html` (or `.pr/<topic>.html`). Before
+   writing, reject a symlink at `.pr` or at the exact output path; never follow a
+   branch-controlled symlink outside the worktree.
+   ```bash
+   test ! -L .pr && test ! -L .pr/design.html
+   mkdir -p .pr
+   ```
 
 7. **Commit under `.pr/`, push to the verified PR head, and link it.** Confirm that the push
    remote resolves to `headRepository.nameWithOwner`; never push the artifact to the base
@@ -96,11 +103,18 @@ ship in the merged tree.
    git commit -m "docs(.pr): design doc for <PR topic>"
    git push <head-repo-remote> HEAD:<headRefName>
    ```
-   Then add the htmlpreview link near the top of the PR description, pointing at the **fork
-   and branch the PR is opened from** (it renders before merge):
+   Query the base repository's visibility before choosing the link:
+   ```bash
+   gh repo view <base-owner>/<base-repo> --json visibility,url
    ```
-   📄 Design doc: https://htmlpreview.github.io/?https://github.com/<fork-owner>/<repo>/blob/<pr-branch>/.pr/design.html
-   ```
+   - **Public repository:** add an htmlpreview link near the top of the PR description,
+     pointing at the **fork and branch the PR is opened from** (it renders before merge):
+     ```
+     📄 Design doc: https://htmlpreview.github.io/?https://github.com/<fork-owner>/<repo>/blob/<pr-branch>/.pr/design.html
+     ```
+   - **Private or internal repository:** link the access-controlled GitHub blob and include
+     local download/open instructions, or use an existing access-controlled artifact
+     service. Never send the document through htmlpreview or another public host.
 
 ## What the page contains
 
@@ -133,8 +147,8 @@ ship in the merged tree.
    evidence. One click from "this changed" to the exact code.
 4. **Hand-draw the carrying diagrams.** Prefer bespoke inline SVG for the before/after that
    makes the argument; Mermaid is fine only for quick auxiliary graphs.
-5. **Self-contained & offline.** One HTML file, inline CSS/SVG, opens by double-click,
-   survives being copied to another machine (htmlpreview needs this).
+5. **Self-contained & offline.** One HTML file, inline CSS/SVG, no external scripts or
+   assets, opens by double-click, and survives being copied to another machine.
 6. **`.pr/` only, and temporary.** The doc is a review aid, not project docs. Keep it in
    `.pr/` and ensure it is removed before merge. Rely on automatic cleanup only when the
    repository's workflow has been verified; otherwise remove it manually. Do not move design

--- a/.agents/skills/pr-design-doc/references/html-craft.md
+++ b/.agents/skills/pr-design-doc/references/html-craft.md
@@ -222,10 +222,12 @@ fix it:
 
 A picture the human can't verify is a liability. Make claims droppable to source:
 
-- Resolve the repo's web base once with `gh repo view --json url`. Build links as
-  `https://github.com/<o>/<r>/blob/<sha>/<path>#L<n>`. Use the merge-base SHA for before-state
-  evidence and the verified PR head SHA for after-state evidence. A deleted file must link to
-  the merge-base SHA; a newly added file has no before-state link.
+- Resolve both repository web bases explicitly. For a fork PR, before-state evidence belongs
+  to the base repository and merge-base SHA; after-state evidence belongs to the head
+  repository and verified head SHA. Query each with
+  `gh repo view <owner>/<repo> --json url`, then build links as
+  `https://github.com/<o>/<r>/blob/<sha>/<path>#L<n>`. A deleted file must link to the base
+  repository at the merge-base SHA; a newly added file has no before-state link.
 - Render locations as `<a class="src" href="{{blobURL}}">path:line</a>` in node detail lines, section text, and a per-component "source" link.
 - Rule: if a box can't be tied to a symbol+location, it's a *concept* box - style it differently and say so; don't fake a link.
 - Put evidence beside the claim it supports. The reader should not have to scroll to a
@@ -255,22 +257,28 @@ DeepWiki-style wikis enforce grounding hard - worth copying:
 
 Keep them short and hand-highlight with spans (no JS highlighter): wrap keywords
 `<span class="kw">`, strings `<span class="str">`, comments `<span class="com">`.
-**HTML-escape first** (`&`→`&amp;` `<`→`&lt;` `>`→`&gt;`), then wrap - source text is
-untrusted; unescaped `<...>` injects. Put long diffs/code inside `<details>` (collapsed).
-Escape every source-derived value inserted into HTML or SVG, including titles, symbol names,
-paths, labels, link text, and attribute values.
+**Escape for the insertion context before wrapping** - source text is untrusted. In text
+nodes, escape `&`, `<`, and `>`. In quoted HTML or SVG attributes, additionally escape `"`
+as `&quot;` and `'` as `&#39;`; always quote attributes. For source URLs, percent-encode the
+dynamic owner, repository, and ref as URL path segments; encode each source-path segment
+separately and rejoin with `/`. Then attribute-escape the completed URL. Put long diffs/code
+inside `<details>` (collapsed). Escape every source-derived value
+inserted into HTML or SVG, including titles, symbol names, paths, labels, link text, and
+attribute values. Never treat source-derived text as markup.
 
 ## Self-contained
 
 - One `.html` file. Inline all CSS and SVG. No build, no framework.
-- CDN only if truly needed (e.g. Mermaid fallback `https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js`); the page must still be useful if a diagram fails to load.
+- No external scripts, styles, fonts, images, or other assets. Besides breaking offline use,
+  third-party active content can read and disclose a private design document opened locally.
 
 ## Mermaid (quick / auxiliary only)
 
-For throwaway or simple graphs where layout doesn't need to be exact, Mermaid is faster
-than hand-SVG. `mermaid.initialize({startOnLoad:true, theme:'neutral'})`. Node text in
-`["..."]`; escape `"` as `&quot;`. But for the **carrying** before/after diagram, hand-SVG
-wins - auto-layout drifts and breaks the side-by-side alignment that makes the delta readable.
+For drafting a throwaway or simple auxiliary graph, locally installed Mermaid can be faster
+than hand-SVG. Render it locally to static SVG, inspect and sanitize the output, then inline
+that SVG. Never ship a Mermaid runtime or CDN script in the page. For the **carrying**
+before/after diagram, hand-SVG wins - auto-layout drifts and breaks the side-by-side alignment
+that makes the delta readable.
 
 ### Public repositories: commit under `.pr/` and use an htmlpreview link
 
@@ -294,13 +302,13 @@ of merge state, so the doc renders while the PR is still open. Point the URL at 
 and branch the PR is opened from**, not `main`.
 
 For public repositories, anyone can open the rendered page without a download or local server.
-This works best for self-contained pages with inline CSS and SVG. CDN scripts still require
-network access.
+This works with self-contained pages containing only inline CSS and SVG.
 
 ### Private repositories: keep the preview private
 
 `htmlpreview` cannot fetch private repository content. Do not work around that by publishing
-the design doc to GitHub Pages or another public host.
+the design doc to GitHub Pages or another public host. Keep the document free of external
+scripts and assets: opening a local file does not make third-party active content private.
 
 - Link authorized reviewers to the committed GitHub blob and ask them to download and open the
   self-contained HTML file locally; or use an existing access-controlled artifact service.

--- a/.agents/skills/pr-design-doc/references/html-craft.md
+++ b/.agents/skills/pr-design-doc/references/html-craft.md
@@ -1,0 +1,314 @@
+# html-craft - how to build the page
+
+Shared craft for every show-me dimension. One self-contained, offline, editorial HTML
+page with hand-drawn SVG figures and code-grounded claims.
+
+## The look (editorial document, light theme)
+
+Calm, readable, document-like - not a dark dashboard. Skeleton:
+
+```html
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{Title}}</title>
+<style>
+  :root{
+    /* single source of truth - prose AND inline-SVG fills both read these (see SVG section) */
+    --fg:#1a1a1a; --muted:#5a5a5a; --subtle:#8a8a82;      /* 3 text weights: title · detail · sublabel */
+    --bg:#fdfdfb; --card:#ffffff; --elevated:#f7f6f1;     /* page · node fill · raised band/pill */
+    --accent:#2b4eaa; --accent-soft:#e6ecfa;
+    --rule:#e2e2dc; --rule-strong:#bdbcb4;                /* hairline · emphasized border */
+    --code-bg:#f3f1ec; --warn:#b25b0e; --ok:#2f7a3a; --crit:#a02020;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box} html,body{margin:0;background:var(--bg);color:var(--fg);font-family:var(--sans)}
+  body{line-height:1.6;font-size:16px}
+  .wrap{display:grid;grid-template-columns:240px minmax(0,1fr);gap:48px;max-width:1180px;margin:0 auto;padding:32px 28px 96px}
+  nav.toc{position:sticky;top:24px;align-self:start;font-size:13px}
+  nav.toc h2{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin:0 0 10px}
+  nav.toc ol{list-style:none;padding:0;margin:0;counter-reset:toc}
+  nav.toc li{counter-increment:toc;margin:4px 0}
+  nav.toc li::before{content:counter(toc) ". ";color:var(--muted)}
+  nav.toc a{color:var(--fg);text-decoration:none} nav.toc a:hover{color:var(--accent)}
+  header.title{border-bottom:1px solid var(--rule);padding-bottom:22px;margin-bottom:28px}
+  header.title .eyebrow{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--accent);font-weight:700}
+  header.title h1{font-size:34px;margin:6px 0 4px;letter-spacing:-.01em}
+  header.title .sub{color:var(--muted);max-width:740px}
+  h2{font-size:22px;margin:44px 0 10px} h2 .num{color:var(--muted);font-weight:500;margin-right:8px}
+  h3{font-size:16px;margin:22px 0 8px}
+  code{font-family:var(--mono);font-size:.88em;background:var(--code-bg);padding:1px 5px;border-radius:3px}
+  pre{font-family:var(--mono);font-size:13px;background:var(--code-bg);padding:14px 16px;border-radius:6px;overflow-x:auto;border:1px solid var(--rule)}
+  pre code{background:transparent;padding:0}
+  .kw{color:#7048a8}.str{color:var(--ok)}.com{color:var(--subtle);font-style:italic}
+  table{border-collapse:collapse;width:100%;font-size:14px;margin:12px 0}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--rule);vertical-align:top}
+  th{font-weight:600;background:var(--code-bg)}
+  .callout{border-left:3px solid var(--accent);background:var(--accent-soft);padding:10px 14px;margin:14px 0;border-radius:0 4px 4px 0;font-size:14.5px}
+  .callout.warn{border-color:var(--warn);background:#fbf1e6} .callout.note{border-color:var(--muted);background:#f3f1ec}
+  .fig{margin:18px 0 22px}
+  .fig svg{display:block;max-width:100%;height:auto;background:#fff;border:1px solid var(--rule);border-radius:6px}
+  .fig figcaption{font-size:13px;color:var(--muted);margin-top:6px;text-align:center}
+  a.src{font-family:var(--mono);font-size:12px;color:var(--accent);text-decoration:none;border-bottom:1px dotted var(--accent)}
+  details{border:1px solid var(--rule);border-radius:6px;margin:12px 0}
+  details>summary{cursor:pointer;padding:8px 12px;color:var(--muted);font-size:13px;list-style:none}
+  details>summary::-webkit-details-marker{display:none}
+  details>summary::before{content:"▸ "} details[open]>summary::before{content:"▾ "}
+  .ba{display:grid;grid-template-columns:1fr 1fr;gap:16px;align-items:start}
+  @media(max-width:760px){.wrap{grid-template-columns:1fr}.ba{grid-template-columns:1fr}}
+</style></head><body>
+<div class="wrap">
+  <nav class="toc"><h2>Contents</h2><ol>
+    <li><a href="#sec1">…</a></li>
+  </ol></nav>
+  <main>
+    <header class="title"><div class="eyebrow">{{kind}}</div><h1>{{Title}}</h1>
+      <p class="sub">{{one-paragraph mental model - the big picture in 2-3 sentences}}</p></header>
+    <section id="sec1"><h2><span class="num">1</span>…</h2> … </section>
+  </main>
+</div></body></html>
+```
+
+Numbered sticky TOC + one-paragraph mental model up top + sectioned body. No JS needed
+for this shell.
+
+## First screen: 15-second orientation
+
+The reader's attention is the budget. The first viewport should answer four questions
+without requiring a full read:
+
+1. **What is this?** A one-paragraph mental model in the title subtitle.
+2. **Why does it matter?** The highest-impact conclusion, risk, or action in a `★`
+   callout near the top.
+3. **Where should I jump?** A numbered sticky TOC whose labels carry information, not
+   just categories.
+4. **Why should I trust it?** Nearby source links (`path:line`, test, command, commit,
+   or fixture) for the first substantive claim.
+
+Do not open with "I read these files" or a chronological work log. Start with the
+reader's decision: what changed, how the system works, what path matters, or where to
+look next. Put methods, command output, and raw diffs behind `<details>` unless they
+are the point of the report.
+
+## Skimmable structure
+
+Design the page so a busy reader can scan headings, captions, callouts, and tables
+before choosing where to dive:
+
+- **Headings make claims.** Prefer "Writes only cross the queue" over "Architecture",
+  when the section has a specific finding. Generic labels are acceptable only when the
+  title/subtitle already carries the finding.
+- **One paragraph, one judgment.** Keep paragraphs short; split when a sentence starts
+  proving a different point.
+- **Number parallel points.** If you say "three rules" or "two risks", number them so
+  the reader can reconcile the claim with the list.
+- **Use tables only for stable comparison axes.** A table should reduce cognitive
+  work, not force subtle judgments into neat boxes.
+- **Make captions do work.** A caption states the takeaway of the figure, not merely
+  its type.
+
+## Callouts (give them semantic types)
+
+The `.callout` / `.callout.warn` / `.callout.note` styles aren't interchangeable - assign
+each a fixed job and the reader learns to skim by them:
+
+- **`★` key takeaway** (accent) - the one load-bearing sentence of a section. At most one per
+  section; it's what the reader should remember if they read nothing else.
+- **`ⓘ` note** (`.note`, muted) - a reading hint for a figure, an aside, a "why we did it this
+  way" that isn't on the critical path.
+- **`⚠` warning** (`.warn`) - a boundary, a risk, a gotcha, a guardrail: trust boundaries,
+  "this does NOT do X", "never commit the secret". Reserve it for things that bite.
+
+Don't let callouts become wallpaper - if every paragraph is a colored box, none of them carry
+weight. A glyph prefix (`★ ⓘ ⚠`) makes the type legible before the reader parses the text.
+
+## Hand-drawn SVG figures (the diagrams that carry the argument)
+
+Draw bespoke inline `<svg viewBox="0 0 W H">` with a `<defs>` for arrow markers and a
+scoped `<style>`. You place every box → before/after stays aligned, legible, and the
+delta is unmistakable. Semantic class system:
+
+```html
+<svg viewBox="0 0 960 460" role="img" aria-labelledby="f1-t f1-d">
+ <title id="f1-t">moduleA call path - before vs after</title>
+ <desc id="f1-d">Old direct call is replaced by a routed path through the new resolver.</desc>
+ <defs>
+  <!-- one marker per semantic color; marker fills read the page palette -->
+  <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+    <path d="M0,0 L10,5 L0,10 Z" fill="var(--subtle)"/></marker>
+  <marker id="arr-chg" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+    <path d="M0,0 L10,5 L0,10 Z" fill="var(--warn)"/></marker>
+  <!-- subtle "elevated" wash for the box that is the figure's subject -->
+  <linearGradient id="subj" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="var(--accent)" stop-opacity=".10"/>
+    <stop offset="1" stop-color="var(--accent)" stop-opacity=".02"/></linearGradient>
+  <style>
+    /* every fill/stroke is a --token: the palette lives once, in :root - prose & figures can't drift */
+    .existing{fill:var(--code-bg);stroke:var(--subtle);stroke-width:1.4;stroke-dasharray:5 3} /* before */
+    .ex-title{font:700 13px var(--sans);fill:var(--muted)} .ex-detail{font:11.5px var(--mono);fill:var(--subtle)}
+    .new{fill:var(--accent-soft);stroke:var(--accent);stroke-width:2}                         /* after / added */
+    .new-title{font:800 13px var(--sans);fill:var(--accent)} .detail{font:11.5px var(--mono);fill:var(--fg)}
+    .edge{stroke:var(--subtle);stroke-width:1.5;stroke-dasharray:5 3;fill:none}
+    .edge-chg{stroke:var(--warn);stroke-width:1.8;fill:none;stroke-dasharray:5 3}             /* the delta */
+    .lbl{font:600 10.5px var(--mono);fill:var(--accent)} .gap{font:700 11.5px var(--mono);fill:var(--warn)}
+  </style>
+ </defs>
+ <!-- ===== BEFORE: direct call ===== -->
+ <g>
+  <rect class="existing" x="40" y="60" width="180" height="74" rx="6"/>
+  <text class="ex-title"  x="130" y="90"  text-anchor="middle">moduleA.fn()</text>
+  <text class="ex-detail" x="130" y="110" text-anchor="middle">old behavior · a.py:42</text>
+ </g>
+ <!-- ===== AFTER: routed call (the change) ===== -->
+ <g>
+  <rect class="new" x="300" y="60" width="180" height="74" rx="6"/>
+  <text class="new-title" x="390" y="90" text-anchor="middle">moduleA.fn()</text>
+  <path class="edge-chg" d="M220,97 L300,97" marker-end="url(#arr-chg)"/>
+  <!-- pill behind an on-edge label so it stays legible over the line -->
+  <rect x="236" y="79" width="48" height="16" rx="5" fill="var(--elevated)" stroke="var(--rule)"/>
+  <text class="gap" x="260" y="91" text-anchor="middle">new path</text>
+ </g>
+</svg>
+```
+
+**Five craft moves in that skeleton - they're what make a figure read like a designed
+diagram instead of a sketch:**
+- **Drive every fill/stroke from `var(--token)`.** Define the palette once in `:root`; the
+  SVG references it. One source of truth - prose and figures stay in lockstep, and a palette
+  tweak reflows every diagram. Never paste a raw hex into a figure.
+- **Three text weights, always the same three.** `--fg` for the node title (the real symbol),
+  `--muted` for the detail line, `--subtle` for sublabels/`path:line`. The eye sorts the
+  hierarchy without reading. Mixing weights ad-hoc is what makes a diagram look noisy.
+- **`<title>` + `<desc>` with `aria-labelledby`.** Not decoration: it's the figure's own
+  caption-of-record (screen readers, and a note-to-self of what the figure claims).
+- **A gradient wash marks the subject.** The one container the figure is *about* gets the
+  `#subj` wash (accent 10%→2%); everything else is flat. The reader's eye lands on the
+  protagonist before reading a word.
+- **`<g>` groups + `<!-- section -->` comments + on-edge label pills.** Author the SVG like
+  code: one `<g>` per logical unit, a comment naming it, and a small `rect` pill behind any
+  label that sits on a line (a bare label over an edge turns to mush). It stays editable when
+  you revise the layout three times.
+
+**The before/after encoding (use consistently):**
+- **dashed gray** (`.existing`, `.edge` muted) = what was there before / unchanged context.
+- **solid accent** (`.new`) = what this change adds / the after-state.
+- **orange dashed** (`.edge-chg`, `.gap`) = the *delta* - the new/changed flow, the gap being filled. This is what the eye should land on.
+
+Node boxes carry a **title (real symbol) + a detail line (behavior + `file:line`)**, so the
+diagram is already half-grounded to code.
+
+Two ways to show before/after:
+1. **Side-by-side figures** in a `.ba` grid - `<figure>` "Before" | `<figure>` "After". Best when layouts differ a lot.
+2. **One overlaid figure** - existing nodes dashed-gray, new nodes/edges solid-accent + orange delta, in the same coordinate space. Best when the change is *additive* to an existing structure (most legible "what's new" read).
+
+## Caption every figure, and hint how to read the hard ones
+
+A figure with no caption makes the reader reverse-engineer your intent. Two cheap habits
+fix it:
+
+- **The `<figcaption>` states the takeaway, not a label.** Not "Architecture diagram" -
+  *"Requests never touch the DB directly; every write goes through the queue."* The caption
+  is the one sentence you'd say pointing at the figure. Number them (`Fig 3 ·`) and
+  **cross-reference between figures** (`state machine in Fig 2`, `evolve timing in Fig 5`) so
+  a multi-figure report reads as one system at different altitudes, not five loose pictures.
+- **For a figure with a non-obvious convention, add a one-line reading hint** in a `.callout.note`
+  right under it, naming the single thing that unlocks it: *"Every arrow enters or leaves the
+  bus - there are no agent-to-agent arrows, because the protocol is 'read/write the bus'."*
+  One sentence that says *how to look* saves the reader a minute of squinting. Put the hint in
+  the figure too when you can - an in-diagram `→ §3.2 / Fig 2` link (accent mono) turns the
+  picture into a table of contents.
+
+## Ground every claim to code (clickable)
+
+A picture the human can't verify is a liability. Make claims droppable to source:
+
+- Resolve the repo's web base once with `gh repo view --json url`. Build links as
+  `https://github.com/<o>/<r>/blob/<sha>/<path>#L<n>`. Use the merge-base SHA for before-state
+  evidence and the verified PR head SHA for after-state evidence. A deleted file must link to
+  the merge-base SHA; a newly added file has no before-state link.
+- Render locations as `<a class="src" href="{{blobURL}}">path:line</a>` in node detail lines, section text, and a per-component "source" link.
+- Rule: if a box can't be tied to a symbol+location, it's a *concept* box - style it differently and say so; don't fake a link.
+- Put evidence beside the claim it supports. The reader should not have to scroll to a
+  bibliography to verify a behavior statement, edge, risk, metric, or test result.
+- Commands count as evidence when behavior must be observed: show the command and the
+  relevant result near the claim, with full logs collapsed if noisy.
+
+### Grounding discipline (borrowed from DeepWiki)
+
+DeepWiki-style wikis enforce grounding hard - worth copying:
+
+- **Source manifest per section.** Open each major section / component card with a small
+  collapsed list of the exact files it's built from:
+  `<details><summary>Sources</summary> path/a.py · path/b.py …</details>`. The reader sees
+  what the claim rests on before trusting it.
+- **Cite after every substantive claim, diagram, table, and snippet.** Inline format:
+  `Sources: [path:start-end]` (range) or `[path:line]` (single), multiple allowed. A
+  section with no citations is a smell - either ground it or cut it.
+- **Solely from the code. Do not invent.** Every statement, box, edge, and number must be
+  derived from files you actually read - not from how "similar systems usually work." If
+  something important isn't in the code, say so explicitly rather than guessing. Mark genuine
+  inferences as inferences.
+- **Breadth check.** Decide if necessary, depending on PR. A "comprehensive" page that cites only 1-2 files is probably shallow -
+  pull in the related files (callers, callees, config, tests) until the picture is real.
+
+## Code excerpts (when shown)
+
+Keep them short and hand-highlight with spans (no JS highlighter): wrap keywords
+`<span class="kw">`, strings `<span class="str">`, comments `<span class="com">`.
+**HTML-escape first** (`&`→`&amp;` `<`→`&lt;` `>`→`&gt;`), then wrap - source text is
+untrusted; unescaped `<...>` injects. Put long diffs/code inside `<details>` (collapsed).
+Escape every source-derived value inserted into HTML or SVG, including titles, symbol names,
+paths, labels, link text, and attribute values.
+
+## Self-contained
+
+- One `.html` file. Inline all CSS and SVG. No build, no framework.
+- CDN only if truly needed (e.g. Mermaid fallback `https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js`); the page must still be useful if a diagram fails to load.
+
+## Mermaid (quick / auxiliary only)
+
+For throwaway or simple graphs where layout doesn't need to be exact, Mermaid is faster
+than hand-SVG. `mermaid.initialize({startOnLoad:true, theme:'neutral'})`. Node text in
+`["..."]`; escape `"` as `&quot;`. But for the **carrying** before/after diagram, hand-SVG
+wins - auto-layout drifts and breaks the side-by-side alignment that makes the delta readable.
+
+### Public repositories: commit under `.pr/` and use an htmlpreview link
+
+Because the page is **self-contained**, GitHub can render it through `htmlpreview.github.io`
+(it fetches the raw HTML and serves it with the right content-type - plain `raw.githubusercontent.com`
+won't, it returns `text/plain`). Commit the file to the PR branch under the temporary `.pr/`
+directory, then build the link and paste it in the PR description:
+
+```bash
+# commit the html under .pr/ on your PR branch (this dir is temporary, see the skill)
+git add .pr/design.html && git commit -m "docs(.pr): design doc" && git push <your-fork> <branch>
+# link template - use YOUR fork + PR branch, so it renders before the PR is merged:
+#   https://htmlpreview.github.io/?https://github.com/<fork-owner>/<repo>/blob/<pr-branch>/.pr/design.html
+```
+
+Example shape:
+`https://htmlpreview.github.io/?https://github.com/FORK_OWNER/REPO/blob/PR_BRANCH/.pr/design.html`
+
+`<pr-branch>` can be any branch or commit - `raw.githubusercontent.com` serves it regardless
+of merge state, so the doc renders while the PR is still open. Point the URL at the **fork
+and branch the PR is opened from**, not `main`.
+
+For public repositories, anyone can open the rendered page without a download or local server.
+This works best for self-contained pages with inline CSS and SVG. CDN scripts still require
+network access.
+
+### Private repositories: keep the preview private
+
+`htmlpreview` cannot fetch private repository content. Do not work around that by publishing
+the design doc to GitHub Pages or another public host.
+
+- Link authorized reviewers to the committed GitHub blob and ask them to download and open the
+  self-contained HTML file locally; or use an existing access-controlled artifact service.
+- For a local browser preview, open `.pr/design.html` directly. If the browser needs HTTP,
+  serve only on loopback:
+  ```bash
+  python -m http.server 8000 --bind 127.0.0.1 --directory .pr
+  # open http://127.0.0.1:8000/design.html
+  ```
+- Use GitHub Pages only when the user explicitly authorizes publication and an administrator
+  confirms that private Pages access control is enabled for this repository.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
This PR proposes a repo-specific PR design doc that the agent can add to more challenging PRs, to show humans what is the PR doing. People find for quite a while now that raw diffs are far more time consuming to review than an explanation of intentions and what is important.

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

## Why

Reviewers need a safe, reusable way to explain non-trivial pull requests.

## Summary

- Add `.agents/skills/pr-design-doc/SKILL.md` with explicit pull-request head verification, branch-safe pushes, and repository-aware cleanup.
- Bundle `references/html-craft.md` with merge-base/head evidence links, escaped source content, and matching SVG semantics.
- Keep private-repository previews local or access-controlled; public hosting is never the default.

## Issue Number

Fixes #16304

## How to Test

The AI agent ran this strict loader check from the repository root:

```bash
OPENHANDS_SUPPRESS_BANNER=1 /Users/enyst/repos/agent-sdk/.venv/bin/python -c 'from pathlib import Path; from openhands.sdk.skills.skill import Skill; s=Skill.load(Path(".agents/skills/pr-design-doc/SKILL.md"), strict=True, skip_mcp=True); print(s.model_dump().keys()); print(s.model_dump(mode="json", exclude={"content"}))'
```

It exited 0 and reported:

```text
name: pr-design-doc
trigger: keyword [/pr-design-doc, /design-doc]
is_agentskills_format: true
license: MIT
references: [html-craft.md]
```

`git diff --check` also passed, and both committed files match the independently corrected source byte-for-byte.

## Video/Screenshots

Not applicable: this is a repository-local Markdown skill with no product UI change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This is a corrected, repository-local follow-up to OpenHands/extensions#451. The `HUMAN:` section remains untouched as required; this PR is intentionally a draft pending Engel's testing note.
