### PR TITLE
docs(codereview): require design docs for deep, high-risk PRs

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -183,7 +183,9 @@ minutes, for example:
 - a new or changed public API, wire/event contract, or persisted-state owner;
 - a new module or subsystem, or a cross-cutting refactor or migration;
 - a behavior change in core logic (agent loop, conversation, event flow, backend
-  selection).
+  selection); or
+- a large diff (roughly 500+ lines changed) whose intent a reviewer cannot hold
+  in their head at once, even if no single hunk is complex.
 
 Skip it for trivial PRs—a typo, a one-line guard, a config or dependency bump, a
 docs tweak, a small localized bug fix. If the diff is its own explanation, do not

--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -169,6 +169,40 @@ identity.
   relevant workflow against the PR branch.
 - Never broaden live E2E triggers or secret exposure for convenience.
 
+## Design Docs for Deep PRs
+
+A diff shows what changed line by line, not the design: the shape of the change,
+the API before and after, and why this approach. For a *deep* PR, expect a short
+design doc. The `pr-design-doc` skill in `.agents/skills/pr-design-doc/` produces
+a self-contained `.pr/` HTML page (big picture plus before/after, grounded to real
+code) linked from the PR description.
+
+A PR is "deep" when a reviewer cannot fully judge it from the diff in a couple of
+minutes, for example:
+
+- a new or changed public API, wire/event contract, or persisted-state owner;
+- a new module or subsystem, or a cross-cutting refactor or migration;
+- a behavior change in core logic (agent loop, conversation, event flow, backend
+  selection).
+
+Skip it for trivial PRs—a typo, a one-line guard, a config or dependency bump, a
+docs tweak, a small localized bug fix. If the diff is its own explanation, do not
+ask for a page.
+
+When a deep PR ships without a design doc, weigh the omission against the change's
+risk assessment:
+
+- **🔴 HIGH risk and deep, no design doc:** withhold approval. Submit **COMMENT**
+  and ask for a design doc (or an equivalent write-up in the PR description) so a
+  human can judge the proposal before merge.
+- **🟡 MEDIUM risk and deep, no design doc:** use judgment. Prefer to withhold
+  approval and request one when the change is hard to reconstruct from the diff; a
+  MEDIUM change that is small and self-evident does not need a page.
+- **🟢 LOW risk:** never block on a missing design doc.
+
+A design doc is a review aid, not a merge gate by itself. A well-written doc does
+not excuse real correctness, security, or architecture problems.
+
 ## Review Context Integrity
 
 Before submitting the review, compare its summary and every finding against the

--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -173,7 +173,7 @@ identity.
 
 A diff shows what changed line by line, not the design: the shape of the change,
 the API before and after, and why this approach. For a *deep* PR, expect a short
-design doc. The `pr-design-doc` skill in `.agents/skills/pr-design-doc/` produces
+design doc. If needed, you can tell about `pr-design-doc` skill which makes
 a self-contained `.pr/` HTML page (big picture plus before/after, grounded to real
 code) linked from the PR description.
 


### PR DESCRIPTION
HUMAN:
This PR proposes a small patch for the custom review skill to sometimes expect a pr-design-doc if the PR is deeply changing the code design, or large enough that a human reviewer wouldn’t work through it in a minute.

---

AGENT:

## Why

The repository already provides the `pr-design-doc` skill, but the automated review guide does not say when reviewers should expect design context. This follow-up makes that expectation explicit for deep, high-risk changes while exempting small or self-explanatory diffs.

## Summary

- Define practical signals for a deep PR, including public contracts, new subsystems, cross-cutting migrations, core behavior, and large changes whose intent is difficult to reconstruct.
- Tell the reviewer to use COMMENT rather than approval when important design context is missing, scaled by risk.
- Keep design docs advisory for low-risk or self-explanatory changes and preserve correctness, security, and architecture review as the primary gates.

## Issue Number

Fixes #17273

## How to Test

From the PR head, the following lightweight validation passed:

```bash
git diff --check origin/main...pr-17267
grep -q '^triggers:' .agents/skills/custom-codereview-guide.md
```

The existing Ubuntu and Windows test/build checks also pass. Review the new decision matrix against `.agents/skills/pr-design-doc/SKILL.md` and the existing APPROVE-or-COMMENT policy.

## Video/Screenshots

Not applicable. This changes repository-local Markdown review guidance and has no product UI.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Review identified one lifecycle concern still requiring author action: same-repository `.pr/` artifacts are removed as soon as an automated approval is submitted, which can make a branch-linked design doc disappear before a human maintainer reads it. The policy should require durable equivalent context in the PR description before approval, or otherwise reconcile cleanup timing.

---

_This PR description was updated by an AI agent (OpenHands) on behalf of @enyst._

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.40s · commit ff96837  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 1/1 hunks, 1/1 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 4.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 4.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 95.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 2d340af629550f7ac99d8a5dc5152437c98e81246cd1faa644f25589a56e58c4 -->
<!-- jev-fast-audit:end -->
