### PR TITLE
chore: sync package.json volta node pin to 24.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   },
   "packageManager": "npm@10.5.0",
   "volta": {
-    "node": "22.12.0"
+    "node": "24.15.0"
   },
   "msw": {
     "workerDirectory": [


### PR DESCRIPTION
## Summary
- After #17009 raised `package.json` `engines.node` to `>=24`, `volta.node` was left at `22.12.0`, so Volta users still land on Node 22 while npm/CI require 24.
- Bump `volta.node` to `24.15.0` to match CI's intentional `24.15.x` pin (see `.github/workflows/ci.yml` comments about Node 24.16.0 zip-extraction regression).

## Test plan
- [ ] Confirm `package.json` shows `"volta": { "node": "24.15.0" }` alongside `"engines": { "node": ">=24" }`
- [ ] With Volta installed, `volta pin` / opening the repo selects Node 24.15.x
- [ ] Desktop `NODE_BUNDLE_VERSION` remains `22.12.0` (Electron ABI; unrelated to volta/engines)