### PR TITLE
fix: carry runtime services context onto agent-profile launches

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1485,6 +1485,50 @@ describe("agent_settings runtime services suffix", () => {
       payload.agent_settings.agent_context.system_message_suffix as string,
     ).toContain("<RUNTIME_SERVICES>");
   });
+
+  it("carries runtime services on the profile path, where agent_settings can't be sent", () => {
+    // agent_profile_id and agent_settings are mutually exclusive, so the
+    // suffix rides agent_launch_additions and the server appends it after
+    // resolving the profile (#16205).
+    const payload = buildStartConversationRequest({
+      settings: DEFAULT_SETTINGS,
+      query: "hello",
+      agentProfileId: "profile-openhands",
+      agentProfileKind: "openhands",
+      runtimeServicesInfo: {
+        mode: "dev:automation",
+        services: {
+          agent_server: { url_from_agent: "http://localhost:18000" },
+          automation: { url_from_agent: "http://localhost:18001" },
+        },
+      },
+    }) as {
+      agent_profile_id?: string;
+      agent_settings?: unknown;
+      agent_launch_additions?: { system_message_suffix_append?: string };
+    };
+
+    expect(payload.agent_profile_id).toBe("profile-openhands");
+    expect(payload.agent_settings).toBeUndefined();
+    expect(
+      payload.agent_launch_additions?.system_message_suffix_append,
+    ).toContain("<RUNTIME_SERVICES>");
+    expect(
+      payload.agent_launch_additions?.system_message_suffix_append,
+    ).toContain("http://localhost:18001");
+  });
+
+  it("omits the additions entirely when there is no runtime services info", () => {
+    // A deployment without them must send no deployment context at all, not an
+    // empty string the server would append as a blank line.
+    const payload = buildStartConversationRequest({
+      settings: DEFAULT_SETTINGS,
+      query: "hello",
+      agentProfileId: "profile-openhands",
+      agentProfileKind: "openhands",
+    }) as { agent_launch_additions?: unknown };
+    expect(payload.agent_launch_additions).toBeUndefined();
+  });
 });
 
 describe("buildStartConversationRequest — ACP discriminator", () => {

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -1101,6 +1101,10 @@ type AgentSettingsStartConversationPayload = StartConversationPayloadBase & {
   // exclusive agent sources; the server resolves the profile server-side.
   agent_settings?: AgentSettingsPayload;
   agent_profile_id?: string;
+  // Deployment context appended to the *resolved* agent's system-message
+  // suffix, so it survives the profile path where ``agent_settings`` cannot be
+  // sent (``AgentLaunchAdditions``, software-agent-sdk#4030).
+  agent_launch_additions?: { system_message_suffix_append?: string };
   agent?: never;
 };
 
@@ -1189,6 +1193,11 @@ export function buildStartConversationRequest(
     options.runtimeServicesInfo,
     options.query,
   );
+  // Folded into ``agent_settings`` on the inline path; on the profile path it
+  // has to ride ``agent_launch_additions`` instead (see below).
+  const runtimeServicesSuffix = buildRuntimeServicesSystemSuffix(
+    options.runtimeServicesInfo,
+  );
   const acpServerTag = acpMode
     ? getAcpServerTag(sourceAgentSettings)
     : undefined;
@@ -1218,9 +1227,15 @@ export function buildStartConversationRequest(
     // server/SDK's responsibility to restore on the profile path — tracked in
     // software-agent-sdk#3967 (profile resolution must attach the default
     // toolset + public skills, else a profile-launched OpenHands agent has only
-    // Finish/Think). The dev ``RUNTIME_SERVICES`` system-message suffix remains
-    // agent-settings-only; the Canvas UI tool is a top-level client tool and
+    // Finish/Think). The Canvas UI tool is a top-level client tool and
     // therefore works on both inline-agent and profile launch paths.
+    //
+    // ``RUNTIME_SERVICES`` is the one enrichment only the client can compute —
+    // the sandbox-facing URLs of this local stack — so it rides
+    // ``agent_launch_additions``, which the server appends after resolving the
+    // profile (software-agent-sdk#4030). Without it a profile-launched
+    // conversation cannot find the local automation backend and falls through
+    // to the Cloud default (#16205).
     //
     // Persistent memory is NOT on that boundary: ``load_memory`` is a global
     // user preference, so the agent-server stamps the stored
@@ -1230,7 +1245,16 @@ export function buildStartConversationRequest(
     // re-send it here (``agent_profile_id`` and ``agent_settings`` are
     // mutually exclusive).
     ...(options.agentProfileId
-      ? { agent_profile_id: options.agentProfileId }
+      ? {
+          agent_profile_id: options.agentProfileId,
+          ...(runtimeServicesSuffix
+            ? {
+                agent_launch_additions: {
+                  system_message_suffix_append: runtimeServicesSuffix,
+                },
+              }
+            : {}),
+        }
       : { agent_settings: agentSettings }),
     workspace: conversationSettings.workspace,
     // The agent-server caches each client tool's schema per tool *name* for the

--- a/src/hooks/mutation/use-create-conversation.ts
+++ b/src/hooks/mutation/use-create-conversation.ts
@@ -141,19 +141,25 @@ export const useCreateConversation = () => {
       ) {
         // The seeded OpenHands `default` profile is the enriched baseline, not a
         // deliberate profile pick — it mirrors global agent_settings. Launch it
-        // via agent_settings so the canvas-only enrichments the profile-resolution
-        // path drops survive for the common home-launch: the <RUNTIME_SERVICES>
-        // system-message suffix and project-skill loading (buildAgentContext).
+        // via agent_settings so the canvas-only enrichment the profile path
+        // still drops survives the common home-launch: the ~60 bundled public
+        // skills this adapter injects (buildAgentContext). Server-side
+        // discovery is the profile path's own skill pipeline and finds none of
+        // them, so a profile launch here resolves zero skills — the
+        // two-pipeline drift tracked in software-agent-sdk#3979. Reconcile that
+        // and this branch can go, leaving one launch path for every profile.
+        //
+        // <RUNTIME_SERVICES> is no longer a reason: it now rides
+        // `agent_launch_additions` on the profile path (#16205).
         // Named profiles are deliberate custom configs and still use the profile
-        // path (accepting that enrichment boundary).
+        // path (accepting that skills boundary).
         // Trade-off: per-profile fields set on `default` itself don't apply on
         // home-launch — custom per-profile config belongs in a named profile.
         //
         // Scoped to OpenHands: an ACP `default` must keep the profile path.
         // Activation is pointer-only, so global agent_settings is stale (often
         // still OpenHands) when an ACP profile is active — launching it via
-        // agent_settings would start the wrong agent. ACP carries no
-        // <RUNTIME_SERVICES> enrichment, so there's nothing to preserve.
+        // agent_settings would start the wrong agent.
         //
         // Scoped to local: cloud never writes agent_settings, so it always
         // resolves `default` server-side via agent_profile_id (validated below).


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

## Why

A conversation launched with `agent_profile_id` never received the `<RUNTIME_SERVICES>` system-prompt block. That text is an enrichment of `agent_settings`, and the two agent sources are mutually exclusive, so the profile path dropped it.

The user-visible symptom is in #16205: a blank-workspace conversation asked to create an automation calls `https://app.all-hands.dev/api/automation/v1`, gets a `401`, and never tries `http://localhost:18001`. A repository conversation can mask it when the project's `AGENTS.md` happens to document the local endpoint.

**The mechanism to fix it already shipped and was simply never used.** `AgentLaunchAdditions.system_message_suffix_append` was added for exactly this (OpenHands/software-agent-sdk#4030, closing #4029) and is applied by the agent-server right after the profile resolves — `grep agent_launch_additions src/` in canvas returned nothing.

## Summary

- `buildStartConversationRequest` now sends `agent_launch_additions: { system_message_suffix_append }` alongside `agent_profile_id`, carrying the same suffix the inline path folds into `agent_settings`.
- Omitted entirely when there is no runtime-services info, so a deployment without them sends no deployment context rather than an empty string the server would append as a blank line.
- The ACP profile path gets it too; it previously had nothing to preserve.

## Issue Number

Fixes #16205

## How to Test

```bash
npm ci && npm test && npm run lint      # 5630 tests pass; lint + typecheck clean
OH_AGENT_SERVER_LOCAL_PATH=/path/to/software-agent-sdk npm run dev:minimal
```

Create a named agent profile, start a conversation from it with no workspace, and ask it to create an automation — it should reach `http://localhost:18001` rather than the Cloud default.

## Video/Screenshots

Against a live agent-server, launching from a profile that sets both a custom prompt and a scoped toolset, with the deployment context passed as launch additions:

```
POST /api/conversations
  { agent_profile_id: <searchAgent>,
    agent_launch_additions: { system_message_suffix_append: "<RUNTIME_SERVICES>…" } }

resulting agent:
  tools : ['browser_tool_set', 'glob', 'grep']         # profile scope intact
  suffix: 'you are a search agent\n\n<RUNTIME_SERVICES>\nautomation: http://localhost:18001\n</RUNTIME_SERVICES>'
```

Both survive, and the ordering is profile-first / deployment-after, matching how the server appends.

Before this change the same launch produced `system_message_suffix: 'you are a search agent'` with no `<RUNTIME_SERVICES>` block at all.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**This does not yet collapse the two launch paths.** `useCreateConversation` still routes the seeded `default` OpenHands profile through `agent_settings` on local backends. Runtime services were one of that branch's two stated reasons and are now handled; the other is not:

| | `agent_settings` path | `agent_profile_id` path |
|---|---|---|
| `<RUNTIME_SERVICES>` | folded into the context | **now carried** by this PR |
| public skills | the **11** default-enabled catalog skills | server-side discovery — **0 in a local dev env** |

Measured: the bundled catalog holds 60 skills but is *allow-listed*, so a launch injects `DEFAULT_ENABLED_SKILL_NAMES` — 11 of them (`add-skill`, `agent-canvas-environment`, `agent-memory`, `agent-sdk-builder`, `code-review`, `docker`, `github`, `openhands-api`, `openhands-automation`, `openhands-sdk`, `skill-creator`) — unless the user has set an explicit `enabled_skills`. A profile-launched conversation reports `skills: []` with `load_project_skills: true`. So removing the branch today would take `default` home-launches from 11 skills to none.

The difference is not only the count but the *source*: the inline path has canvas inject the skills and sets `load_public_skills: false` so the server does not look, while the profile path relies on the server's own `discover_profile_skills()`.

That is the two-pipeline drift tracked in OpenHands/software-agent-sdk#3979 (drop the npm-bundle injection in favour of one server-owned catalog). Once it is reconciled, the `default` branch can go and every profile takes one path — which also retires the current trap where per-profile fields set on `default` save cleanly but are ignored at launch. I have updated that branch's comment to record the narrowed reason rather than leaving it overstated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

