### PR TITLE
docs: sync SELF_HOSTING Node prerequisite with engines >=24

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -110,7 +110,7 @@ Install the prerequisites on the machine. On Ubuntu:
 ```bash
 apt-get update
 apt-get install -y curl git
-# Node.js 22.x (use nvm, asdf, or NodeSource — whatever you prefer)
+# Node.js 24.x (use nvm, asdf, or NodeSource — whatever you prefer)
 # uv (for the agent-server uvx runtime):
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```


### PR DESCRIPTION
## Summary
- Update the Ubuntu install comment in `docs/SELF_HOSTING.md` from Node.js 22.x to Node.js 24.x so it matches `package.json` `engines.node` (`>=24`) and CI `node-version: "24.15"` after #17009.

## Test plan
- [ ] Confirm `package.json` engines.node is `>=24`
- [ ] Confirm CI workflows pin Node 24.15
- [ ] Confirm README Option 1/3 Node wording is handled separately