### PR TITLE
fix: hide unlisted settings pages from the command menu when locked to a Cloud host

### DIFF
--- a/__tests__/components/features/command-menu/command-menu-items.test.tsx
+++ b/__tests__/components/features/command-menu/command-menu-items.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createCommandMenuItems } from "#/components/features/command-menu/command-menu-items";
 
@@ -21,5 +21,54 @@ describe("the command menu without an admitted interface manifest", () => {
     // Assert
     expect(items.some((item) => item.id === "automations")).toBe(false);
     expect(items.some((item) => item.id === "new-chat")).toBe(true);
+  });
+});
+
+const settingsItemIds = (items: ReturnType<typeof createCommandMenuItems>) =>
+  items.filter((item) => item.group === "settings").map((item) => item.id);
+
+/**
+ * Locked to a Cloud host (SaaS / self-hosted OHE) the settings sidebar lists
+ * only the Application page; the command menu must not re-expose the pages
+ * that sidebar unlists.
+ */
+describe("the command menu settings group", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("lists every settings page when not locked to a Cloud host", () => {
+    // Act
+    const items = createCommandMenuItems({ toggleSidebar: vi.fn() });
+
+    // Assert
+    expect(settingsItemIds(items)).toEqual([
+      "settings",
+      "agent-settings",
+      "llm-settings",
+      "condenser-settings",
+      "verification-settings",
+      "app-settings",
+      "secrets-settings",
+    ]);
+  });
+
+  it("keeps only Settings and Application when locked to a Cloud host", () => {
+    // Arrange
+    vi.stubEnv("VITE_LOCK_TO_CLOUD", "https://app.all-hands.dev");
+
+    // Act
+    const items = createCommandMenuItems({ toggleSidebar: vi.fn() });
+
+    // Assert
+    expect(settingsItemIds(items)).toEqual(["settings", "app-settings"]);
+    expect(items.map((item) => item.id)).toEqual([
+      "new-chat",
+      "customize",
+      "mcp",
+      "settings",
+      "app-settings",
+      "toggle-sidebar",
+    ]);
   });
 });

--- a/src/components/features/command-menu/command-menu-items.tsx
+++ b/src/components/features/command-menu/command-menu-items.tsx
@@ -19,6 +19,8 @@ import {
   getInterfaceCopy,
   hasAutomationInterface,
 } from "#/manifests/automation-interface";
+import { getLockedCloudHost } from "#/api/agent-server-config";
+import { LOCKED_CLOUD_SETTINGS_NAV_PATH } from "#/constants/settings-nav";
 
 const ICON_SIZE = 18;
 
@@ -96,119 +98,133 @@ export const createCommandMenuItems = ({
   toggleSidebar,
 }: {
   toggleSidebar: () => void;
-}): CommandMenuItemDefinition[] => [
-  {
-    id: "new-chat",
-    group: "navigation",
-    titleKey: I18nKey.COMMAND_MENU$NEW_CHAT_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$NEW_CHAT_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$NEW_CHAT_KEYWORDS,
-    icon: <Home size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.conversations,
-  },
-  {
-    id: "customize",
-    group: "navigation",
-    titleKey: I18nKey.COMMAND_MENU$CUSTOMIZE_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$CUSTOMIZE_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$CUSTOMIZE_KEYWORDS,
-    icon: <Sparkles size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.customize,
-  },
-  // The automation interface owns this entry's copy, so an absent manifest
-  // leaves the command menu without it rather than with host copy.
-  ...(hasAutomationInterface()
-    ? [
-        {
-          id: "automations" as const,
-          group: "navigation" as const,
-          title: getInterfaceCopy().commandMenuTitle,
-          description: getInterfaceCopy().commandMenuDescription,
-          keywords: getInterfaceCopy().commandMenuKeywords,
-          icon: <Zap size={ICON_SIZE} />,
-          to: COMMAND_MENU_ROUTE.automations,
-        },
-      ]
-    : []),
-  {
-    id: "mcp",
-    group: "navigation",
-    titleKey: I18nKey.COMMAND_MENU$MCP_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$MCP_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$MCP_KEYWORDS,
-    icon: <Wrench size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.mcp,
-  },
-  {
-    id: "settings",
-    group: "settings",
-    titleKey: I18nKey.COMMAND_MENU$SETTINGS_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$SETTINGS_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$SETTINGS_KEYWORDS,
-    icon: <Settings size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.settings,
-  },
-  {
-    id: "agent-settings",
-    group: "settings",
-    titleKey: I18nKey.COMMAND_MENU$AGENT_SETTINGS_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$AGENT_SETTINGS_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$AGENT_SETTINGS_KEYWORDS,
-    icon: <Bot size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.agentSettings,
-  },
-  {
-    id: "llm-settings",
-    group: "settings",
-    titleKey: I18nKey.COMMAND_MENU$LLM_SETTINGS_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$LLM_SETTINGS_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$LLM_SETTINGS_KEYWORDS,
-    icon: <Search size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.llmSettings,
-  },
-  {
-    id: "condenser-settings",
-    group: "settings",
-    titleKey: I18nKey.COMMAND_MENU$CONDENSER_SETTINGS_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$CONDENSER_SETTINGS_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$CONDENSER_SETTINGS_KEYWORDS,
-    icon: <ListTodo size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.condenserSettings,
-  },
-  {
-    id: "verification-settings",
-    group: "settings",
-    titleKey: I18nKey.COMMAND_MENU$VERIFICATION_SETTINGS_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$VERIFICATION_SETTINGS_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$VERIFICATION_SETTINGS_KEYWORDS,
-    icon: <ShieldCheck size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.verificationSettings,
-  },
-  {
-    id: "app-settings",
-    group: "settings",
-    titleKey: I18nKey.COMMAND_MENU$APP_SETTINGS_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$APP_SETTINGS_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$APP_SETTINGS_KEYWORDS,
-    icon: <PanelsTopLeft size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.appSettings,
-  },
-  {
-    id: "secrets-settings",
-    group: "settings",
-    titleKey: I18nKey.COMMAND_MENU$SECRETS_SETTINGS_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$SECRETS_SETTINGS_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$SECRETS_SETTINGS_KEYWORDS,
-    icon: <KeyRound size={ICON_SIZE} />,
-    to: COMMAND_MENU_ROUTE.secretsSettings,
-  },
-  {
-    id: "toggle-sidebar",
-    group: "actions",
-    titleKey: I18nKey.COMMAND_MENU$TOGGLE_SIDEBAR_TITLE,
-    descriptionKey: I18nKey.COMMAND_MENU$TOGGLE_SIDEBAR_DESCRIPTION,
-    keywordsKey: I18nKey.COMMAND_MENU$TOGGLE_SIDEBAR_KEYWORDS,
-    icon: <Keyboard size={ICON_SIZE} />,
-    perform: toggleSidebar,
-  },
-];
+}): CommandMenuItemDefinition[] => {
+  const items: CommandMenuItemDefinition[] = [
+    {
+      id: "new-chat",
+      group: "navigation",
+      titleKey: I18nKey.COMMAND_MENU$NEW_CHAT_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$NEW_CHAT_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$NEW_CHAT_KEYWORDS,
+      icon: <Home size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.conversations,
+    },
+    {
+      id: "customize",
+      group: "navigation",
+      titleKey: I18nKey.COMMAND_MENU$CUSTOMIZE_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$CUSTOMIZE_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$CUSTOMIZE_KEYWORDS,
+      icon: <Sparkles size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.customize,
+    },
+    // The automation interface owns this entry's copy, so an absent manifest
+    // leaves the command menu without it rather than with host copy.
+    ...(hasAutomationInterface()
+      ? [
+          {
+            id: "automations" as const,
+            group: "navigation" as const,
+            title: getInterfaceCopy().commandMenuTitle,
+            description: getInterfaceCopy().commandMenuDescription,
+            keywords: getInterfaceCopy().commandMenuKeywords,
+            icon: <Zap size={ICON_SIZE} />,
+            to: COMMAND_MENU_ROUTE.automations,
+          },
+        ]
+      : []),
+    {
+      id: "mcp",
+      group: "navigation",
+      titleKey: I18nKey.COMMAND_MENU$MCP_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$MCP_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$MCP_KEYWORDS,
+      icon: <Wrench size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.mcp,
+    },
+    {
+      id: "settings",
+      group: "settings",
+      titleKey: I18nKey.COMMAND_MENU$SETTINGS_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$SETTINGS_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$SETTINGS_KEYWORDS,
+      icon: <Settings size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.settings,
+    },
+    {
+      id: "agent-settings",
+      group: "settings",
+      titleKey: I18nKey.COMMAND_MENU$AGENT_SETTINGS_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$AGENT_SETTINGS_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$AGENT_SETTINGS_KEYWORDS,
+      icon: <Bot size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.agentSettings,
+    },
+    {
+      id: "llm-settings",
+      group: "settings",
+      titleKey: I18nKey.COMMAND_MENU$LLM_SETTINGS_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$LLM_SETTINGS_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$LLM_SETTINGS_KEYWORDS,
+      icon: <Search size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.llmSettings,
+    },
+    {
+      id: "condenser-settings",
+      group: "settings",
+      titleKey: I18nKey.COMMAND_MENU$CONDENSER_SETTINGS_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$CONDENSER_SETTINGS_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$CONDENSER_SETTINGS_KEYWORDS,
+      icon: <ListTodo size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.condenserSettings,
+    },
+    {
+      id: "verification-settings",
+      group: "settings",
+      titleKey: I18nKey.COMMAND_MENU$VERIFICATION_SETTINGS_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$VERIFICATION_SETTINGS_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$VERIFICATION_SETTINGS_KEYWORDS,
+      icon: <ShieldCheck size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.verificationSettings,
+    },
+    {
+      id: "app-settings",
+      group: "settings",
+      titleKey: I18nKey.COMMAND_MENU$APP_SETTINGS_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$APP_SETTINGS_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$APP_SETTINGS_KEYWORDS,
+      icon: <PanelsTopLeft size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.appSettings,
+    },
+    {
+      id: "secrets-settings",
+      group: "settings",
+      titleKey: I18nKey.COMMAND_MENU$SECRETS_SETTINGS_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$SECRETS_SETTINGS_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$SECRETS_SETTINGS_KEYWORDS,
+      icon: <KeyRound size={ICON_SIZE} />,
+      to: COMMAND_MENU_ROUTE.secretsSettings,
+    },
+    {
+      id: "toggle-sidebar",
+      group: "actions",
+      titleKey: I18nKey.COMMAND_MENU$TOGGLE_SIDEBAR_TITLE,
+      descriptionKey: I18nKey.COMMAND_MENU$TOGGLE_SIDEBAR_DESCRIPTION,
+      keywordsKey: I18nKey.COMMAND_MENU$TOGGLE_SIDEBAR_KEYWORDS,
+      icon: <Keyboard size={ICON_SIZE} />,
+      perform: toggleSidebar,
+    },
+  ];
+
+  // Locked-to-Cloud (SaaS / self-hosted OHE) lists only the Application page;
+  // the OHE settings shell owns the rest (OHE-3168).
+  const isLockedToCloud = getLockedCloudHost() !== null;
+
+  return items.filter(
+    (item) =>
+      !isLockedToCloud ||
+      item.group !== "settings" ||
+      item.to === COMMAND_MENU_ROUTE.settings ||
+      item.to === LOCKED_CLOUD_SETTINGS_NAV_PATH,
+  );
+};


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes: with the canvas locked to a Cloud host the ⌘K command menu lists only the Settings and Application entries in its Settings group, and lists every page otherwise (unit tests below, plus the pre-fix run showing exactly the new locked-mode test failing).

---

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
Write a concise summary of what changed and link any reviewer artifacts, such
as files under `.pr/`. For HTML artifacts, include a rendered preview link:
https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/.pr/<file>.html
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc. -->

When Agent Canvas is deployed into OpenHands SaaS or a self-hosted OpenHands Enterprise (OHE) instance it is served at `{origin}/canvas` next to the OHE web app, locked to that host (`static-server.mjs --lock-to-cloud <origin>`; SaaS: `saas-deploy` env values, self-hosted: `OpenHands-Cloud` → `agent-canvas.staticServer.lockToCloud`). In that deployment #17045 scoped the canvas settings sidebar to the **Application** page only, because the OHE settings shell behind "All Cloud Settings" owns Agent, LLM, Condenser, Verification and Secrets. The ⌘K command menu ("Search commands") predates that change and was never taught about the lock: typing "settings" still offers **Agent settings**, **LLM profiles**, **Condenser settings**, **Verification settings** and **Secrets settings**, and running one opens the legacy per-user page the sidebar deliberately unlists.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `createCommandMenuItems` filters its `settings` group down to `/settings` and `LOCKED_CLOUD_SETTINGS_NAV_PATH` (`/settings/app`) when `getLockedCloudHost() !== null` — the same signal and constant `useSettingsNavItems` uses, so the menu and the sidebar list the same pages. Navigation and action entries are untouched; `/settings` already lands on `/settings/app` in that mode.
- The gate is the deployment signal, **not** `backend.kind === "cloud"`, so a standalone canvas that merely added a Cloud backend, and the Electron app, keep the full list.
- Tests added in `command-menu-items.test.tsx` for the locked and unlocked settings groups.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Static checks and unit tests (all run on this branch):

```bash
npm run typecheck                                                       # react-router typegen && tsc → 0 errors
npx eslint src/components/features/command-menu/command-menu-items.tsx \
  __tests__/components/features/command-menu/command-menu-items.test.tsx  # clean
npx prettier --check <same two files>                                   # clean
npx vitest run __tests__/components/features/command-menu
# → 2 files, 10 tests passed
```

TDD evidence: with the `src/` change stashed and only the tests present, exactly the new locked-mode test fails:

```
× keeps only Settings and Application when locked to a Cloud host
  AssertionError: expected [ 'settings', 'agent-settings', …(5) ] to deeply equal [ 'settings', 'app-settings' ]
 Tests  1 failed | 2 passed (3)
```

With the fix restored: `10 passed`.

Manual check, mirrors the SaaS/OHE deployment:

```bash
npm run build
node scripts/static-server.mjs --dir build --port 3001 --lock-to-cloud https://app.openhands.dev --base-path /canvas
# open http://localhost:3001/canvas, complete the Cloud login, press ⌘K and type "settings"
```

Expect: the Settings group shows only **Settings** and **Application settings**; Agent / LLM profiles / Condenser / Verification / Secrets are gone. Without `--lock-to-cloud` (or `VITE_LOCK_TO_CLOUD`) all seven entries are listed as before.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

https://github.com/user-attachments/assets/8039b65a-ef75-441c-ae24-c7014aa83849

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- Behaviour outside locked deployments is byte-for-byte unchanged; no i18n or route changes. The unlisted pages stay routable for in-app deep links, as in #17045.
- The **MCP servers** entry stays: it is a navigation entry and remains reachable through the Customize hub in locked mode.
- The menu also does not honour `feature_flags.hide_llm_settings`; not addressed here since the lock already hides that entry.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.46.0-python` |
| **Automation** | `openhands-automation==1.11.1` |
| **Commit** | `4e47f55d61874f0eb9af57507cdbd00b697a295a` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-4e47f55
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-4e47f55
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-4e47f55-amd64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3244-amd64
ghcr.io/openhands/agent-canvas:pr-17254-amd64
ghcr.io/openhands/agent-canvas:sha-4e47f55-arm64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3244-arm64
ghcr.io/openhands/agent-canvas:pr-17254-arm64
ghcr.io/openhands/agent-canvas:sha-4e47f55
ghcr.io/openhands/agent-canvas:hieptl-ohe-3244
ghcr.io/openhands/agent-canvas:pr-17254
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-4e47f55`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-4e47f55-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->