### PR TITLE
feat: test remote MCP servers on cloud backends via the app server

### DIFF
--- a/__tests__/api/cloud/mcp-service.test.ts
+++ b/__tests__/api/cloud/mcp-service.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import type { Backend } from "#/api/backend-registry/types";
+import { testCloudMcpServer } from "#/api/cloud/mcp-service.api";
+import {
+  getFetchCall,
+  getJsonBody,
+  mockJsonResponse,
+} from "./fetch-test-utils";
+
+const cloudBackend: Backend = {
+  id: "prod",
+  name: "Production",
+  host: "https://app.all-hands.dev",
+  apiKey: "bearer-token",
+  kind: "cloud",
+};
+
+const originalFetch = global.fetch;
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  setRegisteredBackends([cloudBackend]);
+  setActiveSelection({ backendId: cloudBackend.id });
+  fetchMock.mockReset();
+  global.fetch = fetchMock as typeof fetch;
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetActiveStoreForTests();
+  fetchMock.mockReset();
+  global.fetch = originalFetch;
+});
+
+describe("testCloudMcpServer", () => {
+  it("posts the probe request to /api/v1/mcp/test on the active cloud backend", async () => {
+    // Arrange
+    fetchMock.mockResolvedValue(
+      mockJsonResponse({
+        ok: false,
+        error: "refused",
+        error_kind: "connection",
+      }),
+    );
+    const request = {
+      name: "jira",
+      server: {
+        type: "http" as const,
+        url: "https://mcp-jira.example.com/mcp",
+      },
+      timeout: 15,
+    };
+
+    // Act
+    const result = await testCloudMcpServer(request);
+
+    // Assert
+    const [url, init] = getFetchCall(fetchMock);
+    expect(url).toBe(`${cloudBackend.host}/api/v1/mcp/test`);
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: { Authorization: "Bearer bearer-token" },
+    });
+    expect(getJsonBody(init)).toEqual(request);
+    expect(result).toEqual({
+      ok: false,
+      error: "refused",
+      error_kind: "connection",
+    });
+  });
+});

--- a/__tests__/api/mcp-service/mcp-service.api.test.ts
+++ b/__tests__/api/mcp-service/mcp-service.api.test.ts
@@ -9,8 +9,9 @@ import { REDACTED_MCP_SECRET_VALUE } from "#/utils/mcp-config";
 
 // vi.mock factories are hoisted before imports, so spy functions must be
 // created with vi.hoisted() to be in scope inside the factory.
-const { mockTestServer } = vi.hoisted(() => ({
+const { mockTestServer, mockTestCloudServer } = vi.hoisted(() => ({
   mockTestServer: vi.fn(),
+  mockTestCloudServer: vi.fn(),
 }));
 
 vi.mock("@openhands/typescript-client/clients", () => ({
@@ -34,6 +35,10 @@ vi.mock("#/api/agent-server-client-options", () => ({
 
 vi.mock("#/api/backend-registry/active-store", () => ({
   getActiveBackend: vi.fn(),
+}));
+
+vi.mock("#/api/cloud/mcp-service.api", () => ({
+  testCloudMcpServer: mockTestCloudServer,
 }));
 
 const mockGetActiveBackend = vi.mocked(activeStore.getActiveBackend);
@@ -379,17 +384,48 @@ describe("McpService.testServer", () => {
     );
   });
 
-  it("short-circuits with a synthetic ok response on cloud backends", async () => {
-    // Regression: when the active backend is cloud, the local agent-server's
-    // /api/mcp/test endpoint is not reachable. Previously, the helper threw
+  it("short-circuits stdio servers with a synthetic ok response on cloud backends", async () => {
+    // Regression: stdio servers spawn inside the cloud sandbox, which the
+    // browser cannot reach. Previously, the helper threw
     // `NoBackendAvailableError("No backend is configured.")` which surfaced
     // in the install modal and blocked users from creating any MCP server
     // (e.g. Slack) on a cloud session.
     cloudActive();
 
-    const result = await McpService.testServer(SERVER);
+    const result = await McpService.testServer(SLACK_SERVER);
 
     expect(result).toEqual({ ok: true, tools: [] });
     expect(mockTestServer).not.toHaveBeenCalled();
+    expect(mockTestCloudServer).not.toHaveBeenCalled();
+  });
+
+  it("probes remote servers on cloud backends through the app server", async () => {
+    cloudActive();
+    mockTestCloudServer.mockResolvedValue({ ok: true, tools: ["get_me"] });
+    const fetchSettings = vi.spyOn(SettingsService, "fetchSettingsFromApi");
+
+    const result = await McpService.testServer({
+      ...SERVER,
+      headers: { "X-Team": "team-1" },
+      auth: { strategy: "bearer", value: REDACTED_MCP_SECRET_VALUE },
+    });
+
+    expect(result).toEqual({ ok: true, tools: ["get_me"] });
+    expect(mockTestServer).not.toHaveBeenCalled();
+    // Unchanged secrets are restored by the app server from the stored
+    // server (sent as `name`), not fetched from a local agent-server; `auth`
+    // is flattened to headers the way cloud saves persist it.
+    expect(fetchSettings).not.toHaveBeenCalled();
+    expect(mockTestCloudServer).toHaveBeenCalledWith({
+      name: SERVER.id,
+      server: {
+        type: "http",
+        url: SERVER.url,
+        headers: {
+          "X-Team": "team-1",
+          Authorization: `Bearer ${REDACTED_MCP_SECRET_VALUE}`,
+        },
+      },
+    });
   });
 });

--- a/__tests__/components/features/mcp-page/custom-server-editor.test.tsx
+++ b/__tests__/components/features/mcp-page/custom-server-editor.test.tsx
@@ -6,6 +6,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsService from "#/api/settings-service/settings-service.api";
 import McpService from "#/api/mcp-service/mcp-service.api";
 import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import {
   __resetMcpHealthStoreForTests,
   getMcpHealthSnapshot,
   setMcpServerHealth,
@@ -36,6 +41,14 @@ const EDIT_OAUTH_SERVER: MCPServerConfig = {
     strategy: "oauth2",
     authentication: { type: "oauth", client_auth_method: "none" },
   },
+};
+
+const EDIT_REMOTE_SERVER: MCPServerConfig = {
+  id: "jira",
+  type: "shttp",
+  name: "jira",
+  url: "https://mcp-jira.example.com/mcp",
+  auth: { strategy: "bearer", value: "**********" },
 };
 
 function buildSettingsWithMcp(overrides: Partial<Settings> = {}): Settings {
@@ -85,6 +98,22 @@ function EditEditorOnceSettingsLoaded({ onClose }: { onClose: () => void }) {
   );
 }
 
+function EditRemoteEditorOnceSettingsLoaded({
+  onClose,
+}: {
+  onClose: () => void;
+}) {
+  const { data } = useSettings();
+  if (!data) return null;
+  return (
+    <CustomServerEditor
+      server={EDIT_REMOTE_SERVER}
+      existingServers={[EDIT_REMOTE_SERVER]}
+      onClose={onClose}
+    />
+  );
+}
+
 function EditOAuthEditorOnceSettingsLoaded({
   onClose,
 }: {
@@ -118,6 +147,10 @@ function renderWith(ui: React.ReactNode) {
 describe("CustomServerEditor", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    // The backend registry persists to localStorage; wipe it before the
+    // reset re-reads storage so each test starts on the default local backend.
+    window.localStorage.clear();
+    __resetActiveStoreForTests();
     vi.spyOn(SettingsService, "createMcpServer").mockImplementation(
       (settingsKey, server) =>
         SettingsService.saveSettings({
@@ -268,6 +301,63 @@ describe("CustomServerEditor", () => {
         "MCP$TEST_ERROR_CREDENTIALS",
       ),
     );
+  });
+
+  it("offers Test connection for remote servers on cloud backends and shows the result", async () => {
+    // Arrange: a cloud backend is active and the probe (routed through the
+    // app server) succeeds.
+    setRegisteredBackends([
+      {
+        id: "cloud-1",
+        name: "Cloud",
+        host: "https://app.all-hands.dev",
+        apiKey: "k",
+        kind: "cloud",
+      },
+    ]);
+    setActiveSelection({ backendId: "cloud-1" });
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettingsWithMcp(),
+    );
+    const testSpy = vi
+      .spyOn(McpService, "testServer")
+      .mockResolvedValue({ ok: true, tools: ["search_issues"] });
+    renderWith(<EditRemoteEditorOnceSettingsLoaded onClose={vi.fn()} />);
+    await screen.findByTestId("mcp-custom-editor");
+
+    // Act
+    fireEvent.click(screen.getByTestId("mcp-test-connection"));
+
+    // Assert
+    await waitFor(() =>
+      expect(screen.getByTestId("mcp-test-message")).toHaveTextContent(
+        "MCP$TEST_SUCCESS",
+      ),
+    );
+    expect(testSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "shttp", url: EDIT_REMOTE_SERVER.url }),
+    );
+  });
+
+  it("hides Test connection for stdio servers on cloud backends", async () => {
+    setRegisteredBackends([
+      {
+        id: "cloud-1",
+        name: "Cloud",
+        host: "https://app.all-hands.dev",
+        apiKey: "k",
+        kind: "cloud",
+      },
+    ]);
+    setActiveSelection({ backendId: "cloud-1" });
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSettingsWithMcp(),
+    );
+
+    renderWith(<EditEditorOnceSettingsLoaded onClose={vi.fn()} />);
+    await screen.findByTestId("mcp-custom-editor");
+
+    expect(screen.queryByTestId("mcp-test-connection")).not.toBeInTheDocument();
   });
 
   it("reseeds the edited server's health from the fresh pre-save test", async () => {

--- a/__tests__/components/features/mcp-page/install-server-modal.test.tsx
+++ b/__tests__/components/features/mcp-page/install-server-modal.test.tsx
@@ -4,6 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsService from "#/api/settings-service/settings-service.api";
 import McpService from "#/api/mcp-service/mcp-service.api";
 import {
+  __resetActiveStoreForTests,
+  setActiveSelection,
+  setRegisteredBackends,
+} from "#/api/backend-registry/active-store";
+import {
   __resetMcpHealthStoreForTests,
   getMcpHealthSnapshot,
 } from "#/api/mcp-health/mcp-health-store";
@@ -35,6 +40,10 @@ function renderWith(ui: React.ReactNode) {
 describe("InstallServerModal", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    // The backend registry persists to localStorage; wipe it before the
+    // reset re-reads storage so each test starts on the default local backend.
+    window.localStorage.clear();
+    __resetActiveStoreForTests();
     vi.spyOn(SettingsService, "createMcpServer").mockImplementation(
       (settingsKey, server) =>
         SettingsService.saveSettings({
@@ -131,6 +140,92 @@ describe("InstallServerModal", () => {
         verification: "connectivity-only",
       }),
     );
+  });
+
+  it("seeds a remote catalog server's health on cloud backends", async () => {
+    // Arrange: on a cloud backend remote servers are probed through the app
+    // server, so the pre-save verdict is real and must reach the card.
+    __resetMcpHealthStoreForTests();
+    setRegisteredBackends([
+      {
+        id: "cloud-1",
+        name: "Cloud",
+        host: "https://app.all-hands.dev",
+        apiKey: "k",
+        kind: "cloud",
+      },
+    ]);
+    setActiveSelection({ backendId: "cloud-1" });
+    const linear = getMcpMarketplaceCatalog(MCP_MARKETPLACE).find(
+      (e) => e.id === "linear",
+    )!;
+    const getSpy = vi
+      .spyOn(SettingsService, "getSettings")
+      .mockResolvedValue(MOCK_DEFAULT_USER_SETTINGS);
+    vi.spyOn(SettingsService, "saveSettings").mockResolvedValue(true);
+    renderWith(
+      <InstallServerModal
+        existingServers={[]}
+        entry={linear}
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByTestId("mcp-install-modal");
+    await waitFor(() => expect(getSpy).toHaveBeenCalled());
+
+    // Act
+    fireEvent.change(screen.getByTestId("mcp-install-field-api_key"), {
+      target: { value: "lin_api_secret" },
+    });
+    fireEvent.click(screen.getByTestId("mcp-install-submit"));
+
+    // Assert
+    await waitFor(() =>
+      expect(Object.values(getMcpHealthSnapshot())).toEqual([
+        expect.objectContaining({ status: "healthy" }),
+      ]),
+    );
+  });
+
+  it("does not seed a stdio catalog server's health on cloud backends", async () => {
+    // Arrange: stdio servers cannot be probed off-sandbox, so their cloud
+    // pre-save test is synthetic and must not become a health verdict.
+    __resetMcpHealthStoreForTests();
+    setRegisteredBackends([
+      {
+        id: "cloud-1",
+        name: "Cloud",
+        host: "https://app.all-hands.dev",
+        apiKey: "k",
+        kind: "cloud",
+      },
+    ]);
+    setActiveSelection({ backendId: "cloud-1" });
+    const slack = MCP_MARKETPLACE.find((e) => e.id === "slack")!;
+    const saveSpy = vi
+      .spyOn(SettingsService, "saveSettings")
+      .mockResolvedValue(true);
+    renderWith(
+      <InstallServerModal
+        existingServers={[]}
+        entry={slack}
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByTestId("mcp-install-modal");
+
+    // Act
+    fireEvent.change(screen.getByTestId("mcp-install-field-SLACK_BOT_TOKEN"), {
+      target: { value: "xoxb-abc" },
+    });
+    fireEvent.change(screen.getByTestId("mcp-install-field-SLACK_TEAM_ID"), {
+      target: { value: "T01" },
+    });
+    fireEvent.click(screen.getByTestId("mcp-install-submit"));
+
+    // Assert: the install still completes, but no verdict is recorded.
+    await waitFor(() => expect(saveSpy).toHaveBeenCalledTimes(1));
+    expect(getMcpHealthSnapshot()).toEqual({});
   });
 
   it("installs Tavily as a stdio MCP server with TAVILY_API_KEY env", async () => {

--- a/__tests__/components/features/mcp-page/mcp-server-health.test.tsx
+++ b/__tests__/components/features/mcp-page/mcp-server-health.test.tsx
@@ -31,6 +31,14 @@ const GITHUB_SERVER: MCPServerConfig = {
   auth: { strategy: "api_key", value: "github_pat_x" },
 };
 
+const STDIO_SERVER: MCPServerConfig = {
+  id: "local-tool",
+  type: "stdio",
+  name: "local-tool",
+  command: "npx",
+  args: ["-y", "local-tool"],
+};
+
 const OAUTH_SERVER: MCPServerConfig = {
   id: "my-oauth",
   type: "shttp",
@@ -151,7 +159,7 @@ describe("InstalledServerCard connection health", () => {
     );
   });
 
-  it("renders no health section on cloud backends", () => {
+  it("renders the health section for remote servers on cloud backends", () => {
     setRegisteredBackends([
       {
         id: "cloud-1",
@@ -166,7 +174,27 @@ describe("InstalledServerCard connection health", () => {
     renderCard(CUSTOM_SERVER);
 
     expect(
-      screen.queryByTestId(`mcp-server-health-${CUSTOM_SERVER.id}`),
+      screen.getByTestId(`mcp-server-health-${CUSTOM_SERVER.id}`),
+    ).toBeInTheDocument();
+    expect(probeButton(CUSTOM_SERVER.id)).toBeInTheDocument();
+  });
+
+  it("renders no health section for stdio servers on cloud backends", () => {
+    setRegisteredBackends([
+      {
+        id: "cloud-1",
+        name: "Cloud",
+        host: "https://app.all-hands.dev",
+        apiKey: "k",
+        kind: "cloud",
+      },
+    ]);
+    setActiveSelection({ backendId: "cloud-1" });
+
+    renderCard(STDIO_SERVER);
+
+    expect(
+      screen.queryByTestId(`mcp-server-health-${STDIO_SERVER.id}`),
     ).not.toBeInTheDocument();
   });
 

--- a/src/api/cloud/mcp-service.api.ts
+++ b/src/api/cloud/mcp-service.api.ts
@@ -1,0 +1,36 @@
+import type { AgentServerMCPTestRequest } from "@openhands/typescript-client";
+import { getActiveBackend } from "../backend-registry/active-store";
+import type { Backend } from "../backend-registry/types";
+import type { ExtendedMCPTestResponse } from "#/types/mcp-server";
+import { callCloudProxy } from "./proxy";
+
+const DEFAULT_MCP_TEST_TIMEOUT_SECONDS = 15;
+
+function getActiveCloudBackend(): Backend {
+  const active = getActiveBackend().backend;
+  if (active.kind !== "cloud") {
+    throw new Error("Cloud MCP test call requires a cloud backend.");
+  }
+  return active;
+}
+
+/**
+ * Probe a remote MCP server through the cloud backend's
+ * `POST /api/v1/mcp/test`, which shares the agent-server test contract
+ * (HTTP 200 with `ok: false` for connection/timeout failures). The probe
+ * lists tools and may then run one read-only tool call, each bounded by
+ * `timeout`, so the request deadline covers both plus a margin.
+ */
+export async function testCloudMcpServer(
+  request: AgentServerMCPTestRequest,
+): Promise<ExtendedMCPTestResponse> {
+  const backend = getActiveCloudBackend();
+  const timeout = request.timeout ?? DEFAULT_MCP_TEST_TIMEOUT_SECONDS;
+  return callCloudProxy<ExtendedMCPTestResponse>({
+    backend,
+    method: "POST",
+    path: "/api/v1/mcp/test",
+    body: request,
+    timeoutSeconds: 2 * timeout + 5,
+  });
+}

--- a/src/api/mcp-service/mcp-service.api.ts
+++ b/src/api/mcp-service/mcp-service.api.ts
@@ -5,6 +5,8 @@ import {
   getActiveBackend,
   getRegisteredBackends,
 } from "../backend-registry/active-store";
+import { testCloudMcpServer } from "../cloud/mcp-service.api";
+import { headersFromMcpAuth } from "../settings-service/settings-service.api";
 import {
   getCredentialValidationForServer,
   type CredentialValidation,
@@ -19,6 +21,8 @@ import { redactMcpSecrets } from "#/utils/redact-mcp-secrets";
 import { substituteRedactedMcpCredentials } from "./mcp-redacted-credentials";
 
 const OAUTH_MCP_TEST_TIMEOUT_SECONDS = 120;
+// Upper bound accepted by the app server's `POST /api/v1/mcp/test`.
+const MAX_CLOUD_MCP_TEST_TIMEOUT_SECONDS = 120;
 
 function toMcpServer(
   server: MCPServerConfig,
@@ -180,18 +184,17 @@ class McpService {
   static async testServer(
     server: MCPServerConfig,
   ): Promise<ExtendedMCPTestResponse> {
-    // The MCP connectivity-test endpoint lives on the local agent-server. It
-    // spawns the configured stdio command / opens an SSE-or-SHTTP connection
-    // from that process's environment. Cloud backends don't expose this
-    // endpoint to the frontend — the MCP server would actually run inside the
-    // cloud sandbox, which isn't reachable from the browser before the user
-    // starts a conversation. Calling `getAgentServerClientOptions()` here for
-    // a cloud-active session would throw `NoBackendAvailableError("No backend
-    // is configured.")` and block the install flow entirely. Short-circuit
-    // with a synthetic success so saving proceeds; any real connection
-    // failure surfaces inside the conversation runtime instead.
     if (getActiveBackend().backend.kind === "cloud") {
-      return { ok: true, tools: [] };
+      // A stdio server spawns inside the cloud sandbox, which isn't reachable
+      // from the browser before the user starts a conversation, so it cannot
+      // be probed from the settings page. Short-circuit with a synthetic
+      // success so saving/installing proceeds; any real failure surfaces
+      // inside the conversation runtime instead. (Throwing here would block
+      // the install flow entirely — see the cloud regression test.)
+      if (server.type === "stdio") {
+        return { ok: true, tools: [] };
+      }
+      return McpService.testRemoteServerViaCloud(server);
     }
     const validation = getCredentialValidationForServer(server);
     const { host, apiKey } = getAgentServerClientOptions();
@@ -207,6 +210,43 @@ class McpService {
     } finally {
       client.close();
     }
+  }
+
+  /**
+   * Remote servers on cloud backends are probed by the app server's
+   * `POST /api/v1/mcp/test`. Unchanged (redacted) credentials are not
+   * substituted here: the app server restores them from the stored server of
+   * the same settings key, which is why the key is sent as `name`. `auth` is
+   * flattened to headers the same way cloud saves persist it so that
+   * restoration matches; an `auth` that cannot be flattened (e.g. OAuth
+   * without tokens) is passed through and the app server answers with a
+   * structured failure.
+   */
+  private static async testRemoteServerViaCloud(
+    server: MCPServerConfig,
+  ): Promise<ExtendedMCPTestResponse> {
+    const validation = getCredentialValidationForServer(server);
+    const authHeaders = server.auth
+      ? headersFromMcpAuth({ ...server.auth })
+      : null;
+    const headers = { ...server.headers, ...authHeaders };
+    const name = server.id || server.name;
+    const timeout = getMcpTestTimeout(server);
+    const request: AgentServerMCPTestRequest = {
+      server: {
+        type: server.type === "sse" ? "sse" : "http",
+        url: server.url!,
+        ...(Object.keys(headers).length > 0 && { headers }),
+        ...(server.auth && authHeaders === null && { auth: server.auth }),
+      },
+      ...(name ? { name } : {}),
+      ...(timeout !== undefined && {
+        timeout: Math.min(timeout, MAX_CLOUD_MCP_TEST_TIMEOUT_SECONDS),
+      }),
+      ...(validation ? { tool_call: validation.toolCall } : {}),
+    };
+    const result = await testCloudMcpServer(request);
+    return finalizeMcpTestResponse(result, validation, [server]);
   }
 
   static async startOAuth(

--- a/src/api/settings-service/settings-service.api.ts
+++ b/src/api/settings-service/settings-service.api.ts
@@ -191,7 +191,7 @@ const basicAuthHeader = (username: string, password: string): string => {
   return `Basic ${token}`;
 };
 
-const headersFromMcpAuth = (
+export const headersFromMcpAuth = (
   auth: Record<string, unknown>,
 ): Record<string, string> | null => {
   switch (auth.strategy) {

--- a/src/components/features/mcp-page/custom-server-editor.tsx
+++ b/src/components/features/mcp-page/custom-server-editor.tsx
@@ -53,6 +53,7 @@ export function CustomServerEditor({
     mutate: testServer,
     isPending: isTesting,
     data: testResult,
+    variables: testedServer,
     reset: resetTest,
   } = useTestMcpServer();
   const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
@@ -60,12 +61,15 @@ export function CustomServerEditor({
     React.useState<ExtendedMCPTestResponse | null>(null);
   const [isOauthTesting, setIsOauthTesting] = React.useState(false);
 
-  // The MCP connectivity-test endpoint only exists on the local agent-server.
-  // For cloud backends `McpService.testServer` short-circuits with a synthetic
-  // success so the save still completes; we hide the manual "Test connection"
-  // button here so cloud users aren't shown a misleading "0 tools" result.
+  // stdio servers cannot be probed from a cloud backend (they spawn inside the
+  // sandbox): `McpService.testServer` short-circuits them with a synthetic
+  // success so the save still completes. Hide the manual "Test connection"
+  // button and the resulting message for them so cloud users aren't shown a
+  // misleading "0 tools" result. Remote servers are probed via the app server.
   const { backend } = useActiveBackend();
   const isCloudBackend = backend.kind === "cloud";
+  const isSyntheticTestResult =
+    isCloudBackend && !oauthTestResult && testedServer?.type === "stdio";
 
   const isEditing = !!server.id;
   const isPending = isAdding || isUpdating || isDeleting;
@@ -88,13 +92,14 @@ export function CustomServerEditor({
   }, [oauthTestResult, testResult, t]);
 
   // A save always follows a fresh successful probe of the exact config being
-  // saved, so publish that result to the card's health entry. On cloud
-  // backends the probe is synthetic — never present it as a health verdict.
+  // saved, so publish that result to the card's health entry. For stdio
+  // servers on cloud backends the probe is synthetic — never present it as a
+  // health verdict.
   const seedSavedServerHealth = (
     serverToSave: MCPServerConfig,
     result: ExtendedMCPTestResponse,
   ) => {
-    if (isCloudBackend) return;
+    if (isCloudBackend && serverToSave.type === "stdio") return;
     // When editing, the server's own entry must be overwritten, so only the
     // OTHER servers guard against a same-key collision.
     const otherServers = isEditing
@@ -247,9 +252,10 @@ export function CustomServerEditor({
             onCancel={onClose}
             onDelete={isEditing ? () => setShowDeleteConfirm(true) : undefined}
             isActionDisabled={isPending}
-            onTest={isCloudBackend ? undefined : handleTestClick}
+            onTest={handleTestClick}
             isTestPending={isTesting || isOauthTesting}
-            testMessage={isCloudBackend ? null : testMessage}
+            testMessage={isSyntheticTestResult ? null : testMessage}
+            isStdioTestUnavailable={isCloudBackend}
           />
         </div>
       </ModalBackdrop>

--- a/src/components/features/mcp-page/install-server-modal.tsx
+++ b/src/components/features/mcp-page/install-server-modal.tsx
@@ -156,8 +156,6 @@ export function InstallServerModal({
   const { mutate: addMcpServer, isPending: isAdding } = useAddMcpServer();
   const { mutate: testMcpServer, isPending: isTesting } = useTestMcpServer();
   const saveFieldsAsSecrets = useSaveFieldsAsSecrets();
-  // Cloud backends get a synthetic test success (no local test endpoint);
-  // never seed card health from it.
   const { backend } = useActiveBackend();
   const isCloudBackend = backend.kind === "cloud";
 
@@ -174,6 +172,9 @@ export function InstallServerModal({
   const [isAuthorizingOAuth, setIsAuthorizingOAuth] = React.useState(false);
   const option = getInstallableMcpConnectionOption(entry);
   const template = option?.transport;
+  // stdio servers on cloud backends get a synthetic test success (they only
+  // run inside the sandbox); never seed card health from it.
+  const isSyntheticTest = isCloudBackend && template?.kind === "stdio";
 
   const isPending =
     isTesting || isAuthorizingOAuth || isAdding || isFinalizingInstall;
@@ -254,7 +255,7 @@ export function InstallServerModal({
             : payload;
           addMcpServer(serverToSave, {
             onSuccess: () => {
-              if (!isCloudBackend) {
+              if (!isSyntheticTest) {
                 seedMcpServerHealth(serverToSave, result, existingServers);
               }
               displaySuccessToast(t(I18nKey.MCP$INSTALL_SUCCESS));
@@ -299,7 +300,7 @@ export function InstallServerModal({
             : payload;
         addMcpServer(serverToSave, {
           onSuccess: () => {
-            if (!isCloudBackend) {
+            if (!isSyntheticTest) {
               seedMcpServerHealth(serverToSave, result, existingServers);
             }
             displaySuccessToast(t(I18nKey.MCP$INSTALL_SUCCESS));

--- a/src/components/features/mcp-page/mcp-server-health.tsx
+++ b/src/components/features/mcp-page/mcp-server-health.tsx
@@ -63,9 +63,10 @@ function getStatusLabel(
  * a Test connection / Retry action, and — on failure — the relevant
  * recovery actions (fix credentials, re-run OAuth, open the docs).
  *
- * Renders nothing for cloud backends: the test endpoint only exists on the
- * local agent-server (`McpService.testServer` short-circuits cloud with a
- * synthetic success that must not be presented as a health verdict).
+ * Renders nothing for stdio servers on cloud backends: those spawn inside
+ * the cloud sandbox, so `McpService.testServer` short-circuits them with a
+ * synthetic success that must not be presented as a health verdict. Remote
+ * servers on cloud backends are probed through the app server.
  */
 export function McpServerHealthSection({
   server,
@@ -77,7 +78,7 @@ export function McpServerHealthSection({
   const { health, probe, reauthorize } = useMcpServerHealth(server);
   const { mutate: updateMcpServer } = useUpdateMcpServer();
 
-  if (backend.kind === "cloud") return null;
+  if (backend.kind === "cloud" && server.type === "stdio") return null;
 
   const isChecking = health.status === "checking";
   const isFailed = health.status === "failed";

--- a/src/components/features/settings/mcp-settings/mcp-server-form.tsx
+++ b/src/components/features/settings/mcp-settings/mcp-server-form.tsx
@@ -39,6 +39,12 @@ interface MCPServerFormProps {
   onTest?: (server: MCPServerConfig) => void;
   isTestPending?: boolean;
   testMessage?: TestMessage | null;
+  /**
+   * Hide the Test button while the form describes a stdio server. Cloud
+   * backends can only probe remote servers; the type is live form state in
+   * add mode, so the form owns this decision.
+   */
+  isStdioTestUnavailable?: boolean;
 }
 
 export function MCPServerForm({
@@ -52,6 +58,7 @@ export function MCPServerForm({
   onTest,
   isTestPending = false,
   testMessage = null,
+  isStdioTestUnavailable = false,
 }: MCPServerFormProps) {
   const { t } = useTranslation("openhands");
   const [serverType, setServerType] = React.useState<MCPServerType>(
@@ -733,7 +740,7 @@ export function MCPServerForm({
           >
             {t(I18nKey.BUTTON$CANCEL)}
           </BrandButton>
-          {onTest && (
+          {onTest && !(isStdioTestUnavailable && serverType === "stdio") && (
             <BrandButton
               testId="mcp-test-connection"
               type="button"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

I verified the changes.

---

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
Write a concise summary of what changed and link any reviewer artifacts, such
as files under `.pr/`. For HTML artifacts, include a rendered preview link:
https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/.pr/<file>.html
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc. -->

Agent Canvas hides MCP connection health on cloud backends: `McpService.testServer` short-circuited with a synthetic `{ ok: true, tools: [] }` (added in #1170 to stop installs from throwing "No backend is configured"), and the health row, editor Test button and post-save seeding were suppressed so that synthetic result was never shown as a verdict. The reason was that the only probe endpoint (`POST /api/mcp/test`) exists on the local agent-server. Cloud users therefore could not verify an MCP server from Settings, and a broken server only surfaced as missing tools in a conversation.

The cloud app server now exposes `POST /api/v1/mcp/test` with the same contract, so remote servers can be probed from a cloud backend too.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Route remote-server tests on cloud backends to the app server's `POST /api/v1/mcp/test` (`src/api/cloud/mcp-service.api.ts`, `McpService.testServer`): the settings key is sent as `name` so the backend restores unchanged redacted credentials, `auth` is flattened to headers the way cloud saves persist it (`headersFromMcpAuth` exported), and `substituteRedactedMcpCredentials` (local-only) is skipped. stdio servers keep the synthetic success because they spawn inside the sandbox.
- Narrow the cloud guards from "cloud" to "cloud and stdio" in `mcp-server-health.tsx`, `custom-server-editor.tsx` and `install-server-modal.tsx`; add `isStdioTestUnavailable` to `MCPServerForm` so the Test button disappears only while a stdio server is being described in add mode.
- Tests for the cloud service call and the cloud behaviour of the service, health section, editor and install modal; the two tests that asserted the old cloud short-circuit were rewritten.

## Issue Number
<!-- Required. The linked issue must carry the `ready-for-dev` label, which
means it has clear acceptance criteria (and, for bugs, reproduction evidence).
If no such issue exists yet, open one using the Bug or Feature Request template
and wait for it to be labeled `ready-for-dev` before opening this PR. -->
Fixes #

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `npm install && npm run lint`
2. `npx vitest run __tests__/api/mcp-service/mcp-service.api.test.ts __tests__/components/features/mcp-page __tests__/api/cloud/mcp-service.test.ts`
3. Manual, once a cloud backend serving `POST /api/v1/mcp/test` is available (companion enterprise PR): `npm run dev`, register that cloud backend and make it active, open the MCP page.
   - An installed remote server card now shows the health row; click **Test connection** → dot turns green with the tool count, or red with a timeout / connection / credential message and **Retry**.
   - Edit a remote server → **Test connection** is available in the editor; leaving the credential as `**********` still probes with the stored value.
   - Add or edit a stdio server → no Test button, saving still works, no health verdict is shown.
   - Install a remote catalog entry (e.g. Linear) → the new card carries the pre-save verdict; install a stdio entry (e.g. Slack) → it saves and shows no verdict.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

For bug fixes: reproduction evidence is required. Show the bug reproduced (the
error state) and then the result after your fix. A terminal screenshot or video
is fine for non-UI bugs.
-->

N/A.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->



<!-- AGENT_CANVAS_DOCKER_START -->
---
**🐳 Docker images for this PR**

• **GHCR package:** https://github.com/OpenHands/OpenHands/pkgs/container/agent-canvas

| Component | Value |
|---|---|
| **Image** | `ghcr.io/openhands/agent-canvas` |
| **Architectures** | amd64, arm64 |
| **Agent Server** | `ghcr.io/openhands/agent-server:1.49.3-python` |
| **Automation** | `openhands-automation==1.13.3` |
| **Commit** | `fe2e35272a70153bdcd9745ffea28c56d6601654` |

**Pull (multi-arch manifest)**
```bash
# Multi-arch manifest — Docker automatically pulls the correct architecture
docker pull ghcr.io/openhands/agent-canvas:sha-fe2e352
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  ghcr.io/openhands/agent-canvas:sha-fe2e352
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-canvas:sha-fe2e352-amd64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3226-amd64
ghcr.io/openhands/agent-canvas:pr-17276-amd64
ghcr.io/openhands/agent-canvas:sha-fe2e352-arm64
ghcr.io/openhands/agent-canvas:hieptl-ohe-3226-arm64
ghcr.io/openhands/agent-canvas:pr-17276-arm64
ghcr.io/openhands/agent-canvas:sha-fe2e352
ghcr.io/openhands/agent-canvas:hieptl-ohe-3226
ghcr.io/openhands/agent-canvas:pr-17276
```

**About Multi-Architecture Support**
- Each tag (e.g., `sha-fe2e352`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `sha-fe2e352-amd64`) are also available if needed
<!-- AGENT_CANVAS_DOCKER_END -->

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.57s · commit 12b38e9  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** ⚠️ reduced context — partial coverage; 28/33 hunks, 12/12 files (context budget: 27, hunk budget: 5).

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 6.0% | No direct hunk selected |
| Weakened authentication | 12.0% | No direct hunk selected |
| Weakened authorization | 20.0% | No direct hunk selected |
| Contract regression | 17.0% | No direct hunk selected |
| Data loss | 6.0% | No direct hunk selected |
| Sensitive data disclosure | 13.0% | No direct hunk selected |
| Unexpected data transfer | 7.0% | No direct hunk selected |
| Credential misuse | 15.0% | No direct hunk selected |
| Untrusted instruction authority | 3.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 3.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 15.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 51.0% | No primary concern to locate |

</details>


<!-- jev-input-signature 236a0d3cfe7592b7b621a8a8fda86992226c6a5cadd6017a06a4927b6d1c3463 -->
<!-- jev-fast-audit:end -->
