### PR TITLE
fix: show file upload progress before sending

### DIFF
--- a/src/components/features/chat/components/chat-input-container.tsx
+++ b/src/components/features/chat/components/chat-input-container.tsx
@@ -92,6 +92,7 @@ export function ChatInputContainer({
 
         <ChatInputRow
           chatInputRef={chatInputRef}
+          disabled={disabled}
           isNewConversationPending={isNewConversationPending}
           onInput={onInput}
           onPaste={onPaste}

--- a/src/components/features/chat/components/chat-input-row.tsx
+++ b/src/components/features/chat/components/chat-input-row.tsx
@@ -4,6 +4,7 @@ import { ChatInputField } from "./chat-input-field";
 interface ChatInputRowProps {
   chatInputRef: React.RefObject<HTMLDivElement | null>;
   isNewConversationPending?: boolean;
+  disabled?: boolean;
   onInput: () => void;
   onPaste: (e: React.ClipboardEvent) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
@@ -14,6 +15,7 @@ interface ChatInputRowProps {
 export function ChatInputRow({
   chatInputRef,
   isNewConversationPending = false,
+  disabled = false,
   onInput,
   onPaste,
   onKeyDown,
@@ -25,7 +27,7 @@ export function ChatInputRow({
       <div className="basis-0 box-border content-stretch flex flex-row gap-4 grow items-end justify-start min-h-px min-w-px p-0 relative shrink-0">
         <ChatInputField
           chatInputRef={chatInputRef}
-          disabled={isNewConversationPending}
+          disabled={disabled || isNewConversationPending}
           onInput={onInput}
           onPaste={onPaste}
           onKeyDown={onKeyDown}

--- a/src/components/features/chat/custom-chat-input.tsx
+++ b/src/components/features/chat/custom-chat-input.tsx
@@ -64,6 +64,7 @@ export function CustomChatInput({
   // mid-submit re-render, before `setSubmittedMessage(null)` was applied —
   // producing a duplicate "Sending…" bubble.
   const onSubmitRef = useRef(onSubmit);
+
   useEffect(() => {
     onSubmitRef.current = onSubmit;
   }, [onSubmit]);
@@ -73,11 +74,11 @@ export function CustomChatInput({
     if (!submittedMessage || disabled) {
       return;
     }
+
     onSubmitRef.current(submittedMessage);
     setSubmittedMessage(null);
   }, [submittedMessage, disabled, setSubmittedMessage]);
 
-  // Custom hooks
   const {
     chatInputRef,
     messageToSend,
@@ -89,6 +90,7 @@ export function CustomChatInput({
   const syncCanSubmit = React.useCallback(() => {
     const text = chatInputRef.current?.innerText ?? "";
     const hasAttachments = images.length > 0 || files.length > 0;
+
     setCanSubmit(text.trim().length > 0 || hasAttachments);
   }, [chatInputRef, images, files]);
 
@@ -126,6 +128,7 @@ export function CustomChatInput({
     onSubmit,
     resetManualResize,
   );
+
   const handleSubmitAndSync = React.useCallback(() => {
     handleSubmit();
     syncCanSubmit();
@@ -152,7 +155,6 @@ export function CustomChatInput({
     closeMenu: closeSlashMenu,
   } = useSlashCommand(chatInputRef as React.RefObject<HTMLDivElement | null>);
 
-  // Cleanup: reset suggestions visibility when component unmounts
   useEffect(
     () => () => {
       setShouldHideSuggestions(false);
@@ -160,18 +162,18 @@ export function CustomChatInput({
     },
     [setShouldHideSuggestions, clearAllFiles],
   );
+
   useEffect(() => {
     syncCanSubmit();
   }, [syncCanSubmit, images.length, files.length]);
+
   return (
     <div className={cn("w-full", className)}>
-      {/* Hidden file input */}
       <HiddenFileInput
         fileInputRef={fileInputRef}
         onChange={handleFileInputChange}
       />
 
-      {/* Container with grip */}
       <div className="relative w-full">
         <ChatInputGrip
           gripRef={gripRef}

--- a/src/hooks/chat/use-chat-submission.ts
+++ b/src/hooks/chat/use-chat-submission.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   clearTextContent,
   clearFileInput,
@@ -15,6 +15,40 @@ export const useChatSubmission = (
   onSubmit: (message: string) => void,
   resetManualResize?: () => void,
 ) => {
+  const [pendingMessage, setPendingMessage] = useState<string | null>(null);
+  const loadingFiles = useConversationStore((state) => state.loadingFiles);
+  const loadingImages = useConversationStore((state) => state.loadingImages);
+
+  const isUploading = loadingFiles.length > 0 || loadingImages.length > 0;
+
+  const completeSubmit = useCallback(
+    (message: string) => {
+      onSubmit(message);
+
+      // Clear the input
+      clearTextContent(chatInputRef.current);
+      clearFileInput(fileInputRef.current);
+
+      // Reset height and show suggestions again
+      smartResize();
+
+      // Reset manual resize state for next message
+      resetManualResize?.();
+    },
+    [chatInputRef, fileInputRef, smartResize, onSubmit, resetManualResize],
+  );
+
+  // Send a message that was requested while files were still uploading.
+  useEffect(() => {
+    if (pendingMessage === null || isUploading) {
+      return;
+    }
+
+    const message = pendingMessage;
+    setPendingMessage(null);
+    completeSubmit(message);
+  }, [pendingMessage, isUploading, completeSubmit]);
+
   // Send button click handler
   const handleSubmit = useCallback(() => {
     const message = chatInputRef.current?.innerText || "";
@@ -26,18 +60,14 @@ export const useChatSubmission = (
       return;
     }
 
-    onSubmit(message);
+    // Keep the prompt visible until all attachments finish processing.
+    if (isUploading) {
+      setPendingMessage(message);
+      return;
+    }
 
-    // Clear the input
-    clearTextContent(chatInputRef.current);
-    clearFileInput(fileInputRef.current);
-
-    // Reset height and show suggestions again
-    smartResize();
-
-    // Reset manual resize state for next message
-    resetManualResize?.();
-  }, [chatInputRef, fileInputRef, smartResize, onSubmit, resetManualResize]);
+    completeSubmit(message);
+  }, [chatInputRef, isUploading, completeSubmit]);
 
   // Handle stop button click
   const handleStop = useCallback((onStop?: () => void) => {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Tested the frontend TypeScript check with `npm run typecheck`. The staged pre-commit checks also passed successfully.

---

AGENT:

Implemented a fix for file upload submission behavior in the chat input.

The change tracks file-processing state and defers message submission when the user presses Send while attachments are still being processed. Once processing finishes, the pending message is submitted automatically while keeping the prompt visible during the upload.

End-to-end UI testing could not be completed because the local development stack requires the `uv` prerequisite/backend setup, which was not configured. The frontend mock server was started successfully with `npm run dev:mock`, but it does not provide the backend behavior required to reproduce the upload flow.

## Why

When a user attaches a large file, the message submission waits for the upload to finish, but the prompt can disappear immediately. This makes it unclear that the file is still being processed and that the message has not yet been sent.

## Summary

- Defer chat message submission when files are still being processed.
- Automatically submit the pending message after file processing completes.
- Preserve the existing chat input behavior for normal submissions.

## Issue

Fixes #16430

## How to Test

1. Start the OpenHands development environment with the required backend prerequisites.
2. Open Agent Canvas.
3. Open a conversation on a remote machine.
4. Drag and drop a large file into the chat input.
5. Enter a prompt.
6. Press Send before the file upload finishes.
7. Verify that the prompt remains visible while the file is uploading.
8. Verify that the message is submitted automatically after the upload finishes.

Validation performed locally:

`npm run typecheck`

The command completed successfully with no TypeScript errors.

The pre-commit validation also passed:
- ESLint
- Prettier
- staged TypeScript checking
- translation completeness checks

## Video/Screenshots

Not yet available. End-to-end reproduction requires the backend development environment, which was not configured locally.

A before/after video should be added before marking this PR ready for review.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No migrations or configuration changes are required.