### PR TITLE
docs: add PZERO OpenAI-compatible example

### DIFF
--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -1,0 +1,51 @@
+# Configuring LLM providers
+
+Agent Canvas uses LLM profiles to connect to model providers. Any
+OpenAI-compatible provider can be configured by selecting a custom model and
+setting its base URL and API key.
+
+## PZERO
+
+[PZERO](https://pzero.studio/agents) is a prepaid, OpenAI-compatible inference
+marketplace. Create an account and obtain a `pzero_` API key from the PZERO
+dashboard before configuring Agent Canvas.
+
+### Configure in Agent Canvas
+
+1. Open **Settings → LLM** and select the **Advanced** configuration.
+2. Enter the following values:
+
+   | Field        | Value                         |
+   | ------------ | ----------------------------- |
+   | Custom Model | `openai/deepseek-v4-flash`    |
+   | Base URL     | `https://api.pzero.studio/v1` |
+   | API Key      | Your `pzero_` API key         |
+
+The `openai/` model prefix tells LiteLLM to use its OpenAI-compatible client.
+The base URL must end at `/v1`; do not include `/chat/completions`.
+
+### Configure with `config.toml`
+
+```toml
+[llm]
+model = "openai/deepseek-v4-flash"
+api_key = "pzero_YOUR_KEY"
+base_url = "https://api.pzero.studio/v1"
+```
+
+### Verify the connection
+
+List the model IDs currently available from PZERO:
+
+```bash
+curl -sS "https://api.pzero.studio/v1/models"
+```
+
+Send a minimal chat completion using the same model and base URL:
+
+```bash
+curl -sS -X POST "https://api.pzero.studio/v1/chat/completions" \
+  -H "Authorization: Bearer $PZERO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"deepseek-v4-flash","messages":[{"role":"user","content":"Hello from PZERO"}],"stream":false}'
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This directory contains the project documentation.
 
 - [Architecture](./architecture.md): system boundaries, runtime modes, and quality gates.
 - [Using ACP agents](./ACP_AGENTS.md): onboard and configure external agents (Claude Code, Codex, Gemini CLI).
+- [Configuring LLM providers](./LLM_PROVIDERS.md): connect OpenAI-compatible providers, including PZERO.
 - [Development guide](./DEVELOPMENT.md)
 - [Canvas Extensions manual testing](./CANVAS_EXTENSIONS_TESTING.md)
 - [Self-hosting guide](./SELF_HOSTING.md)


### PR DESCRIPTION
HUMAN:

This is a docs-only change. I ran Prettier on both changed Markdown files and `git diff --check`. The PZERO model endpoint timed out from this environment, so I am not claiming a live API smoke test.

AGENT:

## Why

The repository had no concrete example for connecting Agent Canvas to PZERO through the existing OpenAI-compatible LiteLLM path. Users had to infer whether the base URL should include `/chat/completions` and how the model ID should be prefixed.

## Summary

- Add `docs/LLM_PROVIDERS.md` with Agent Canvas and `config.toml` setup for an OpenAI-compatible provider.
- Include a PZERO example using `openai/<model>`, the `/v1` base URL, and a `pzero_` API key.
- Link the new guide from the documentation index.

## Issue Number

Fixes #16980

## How to Test

```bash
npx --yes prettier@3.8.3 --check docs/LLM_PROVIDERS.md docs/README.md
git diff --check
```

The new guide can also be reviewed directly at `docs/LLM_PROVIDERS.md`.

## Video/Screenshots

Not applicable: this PR only changes Markdown documentation.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The PZERO endpoint `https://api.pzero.studio/v1/models` timed out from the environment used to prepare this PR, so the documented values are taken from issue #16980 rather than a live smoke test.