### PR TITLE
fix: pass the active org from the gear icon to cloud settings

### DIFF
--- a/__tests__/components/backends/backend-selector.test.tsx
+++ b/__tests__/components/backends/backend-selector.test.tsx
@@ -830,6 +830,27 @@ describe("BackendSelector", () => {
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });
+
+    it("passes the active org to the cloud settings link", () => {
+      let cloudId = "";
+      renderWithProviders(
+        <TestSeed
+          onMount={(ctx) => {
+            cloudId = ctx.addBackend(SEED_CLOUD_PRODUCTION).id;
+            ctx.setActive(cloudId, "org-2");
+          }}
+        >
+          <BackendSelector />
+        </TestSeed>,
+      );
+
+      expect(
+        screen.getByTestId("backend-selector-settings-link"),
+      ).toHaveAttribute(
+        "href",
+        `${SEED_CLOUD_PRODUCTION.host}/settings?org=org-2`,
+      );
+    });
   });
 
   describe("connection indicator", () => {

--- a/__tests__/components/features/sidebar/sidebar-cloud-settings.test.tsx
+++ b/__tests__/components/features/sidebar/sidebar-cloud-settings.test.tsx
@@ -43,7 +43,7 @@ const cloudBackendMock = {
     host: "https://cloud.example.com",
     apiKey: "test-key",
   },
-  orgId: "org-1",
+  orgId: "org-1" as string | null,
 };
 
 vi.mock("#/hooks/query/use-config", () => ({
@@ -230,6 +230,7 @@ describe("Sidebar with Cloud Backend", () => {
   afterEach(() => {
     window.localStorage.clear();
     useSidebarStore.setState({ collapsed: false });
+    cloudBackendMock.orgId = "org-1";
   });
 
   it("opens cloud settings in new tab when connected to cloud backend", () => {
@@ -240,6 +241,17 @@ describe("Sidebar with Cloud Backend", () => {
     expect(settingsLink).toBeInTheDocument();
     expect(settingsLink).toHaveAttribute("target", "_blank");
     expect(settingsLink).toHaveAttribute(
+      "href",
+      "https://cloud.example.com/settings?org=org-1",
+    );
+  });
+
+  it("omits the org param from the cloud settings link when no org is active", () => {
+    cloudBackendMock.orgId = null;
+    useSidebarStore.setState({ collapsed: true });
+    renderSidebar("/conversations");
+
+    expect(screen.getByTestId("collapsed-settings-link")).toHaveAttribute(
       "href",
       "https://cloud.example.com/settings",
     );

--- a/src/components/features/backends/backend-selector.tsx
+++ b/src/components/features/backends/backend-selector.tsx
@@ -191,6 +191,11 @@ export function BackendSelector({
     : options.find((o) => o.value === activeValue);
   const isSettingsActive = Boolean(settingsMatch || settingsSubrouteMatch);
   const settingsLabel = t(I18nKey.SIDEBAR$SETTINGS);
+  // `org` is consumed by the cloud settings loader so the page opens on the
+  // org that is active here instead of the cloud's last-used org.
+  const cloudSettingsOrgQuery = active.orgId
+    ? `?org=${encodeURIComponent(active.orgId)}`
+    : "";
   const isRightPanelShown = useConversationStore(
     (state) => state.isRightPanelShown,
   );
@@ -420,7 +425,7 @@ export function BackendSelector({
           >
             {active.backend.kind === "cloud" ? (
               <a
-                href={`${active.backend.host.replace(/\/+$/, "")}/settings`}
+                href={`${active.backend.host.replace(/\/+$/, "")}/settings${cloudSettingsOrgQuery}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 data-testid="backend-selector-settings-link"

--- a/src/components/features/sidebar/sidebar-rail-body.tsx
+++ b/src/components/features/sidebar/sidebar-rail-body.tsx
@@ -60,6 +60,7 @@ export interface SidebarRailBodyProps {
   isExtensionsActive: boolean;
   currentPath: string;
   activeBackend: Backend;
+  activeOrgId: string | null;
   activeBackendHealth: { isConnected: boolean | null } | undefined;
   collapsedBackendPopoverOpen: boolean;
   setCollapsedBackendPopoverOpen: (open: boolean) => void;
@@ -83,6 +84,7 @@ export function SidebarRailBody({
   isExtensionsActive,
   currentPath,
   activeBackend,
+  activeOrgId,
   activeBackendHealth,
   collapsedBackendPopoverOpen,
   setCollapsedBackendPopoverOpen,
@@ -109,8 +111,13 @@ export function SidebarRailBody({
   };
 
   const isCloudBackend = activeBackend.kind === "cloud";
+  // `org` is consumed by the cloud settings loader so the page opens on the
+  // org that is active here instead of the cloud's last-used org.
+  const cloudSettingsOrgQuery = activeOrgId
+    ? `?org=${encodeURIComponent(activeOrgId)}`
+    : "";
   const cloudSettingsUrl = isCloudBackend
-    ? `${activeBackend.host.replace(/\/+$/, "")}/settings`
+    ? `${activeBackend.host.replace(/\/+$/, "")}/settings${cloudSettingsOrgQuery}`
     : null;
 
   return (

--- a/src/components/features/sidebar/sidebar.tsx
+++ b/src/components/features/sidebar/sidebar.tsx
@@ -192,6 +192,7 @@ export function Sidebar() {
     isExtensionsActive,
     currentPath,
     activeBackend: active.backend,
+    activeOrgId: active.orgId,
     activeBackendHealth,
     collapsedBackendPopoverOpen,
     setCollapsedBackendPopoverOpen,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes: both gear icons now carry the active org in their Cloud Settings href, and the href is unchanged when no org is active (unit tests below, plus the pre-fix run showing the two new org assertions failing).

---

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
Write a concise summary of what changed and link any reviewer artifacts, such
as files under `.pr/`. For HTML artifacts, include a rendered preview link:
https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/.pr/<file>.html
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc. -->

#17066 made the "All Cloud Settings" and "Integrations" links append `?org=<active org id>` so the cloud settings page opens on the org selected in the canvas. The two gear icons added by #16883 (the one next to the backend selector, and the collapsed-rail gear) were not covered: they still build `${backend.host}/settings` from the host alone. Clicking either gear therefore opens Cloud Settings on the cloud's last-used org, so a user working in a team org in the canvas can land in the Personal Workspace on the cloud without noticing.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `BackendSelector` appends `?org=<encodeURIComponent(active.orgId)>` to the cloud gear href when the active selection has an org; the URL is unchanged when there is no org. Same inline pattern as `CloudSettingsLink`.
- `SidebarRailBody` takes a new `activeOrgId` prop (passed from `Sidebar` as `active.orgId`) and appends the same query to the collapsed-rail gear href.
- Tests: `sidebar-cloud-settings.test.tsx` now expects `https://cloud.example.com/settings?org=org-1` for the mocked org and gains a no-org case; `backend-selector.test.tsx` gains a case seeding `setActive(cloudId, "org-2")` and expecting `${host}/settings?org=org-2`.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npx vitest run __tests__/components/features/sidebar/sidebar-cloud-settings.test.tsx __tests__/components/backends/backend-selector.test.tsx __tests__/components/features/settings/cloud-settings-link.test.tsx` → 34 passed.
2. `npx tsc --noEmit` → clean. `npx eslint` on the touched files reports only pre-existing findings outside the changed lines.
3. Run the canvas against a cloud backend that has a Personal Workspace and a team org. Switch to the team org and inspect the gear next to the backend selector, then collapse the sidebar and inspect the collapsed-rail gear: both hrefs end with `/settings?org=<team org uuid>`. Switch back to Personal and the `org` value follows. With a cloud that honors `?org=`, clicking either gear opens Cloud Settings on the same org; on a cloud that does not, the param is ignored and the previous behavior remains.

Reproduction before this change (new tests run against `main`'s source): the two org assertions fail with `href="https://cloud.example.com/settings"` and `href="https://app.all-hands.dev/settings"` — no `?org=` regardless of the active org — while the no-org case passes.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

https://github.com/user-attachments/assets/f4dd267c-b117-4ef9-bcf2-3707d26793c5

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- Effective only against a cloud whose settings loader consumes `?org=`; otherwise the param is ignored and nothing regresses.
- #17253 edits the `target`/`rel` lines directly under both hrefs changed here; whichever merges second needs a trivial rebase.
- Follow-up, not in this PR: the "Skills & Plugins" cloud links in `extensions-navigation.tsx` and `extensions-mobile-hub.tsx` build `${host}/settings/skills` without `?org=` as well.

<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.46.0-python` |
| **Automation** | `openhands-automation==1.11.1` |
| **Commit** | `7527028cfce33bfec51351fc124dd9bf239a3ded` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-7527028
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-7527028
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-7527028-amd64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3243-amd64
ghcr.io/openhands/agent-canvas:pr-17256-amd64
ghcr.io/openhands/agent-canvas:sha-7527028-arm64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3243-arm64
ghcr.io/openhands/agent-canvas:pr-17256-arm64
ghcr.io/openhands/agent-canvas:sha-7527028
ghcr.io/openhands/agent-canvas:hieptl-ohe-3243
ghcr.io/openhands/agent-canvas:pr-17256
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-7527028`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-7527028-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->