### PR TITLE
chore: bump SDK to 1.46.0 and automation to 1.11.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,10 +581,10 @@ When adding code that needs a new string, decide up front which rule it falls un
 - `scripts/dev-safe.mjs` uses `uvx` for temporary agent-server installation — no permanent `uv tool install` needed. Environment variables (highest precedence first):
   - `OH_AGENT_SERVER_LOCAL_PATH` — absolute path to a local `software-agent-sdk` checkout. Runs the local checkout via `uvx` with `--with-editable` for `openhands-sdk`/`openhands-tools`/`openhands-workspace` and `--reinstall` for `openhands-agent-server`, so SDK edits are picked up on restart. Highest precedence.
   - `OH_AGENT_SERVER_GIT_REF` — git commit SHA or branch name (takes precedence over version)
-  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.45.0")
+  - `OH_AGENT_SERVER_VERSION` — specific PyPI version (e.g., "1.46.0")
   - `OH_SECRET_KEY` — secret key for settings encryption; auto-generated and persisted to `~/.openhands/agent-canvas/secret-key.txt` on first run (same file Docker uses), ensuring dev mode and Docker share the same key when both mount the same `~/.openhands` directory. Override with the env var to pin a specific key.
   - `SESSION_API_KEY` / `OH_SESSION_API_KEYS_0` / `VITE_SESSION_API_KEY` — session API key for agent-server authentication; auto-generated using `crypto.randomBytes(32)` if not set, passed to both agent-server (`OH_SESSION_API_KEYS_0`) and frontend (`VITE_SESSION_API_KEY`)
-  - Default: released PyPI version `1.45.0` for agent-server SDK libraries
+  - Default: released PyPI version `1.46.0` for agent-server SDK libraries
 
 - Security: launchers generate and persist a 64-character session API key at `~/.openhands/agent-canvas/session-api-key.txt` unless overridden. The agent-server and automation backend share that session key. `OH_SECRET_KEY` protects settings encryption and is persisted separately at `~/.openhands/agent-canvas/secret-key.txt`.
 - `scripts/dev-safe.mjs` should fail fast if `uvx` cannot be spawned (for example missing PATH entries).

--- a/__tests__/scripts/dev-safe.test.ts
+++ b/__tests__/scripts/dev-safe.test.ts
@@ -468,13 +468,13 @@ describe("buildAgentServerCommand", () => {
     // Defaults to the released PyPI version with all SDK packages pinned to same version
     expect(cmd.args).toEqual([
       "--from",
-      "openhands-agent-server==1.45.0",
+      "openhands-agent-server==1.46.0",
       "--with",
-      "openhands-sdk==1.45.0",
+      "openhands-sdk==1.46.0",
       "--with",
-      "openhands-tools==1.45.0",
+      "openhands-tools==1.46.0",
       "--with",
-      "openhands-workspace==1.45.0",
+      "openhands-workspace==1.46.0",
       "--with",
       "agent-client-protocol<0.11",
       "--with",
@@ -483,7 +483,7 @@ describe("buildAgentServerCommand", () => {
       "--import-modules",
       "canvas_ui_tool",
     ]);
-    expect(cmd.source).toBe("PyPI (1.45.0, default)");
+    expect(cmd.source).toBe("PyPI (1.46.0, default)");
   });
 
   it("uses specific PyPI version when OH_AGENT_SERVER_VERSION is set with all packages pinned", () => {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,9 +1,9 @@
 {
   "_comment": "Single source of truth for version pins, ports, paths, and defaults shared across the npm and Docker install paths. Read by scripts/dev-safe.mjs, scripts/dev-with-automation.mjs, docker/entrypoint.sh (via generated defaults.env), and .github/workflows/docker.yml.",
   "versions": {
-    "agentServer": "1.45.0",
+    "agentServer": "1.46.0",
     "agentCanvas": "1.16.0",
-    "automation": "1.11.0"
+    "automation": "1.11.1"
   },
   "compatibility": {
     "minimumAgentServer": "1.28.0"

--- a/scripts/check-sdk-version-sync.mjs
+++ b/scripts/check-sdk-version-sync.mjs
@@ -19,7 +19,7 @@
  *
  * Usage:
  *   node scripts/check-sdk-version-sync.mjs
- *   EXPECTED_SDK_VERSION=1.45.0 node scripts/check-sdk-version-sync.mjs
+ *   EXPECTED_SDK_VERSION=1.46.0 node scripts/check-sdk-version-sync.mjs
  *   node scripts/check-sdk-version-sync.mjs --check-pypi
  *
  * Environment variables:
@@ -78,7 +78,7 @@ Triggering from other repos:
     -H "Authorization: token \$GITHUB_TOKEN" \\
     -H "Accept: application/vnd.github.v3+json" \\
     https://api.github.com/repos/OpenHands/OpenHands/dispatches \\
-    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.45.0"}}'
+    -d '{"event_type": "sdk-version-check", "client_payload": {"version": "1.46.0"}}'
 `);
   process.exit(0);
 }
@@ -260,9 +260,9 @@ async function fetchPyPIDependencies(packageName, version) {
  * Parse PyPI requires_dist array and extract SDK package versions
  *
  * PyPI returns dependencies in PEP 508 format like:
- *   "openhands-sdk>=1.45.0,<2.0.0"
- *   "openhands-tools==1.45.0"
- *   "openhands-workspace (>=1.45.0)"
+ *   "openhands-sdk>=1.46.0,<2.0.0"
+ *   "openhands-tools==1.46.0"
+ *   "openhands-workspace (>=1.46.0)"
  */
 function parseSdkVersionsFromRequiresDist(requiresDist) {
   const versions = {};
@@ -276,7 +276,7 @@ function parseSdkVersionsFromRequiresDist(requiresDist) {
       }
 
       // Extract the version number - look for patterns like:
-      // ">=1.45.0", "==1.45.0", "(>=1.45.0)", "~=1.45.0"
+      // ">=1.46.0", "==1.46.0", "(>=1.46.0)", "~=1.46.0"
       // After the package name and before any comma or closing paren
       const versionPattern = /[><=~!]+\s*([0-9]+(?:\.[0-9]+)*)/;
       const match = dep.match(versionPattern);

--- a/scripts/dev-safe.mjs
+++ b/scripts/dev-safe.mjs
@@ -421,7 +421,7 @@ export const AGENT_SERVER_IMPORT_MODULES = "canvas_ui_tool";
  *   edits are picked up without a manual reinstall. The agent-server itself
  *   is rebuilt from local source on each invocation (--reinstall).
  * - OH_AGENT_SERVER_GIT_REF: Git commit SHA or branch name
- * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.45.0")
+ * - OH_AGENT_SERVER_VERSION: Specific PyPI version (e.g., "1.46.0")
  *
  * If none are set, defaults to the released version specified by
  * DEFAULT_AGENT_SERVER_VERSION. Set OH_AGENT_SERVER_GIT_REF to use a


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Spot check confirms app still works
---

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

## Why

The automation service (`OpenHands/automation`) was just bumped to SDK `1.46.0` (openhands/automation#432) and its next patch release will be `1.11.1`. Agent Canvas pins both the agent-server SDK version and the automation package version in `config/defaults.json`, and a drift-detection test (`__tests__/scripts/docs-version-sync.test.ts`) asserts that every documented/example version string matches that pin. This PR brings the Canvas pins and all of their in-tree references up to the new releases so `check-sdk-version-sync` stays green and local dev installs the new versions by default.

## Summary

- Bump `versions.agentServer` `1.45.0` → `1.46.0` and `versions.automation` `1.11.0` → `1.11.1` in `config/defaults.json` (the single source of truth read by `dev-safe.mjs`, `dev-with-automation.mjs`, and Docker entrypoint).
- Update the example/default version strings that the `docs-version-sync` drift test asserts must match the pin: `AGENTS.md`, `scripts/dev-safe.mjs` doc comment, and the usage/examples in `scripts/check-sdk-version-sync.mjs`.
- Update the hardcoded expectations in `__tests__/scripts/dev-safe.test.ts` (`buildAgentServerCommand` default case) to `1.46.0`, since that command derives its `uvx` args from `config/defaults.json`.

## Issue Number

N/A — version bump to stay in sync with openhands/automation#432 and the upcoming `openhands-automation` 1.11.1 release. No `ready-for-dev` issue exists for routine version sync.

## How to Test

Run the version-sensitive unit suites (no network/Docker needed):

```bash
npm ci
npx vitest run __tests__/scripts/dev-safe.test.ts \
  __tests__/scripts/docs-version-sync.test.ts \
  __tests__/scripts/check-sdk-version-sync.test.ts \
  __tests__/scripts/dev-with-automation.test.ts
```

Verified locally: 4 test files, 143 tests passed (`dev-safe` 21, `docs-version-sync` 6, `check-sdk-version-sync` 55, `dev-with-automation` 61).

To confirm the pins resolve end-to-end, start the local dev stack (requires `uvx`):

```bash
npm run dev
```

The agent-server `uvx` invocation should pin `openhands-agent-server==1.46.0` (plus `openhands-sdk`/`openhands-tools`/`openhands-workspace==1.46.0`) and the automation backend should install `openhands-automation==1.11.1`.

## Video/Screenshots

Not a UI change. Test output confirming the bump is consistent with the drift checks:

```
 Test Files  4 passed (4)
      Tests  143 passed (143)
```

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- Companion PR: openhands/automation#432 (bumps `openhands-sdk`/`openhands-workspace` to `1.46.0`; release-please will cut `openhands-automation` 1.11.1 from it).
- `versions.agentCanvas` is intentionally left at `1.16.0`; this PR does not touch the Canvas frontend version.
- Kept as draft pending the `openhands-automation` 1.11.1 release being published to PyPI (the `check-sdk-version-sync` CI job checks the released package against `versions.agentServer`). The local drift tests pass regardless since they validate in-tree string consistency, not PyPI.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f90470c6-5172-46e4-ab29-03e666f9d362)
<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.46.0-python` |
| **Automation** | `openhands-automation==1.11.1` |
| **Commit** | `3a7317e88a37430fd516405dac0953db19f3567f` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-3a7317e
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-3a7317e
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-3a7317e-amd64
ghcr.io/openhands/agent-canvas:chore-bump-sdk-and-automation-versions-amd64
ghcr.io/openhands/agent-canvas:pr-17238-amd64
ghcr.io/openhands/agent-canvas:sha-3a7317e-arm64
ghcr.io/openhands/agent-canvas:chore-bump-sdk-and-automation-versions-arm64
ghcr.io/openhands/agent-canvas:pr-17238-arm64
ghcr.io/openhands/agent-canvas:sha-3a7317e
ghcr.io/openhands/agent-canvas:chore-bump-sdk-and-automation-versions
ghcr.io/openhands/agent-canvas:pr-17238
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-3a7317e`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-3a7317e-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->