### PR TITLE
fix: isolate embedded modal portal hosts

### DIFF
--- a/__tests__/agent-server-ui-providers.test.tsx
+++ b/__tests__/agent-server-ui-providers.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, useQueryClient } from "@tanstack/react-query";
@@ -23,6 +24,7 @@ import {
   setQueryClient,
 } from "#/index";
 import i18n from "#/i18n";
+import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
 
 const telemetryProviderMock = vi.hoisted(() => vi.fn());
 vi.mock("#/components/providers/telemetry-provider", () => ({
@@ -275,5 +277,103 @@ describe("AgentServerUIProviders", () => {
     expect(themedContainer).toHaveAttribute("data-theme", "light");
     expect(themedContainer).toHaveClass("light", "inner-shell");
     expect(themedContainer).toContainElement(screen.getByTestId("root-child"));
+  });
+
+  it("portals simultaneous modals into isolated body-level hosts", async () => {
+    render(
+      <>
+        <AgentServerUIRoot
+          theme="light"
+          style={{ transform: "translateX(0)" }}
+          styleOverrides={{ "--oh-color-base": "#fefefe" }}
+        >
+          <ModalBackdrop aria-label="light-root-modal">
+            <div>light modal</div>
+          </ModalBackdrop>
+        </AgentServerUIRoot>
+        <AgentServerUIRoot
+          theme="dark"
+          styleOverrides={{ "--oh-color-base": "#010101" }}
+        >
+          <ModalBackdrop elevated aria-label="dark-root-modal">
+            <div>dark modal</div>
+          </ModalBackdrop>
+        </AgentServerUIRoot>
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll("[data-agent-server-ui-portal-host]"),
+      ).toHaveLength(2);
+    });
+
+    const lightDialog = screen.getByRole("dialog", {
+      name: "light-root-modal",
+    });
+    const darkDialog = screen.getByRole("dialog", {
+      name: "dark-root-modal",
+    });
+    const lightHost = lightDialog.closest<HTMLDivElement>(
+      "[data-agent-server-ui-portal-host]",
+    );
+    const darkHost = darkDialog.closest<HTMLDivElement>(
+      "[data-agent-server-ui-portal-host]",
+    );
+
+    expect(lightHost?.parentElement).toBe(document.body);
+    expect(darkHost?.parentElement).toBe(document.body);
+    expect(lightHost).not.toBe(darkHost);
+    expect(lightHost).toHaveAttribute("data-agent-server-ui");
+    expect(lightHost).toHaveAttribute("data-theme", "light");
+    expect(lightHost).toHaveClass("light", "text-foreground");
+    expect(lightHost?.style.getPropertyValue("--oh-color-base")).toBe(
+      "#fefefe",
+    );
+    expect(lightHost).not.toHaveStyle({ transform: "translateX(0)" });
+    expect(darkHost).toHaveAttribute("data-theme", "dark");
+    expect(darkHost).toHaveClass("dark", "text-foreground");
+    expect(darkHost?.style.getPropertyValue("--oh-color-base")).toBe("#010101");
+    expect(lightHost).not.toContainElement(darkDialog);
+    expect(darkHost).not.toContainElement(lightDialog);
+  });
+
+  it("creates one portal host through Strict Mode and removes it on unmount", async () => {
+    const view = render(
+      <React.StrictMode>
+        <AgentServerUIRoot>
+          <ModalBackdrop aria-label="strict-mode-modal">
+            <div>strict modal</div>
+          </ModalBackdrop>
+        </AgentServerUIRoot>
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll("[data-agent-server-ui-portal-host]"),
+      ).toHaveLength(1);
+    });
+    expect(
+      screen.getByRole("dialog", { name: "strict-mode-modal" }),
+    ).toBeInTheDocument();
+
+    view.unmount();
+
+    expect(
+      document.querySelector("[data-agent-server-ui-portal-host]"),
+    ).toBeNull();
+  });
+
+  it("renders the scoped root without touching the document during SSR", () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <AgentServerUIRoot>
+          <ModalBackdrop aria-label="server-modal">
+            <div>server modal</div>
+          </ModalBackdrop>
+        </AgentServerUIRoot>,
+      ),
+    ).not.toThrow();
   });
 });

--- a/src/components/providers/agent-server-ui-root.tsx
+++ b/src/components/providers/agent-server-ui-root.tsx
@@ -1,5 +1,10 @@
 import React from "react";
+import { createPortal } from "react-dom";
 import { cn } from "#/utils/utils";
+import {
+  MODAL_PORTAL_HOST_ATTRIBUTE,
+  ModalPortalHostContext,
+} from "#/contexts/modal-portal-host-context";
 import {
   AGENT_SERVER_UI_DEFAULT_CSS_VARIABLES,
   AGENT_SERVER_UI_DEFAULT_THEME,
@@ -27,6 +32,9 @@ export function AgentServerUIRoot({
   contentClassName,
   ...divProps
 }: AgentServerUIRootProps) {
+  const [canUseDOM, setCanUseDOM] = React.useState(false);
+  const [modalPortalHost, setModalPortalHost] =
+    React.useState<HTMLDivElement | null>(null);
   const scopedStyle = React.useMemo(
     () =>
       ({
@@ -36,21 +44,47 @@ export function AgentServerUIRoot({
       }) as React.CSSProperties,
     [style, styleOverrides],
   );
+  const portalScopedStyle = React.useMemo(
+    () =>
+      ({
+        ...AGENT_SERVER_UI_DEFAULT_CSS_VARIABLES,
+        ...styleOverrides,
+      }) as React.CSSProperties,
+    [styleOverrides],
+  );
+
+  React.useEffect(() => {
+    setCanUseDOM(true);
+  }, []);
 
   return (
-    <div
-      data-agent-server-ui=""
-      {...divProps}
-      className={className}
-      // CSS custom properties injected onto the scope root so descendants can resolve var(--oh-*)
-      style={scopedStyle}
-    >
+    <ModalPortalHostContext.Provider value={modalPortalHost}>
       <div
-        className={cn(theme, contentClassName, "text-foreground")}
-        data-theme={theme}
+        data-agent-server-ui=""
+        {...divProps}
+        className={className}
+        // CSS custom properties injected onto the scope root so descendants can resolve var(--oh-*)
+        style={scopedStyle}
       >
-        {children}
+        <div
+          className={cn(theme, contentClassName, "text-foreground")}
+          data-theme={theme}
+        >
+          {children}
+        </div>
       </div>
-    </div>
+      {canUseDOM &&
+        createPortal(
+          <div
+            ref={setModalPortalHost}
+            data-agent-server-ui=""
+            {...{ [MODAL_PORTAL_HOST_ATTRIBUTE]: "" }}
+            className={cn(theme, "text-foreground")}
+            data-theme={theme}
+            style={portalScopedStyle}
+          />,
+          document.body,
+        )}
+    </ModalPortalHostContext.Provider>
   );
 }

--- a/src/components/shared/modals/modal-backdrop.tsx
+++ b/src/components/shared/modals/modal-backdrop.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createPortal } from "react-dom";
+import { useModalPortalHost } from "#/contexts/modal-portal-host-context";
 
 interface ModalBackdropProps {
   children: React.ReactNode;
@@ -23,28 +24,32 @@ export function ModalBackdrop({
   elevated = false,
   "aria-label": ariaLabel,
 }: ModalBackdropProps) {
+  const configuredPortalHost = useModalPortalHost();
+  const portalHost =
+    configuredPortalHost === undefined && typeof document !== "undefined"
+      ? document.body
+      : configuredPortalHost;
+
   React.useEffect(() => {
-    if (!closeOnEscape) return undefined;
+    if (!portalHost || !closeOnEscape) return undefined;
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose?.();
     };
 
     window.addEventListener("keydown", handleEscape);
     return () => window.removeEventListener("keydown", handleEscape);
-  }, [closeOnEscape, onClose]);
+  }, [closeOnEscape, onClose, portalHost]);
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!closeOnBackdropClick) return;
     if (e.target === e.currentTarget) onClose?.(); // only close if the click was on the backdrop
   };
 
-  if (typeof document === "undefined") return null;
+  if (!portalHost) return null;
 
-  // Portal to document.body so the modal's `position: fixed` resolves
-  // against the viewport. Otherwise a transformed ancestor (e.g. the
-  // onboarding slide rail) would become the containing block and the
-  // modal would render trapped inside it instead of overlapping its
-  // parent modal.
+  // Portal to the owning root's body-level host so scoped styles are retained
+  // while `position: fixed` still resolves against the viewport. Standalone
+  // callers without a root keep the historical document.body fallback.
   return createPortal(
     <div
       role="dialog"
@@ -60,6 +65,6 @@ export function ModalBackdrop({
       />
       <div className="relative">{children}</div>
     </div>,
-    document.body,
+    portalHost,
   );
 }

--- a/src/contexts/modal-portal-host-context.tsx
+++ b/src/contexts/modal-portal-host-context.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export const MODAL_PORTAL_HOST_ATTRIBUTE = "data-agent-server-ui-portal-host";
+
+type ModalPortalHost = HTMLElement | null | undefined;
+
+export const ModalPortalHostContext =
+  React.createContext<ModalPortalHost>(undefined);
+
+export const useModalPortalHost = () =>
+  React.useContext(ModalPortalHostContext);


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

Each `AgentServerUIRoot` now owns a scoped, body-level modal host. `ModalBackdrop` resolves the host belonging to its embedding root while preserving the existing `document.body` fallback for standalone consumers.

## Why

Embedded dialogs were rendered under `document.body`, outside the root carrying `data-agent-server-ui`, theme state, and CSS variables. Multiple embedded roots could therefore lose their own styling context or leak modal styling across roots. The portal still needs to remain a direct body child so fixed positioning is viewport-relative.

## Summary

- add a per-root portal host that carries the embedding scope, theme, default variables, and caller overrides
- route shared modal backdrops to the owning host without copying layout-affecting styles
- cover simultaneous light/dark roots, StrictMode cleanup, SSR, and the existing Escape/backdrop/stacking behavior

## Issue Number

Fixes #17215

## How to Test

1. Run `npm ci` from `frontend`.
2. Run `npx vitest run __tests__/agent-server-ui-providers.test.tsx __tests__/components/shared/modals/modal-backdrop.test.tsx` (13/13 tests pass).
3. Run `npm run typecheck`, `npm run lint`, `npm run build:app`, and `npm run build:lib` (all pass; lint retains one pre-existing unused-disable warning in `src/hooks/query/use-local-git-info.ts:136`).
4. Render two `AgentServerUIRoot` instances with different themes and CSS variable overrides, then open one modal from each root. Inspect the two `[data-agent-server-ui-modal-portal-host]` elements: each is a direct child of `body`, and each carries only its owning root's theme and variables.

## Video/Screenshots

Verified in Chromium at 1440x900 against the production library build. Two dialogs were open simultaneously. The DOM evidence was:

```text
Host 1: theme=light, base=#f5f5f5, bodyChild=true
Host 2: theme=dark, base=#101010, bodyChild=true
```

The light and dark dialog surfaces rendered independently while both portal hosts remained direct body children.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No dependencies or public props were added. Only CSS custom properties and explicit `styleOverrides` are copied to the portal host; ordinary root layout styles such as `transform` are intentionally not copied, so they cannot create a containing block for fixed dialogs.
