### PR TITLE
fix: open Cloud settings in the same tab when locked to a Cloud host

### DIFF
--- a/__tests__/components/backends/backend-selector.test.tsx
+++ b/__tests__/components/backends/backend-selector.test.tsx
@@ -830,6 +830,33 @@ describe("BackendSelector", () => {
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });
+
+    it("renders the cloud settings link as a same-tab anchor when locked to Cloud", async () => {
+      // Arrange: an OHE/SaaS-hosted canvas locked to the active cloud host
+      vi.stubEnv("VITE_LOCK_TO_CLOUD", SEED_CLOUD_PRODUCTION.host);
+      let cloudId = "";
+
+      // Act
+      renderWithProviders(
+        <TestSeed
+          onMount={(ctx) => {
+            cloudId = ctx.addBackend(SEED_CLOUD_PRODUCTION).id;
+            ctx.setActive(cloudId, null);
+          }}
+        >
+          <BackendSelector />
+        </TestSeed>,
+      );
+
+      // Assert: same tab, so browser Back returns to the canvas
+      const link = screen.getByTestId("backend-selector-settings-link");
+      expect(link).toHaveAttribute(
+        "href",
+        `${SEED_CLOUD_PRODUCTION.host}/settings`,
+      );
+      expect(link).not.toHaveAttribute("target");
+      expect(link).not.toHaveAttribute("rel");
+    });
   });
 
   describe("connection indicator", () => {

--- a/__tests__/components/features/settings/cloud-settings-link.test.tsx
+++ b/__tests__/components/features/settings/cloud-settings-link.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -47,6 +47,7 @@ beforeEach(() => {
 afterEach(() => {
   window.localStorage.clear();
   __resetActiveStoreForTests();
+  vi.unstubAllEnvs();
 });
 
 describe("CloudSettingsLink", () => {
@@ -77,6 +78,23 @@ describe("CloudSettingsLink", () => {
       "href",
       "https://app.all-hands.dev/settings",
     );
+  });
+
+  it("opens in the same tab without the external-link icon when locked to Cloud", () => {
+    // Arrange: an OHE/SaaS-hosted canvas locked to the active cloud host
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "https://app.all-hands.dev");
+    setRegisteredBackends([cloudBackend]);
+    setActiveSelection({ backendId: cloudBackend.id });
+
+    // Act
+    renderWithProviders();
+
+    // Assert: same tab (Back returns to the canvas) and no "new tab" hint
+    const link = screen.getByTestId("settings-cloud-link");
+    expect(link).toHaveAttribute("href", "https://app.all-hands.dev/settings");
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
+    expect(link.querySelector("svg.lucide-external-link")).toBeNull();
   });
 
   it("appends the active org so cloud settings open on the same organization", () => {

--- a/__tests__/components/features/sidebar/sidebar-cloud-settings.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar-cloud-settings.test.tsx
@@ -1,8 +1,4 @@
-import {
-  render,
-  screen,
-  fireEvent,
-} from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Sidebar } from "#/components/features/sidebar/sidebar";
@@ -230,6 +226,7 @@ describe("Sidebar with Cloud Backend", () => {
   afterEach(() => {
     window.localStorage.clear();
     useSidebarStore.setState({ collapsed: false });
+    vi.unstubAllEnvs();
   });
 
   it("opens cloud settings in new tab when connected to cloud backend", () => {
@@ -251,5 +248,23 @@ describe("Sidebar with Cloud Backend", () => {
 
     const settingsLink = screen.getByTestId("collapsed-settings-link");
     expect(settingsLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("opens cloud settings in the same tab when locked to Cloud", () => {
+    // Arrange: an OHE/SaaS-hosted canvas locked to the active cloud host
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "https://cloud.example.com");
+    useSidebarStore.setState({ collapsed: true });
+
+    // Act
+    renderSidebar("/conversations");
+
+    // Assert: same tab, so browser Back returns to the canvas
+    const settingsLink = screen.getByTestId("collapsed-settings-link");
+    expect(settingsLink).toHaveAttribute(
+      "href",
+      "https://cloud.example.com/settings",
+    );
+    expect(settingsLink).not.toHaveAttribute("target");
+    expect(settingsLink).not.toHaveAttribute("rel");
   });
 });

--- a/src/components/features/backends/backend-selector.tsx
+++ b/src/components/features/backends/backend-selector.tsx
@@ -421,8 +421,8 @@ export function BackendSelector({
             {active.backend.kind === "cloud" ? (
               <a
                 href={`${active.backend.host.replace(/\/+$/, "")}/settings`}
-                target="_blank"
-                rel="noopener noreferrer"
+                target={isLockedToCloud ? undefined : "_blank"}
+                rel={isLockedToCloud ? undefined : "noopener noreferrer"}
                 data-testid="backend-selector-settings-link"
                 aria-label={settingsLabel}
                 className={cn(

--- a/src/components/features/settings/cloud-settings-link.tsx
+++ b/src/components/features/settings/cloud-settings-link.tsx
@@ -3,6 +3,7 @@ import { Cloud, ExternalLink } from "lucide-react";
 import { I18nKey } from "#/i18n/declaration";
 import { useActiveBackendContext } from "#/contexts/active-backend-context";
 import { isNoBackend } from "#/api/backend-registry/active-store";
+import { getLockedCloudHost } from "#/api/agent-server-config";
 import { cn } from "#/utils/utils";
 import {
   SIDEBAR_ICON_SLOT_CLASS,
@@ -13,7 +14,9 @@ import {
 
 /**
  * Renders only for cloud backends — local backends have no equivalent
- * hosted settings page.
+ * hosted settings page. Opens in the same tab when the canvas is locked to a
+ * Cloud host (SaaS / self-hosted OHE): the settings page shares that host
+ * with the canvas, so Back should return here (OHE-3242).
  */
 export function CloudSettingsLink() {
   const { t } = useTranslation("openhands");
@@ -21,6 +24,8 @@ export function CloudSettingsLink() {
   const { backend, orgId } = active;
 
   if (isNoBackend(backend) || backend.kind !== "cloud") return null;
+
+  const isLockedToCloud = getLockedCloudHost() !== null;
 
   // `org` is consumed by the cloud settings loader so the page opens on the
   // org that is active here instead of the cloud's last-used org.
@@ -31,8 +36,8 @@ export function CloudSettingsLink() {
     <a
       data-testid="settings-cloud-link"
       href={cloudSettingsUrl}
-      target="_blank"
-      rel="noopener noreferrer"
+      target={isLockedToCloud ? undefined : "_blank"}
+      rel={isLockedToCloud ? undefined : "noopener noreferrer"}
       className={cn(
         sidebarNavRowClassName({ collapsed: false }),
         SIDEBAR_ROW_INTERACTIVE_CLASS.idle,
@@ -44,10 +49,12 @@ export function CloudSettingsLink() {
       <span className={cn(sidebarNavLabelClassName(false), "flex-1")}>
         {t(I18nKey.SETTINGS$CLOUD_SETTINGS_LINK)}
       </span>
-      <ExternalLink
-        className="size-4 shrink-0 text-[var(--oh-muted)]"
-        aria-hidden
-      />
+      {!isLockedToCloud && (
+        <ExternalLink
+          className="size-4 shrink-0 text-[var(--oh-muted)]"
+          aria-hidden
+        />
+      )}
     </a>
   );
 }

--- a/src/components/features/sidebar/sidebar-rail-body.tsx
+++ b/src/components/features/sidebar/sidebar-rail-body.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { OpenHandsLogoButton } from "#/components/shared/buttons/openhands-logo-button";
 import { NavigationLink } from "#/components/shared/navigation-link";
+import { getLockedCloudHost } from "#/api/agent-server-config";
 import {
   automationListPath,
   getInterfaceCopy,
@@ -112,6 +113,10 @@ export function SidebarRailBody({
   const cloudSettingsUrl = isCloudBackend
     ? `${activeBackend.host.replace(/\/+$/, "")}/settings`
     : null;
+  // Locked-to-Cloud (SaaS / self-hosted OHE) serves the canvas at /canvas on
+  // the cloud host itself, so cloud settings open in this tab and Back
+  // returns here (OHE-3242). Standalone / Electron keep the new tab.
+  const isLockedToCloud = getLockedCloudHost() !== null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -280,8 +285,8 @@ export function SidebarRailBody({
             {isCloudBackend && cloudSettingsUrl ? (
               <a
                 href={cloudSettingsUrl}
-                target="_blank"
-                rel="noopener noreferrer"
+                target={isLockedToCloud ? undefined : "_blank"}
+                rel={isLockedToCloud ? undefined : "noopener noreferrer"}
                 data-testid="collapsed-settings-link"
                 aria-label={t(I18nKey.SIDEBAR$SETTINGS)}
                 className={sidebarNavRowClassName({ collapsed: true })}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes: the three Cloud settings links render without `target`/`rel` when the canvas is locked to a Cloud host, and still open a new tab otherwise (unit tests below, plus the pre-fix run showing exactly the three new tests failing).

---

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
Write a concise summary of what changed and link any reviewer artifacts, such
as files under `.pr/`. For HTML artifacts, include a rendered preview link:
https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/.pr/<file>.html
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc. -->

When Agent Canvas is deployed into OpenHands SaaS or a self-hosted OpenHands Enterprise (OHE) instance it is served at `{origin}/canvas` next to the OHE web app, locked to that host (`static-server.mjs --lock-to-cloud <origin>`; SaaS: `saas-deploy` env values, self-hosted: `OpenHands-Cloud/replicated/openhands.yaml` → `agent-canvas.staticServer.lockToCloud`). In that deployment the OHE settings shell is part of the same site — its rail even has a same-tab "Back to App" link to `/canvas` — yet every Cloud settings link in the canvas opens a **new tab**: the gear next to the backend selector, the gear in the collapsed sidebar, and "All Cloud Settings" in the canvas settings nav. Each visit to Settings adds another tab, and browser Back never returns to the canvas (the canvas half of "Settings opens in a new tab").

#16883 made the gear open a new tab on purpose; this reverses that only where the canvas and the settings page share a host.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `BackendSelector` (expanded gear), `SidebarRailBody` (collapsed gear) and `CloudSettingsLink` ("All Cloud Settings") drop `target="_blank"` / `rel="noopener noreferrer"` when `getLockedCloudHost() !== null`, so the Cloud settings page opens in the same tab and Back returns to the canvas. `CloudSettingsLink` also hides its trailing external-link icon in that mode, since it only existed to announce the new tab.
- The gate is the deployment signal (`getLockedCloudHost()`, same as `IntegrationsSettingsLink`, `useSettingsNavItems`, `AgentCanvasVersionTile`), **not** `backend.kind === "cloud"`: a standalone canvas that merely added a Cloud backend, and the Electron app, keep opening a new tab. Electron routes `_blank` links to the system browser through `setWindowOpenHandler` and has no `will-navigate` guard on the main window, so a same-tab external anchor there would navigate the desktop app away from the canvas.
- Tests added for the locked case in `backend-selector.test.tsx`, `sidebar-cloud-settings.test.tsx` and `cloud-settings-link.test.tsx` (no `target`/`rel`, and no external-link icon on the "All Cloud Settings" row). Existing new-tab tests are unchanged and still pass. `IntegrationsSettingsLink` needs no change: it already returns `null` when locked.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Static checks and unit tests (all run on this branch):

```bash
npm run typecheck       # tsc: no errors in the changed files. main currently has 2 pre-existing
                        # errors in src/manifests/automation-setup.test.ts (missing
                        # @openhands/extensions/testing fixture in node_modules), unrelated.
npx eslint src/components/features/backends/backend-selector.tsx \
  src/components/features/sidebar/sidebar-rail-body.tsx \
  src/components/features/settings/cloud-settings-link.tsx        # clean
npx prettier --check <same three files>                            # clean
npx vitest run \
  __tests__/components/backends/backend-selector.test.tsx \
  __tests__/components/features/sidebar/sidebar-cloud-settings.test.tsx \
  __tests__/components/features/settings/cloud-settings-link.test.tsx \
  __tests__/components/features/settings/integrations-settings-link.test.tsx
# → 4 files, 38 tests passed
```

TDD evidence: running the three updated test files against a clean checkout of `main` (only the tests copied over) fails exactly the three new tests and nothing else:

```
× renders the cloud settings link as a same-tab anchor when locked to Cloud
× opens cloud settings in the same tab when locked to Cloud
× opens in the same tab without the external-link icon when locked to Cloud
   Error: expect(element).not.toHaveAttribute("target") // element.hasAttribute("target")
 Tests  3 failed | 32 passed (35)
```

Manual check in a locked deployment (staging `/canvas` or an OHE install): click the expanded gear, the collapsed gear, and Settings → "All Cloud Settings". Each opens the OHE settings page in the same tab; Back returns to the canvas. Without `--lock-to-cloud` (or `VITE_LOCK_TO_CLOUD`), the same links still open a new tab.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

Reproduction evidence is the pre-fix test run above: on `main` all three links carry `target="_blank"` under the lock, so every click opens a new tab; on this branch the attribute is gone and the tests pass.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- Behaviour outside locked deployments is byte-for-byte unchanged (standalone canvas, Electron, local backends).
- Same-tab navigation leaves the canvas SPA, so in-memory state such as an unsent draft is lost until Back restores the page; the active backend selection is persisted.
- The gear links still don't pass `?org=` (only "All Cloud Settings" does);


<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.46.0-python` |
| **Automation** | `openhands-automation==1.11.1` |
| **Commit** | `930ccd6e9b607472ef886129d7b9492a02f56c60` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-930ccd6
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-930ccd6
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-930ccd6-amd64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3261-amd64
ghcr.io/openhands/agent-canvas:pr-17253-amd64
ghcr.io/openhands/agent-canvas:sha-930ccd6-arm64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3261-arm64
ghcr.io/openhands/agent-canvas:pr-17253-arm64
ghcr.io/openhands/agent-canvas:sha-930ccd6
ghcr.io/openhands/agent-canvas:hieptl-ohe-3261
ghcr.io/openhands/agent-canvas:pr-17253
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-930ccd6`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-930ccd6-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->