### PR TITLE
test: cover context usage reset between conversations

### DIFF
--- a/__tests__/hooks/use-context-window-usage.test.ts
+++ b/__tests__/hooks/use-context-window-usage.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import useMetricsStore, { type MetricsState } from "#/stores/metrics-store";
 import type { TokenUsage } from "#/api/conversation-service/agent-server-conversation-service.types";
@@ -101,6 +101,23 @@ describe("useContextWindowUsage", () => {
       perTurnToken: 500,
       contextWindow: 128_000,
     });
+  });
+
+  it("hides stale usage after the conversation metrics store is reset", () => {
+    useMetricsStore.setState({ usage: storeUsage(128_000, 500) });
+
+    const { result } = renderHook(() => useContextWindowUsage());
+
+    expect(result.current).toEqual({
+      perTurnToken: 500,
+      contextWindow: 128_000,
+    });
+
+    act(() => {
+      useMetricsStore.getState().resetMetrics();
+    });
+
+    expect(result.current).toBeNull();
   });
 
   it("returns null when no source reports a positive context window", () => {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Test-only change: adds the hook spec and touches no production code. Verified with the repo's test run for the changed file.

---

AGENT:

## Why

#17271 reports that a new conversation can retain context-window usage from the previous one. The production reset path is already in the base branch; this PR adds the missing regression coverage so the behavior cannot silently regress again.

## Summary

- Add `__tests__/hooks/use-context-window-usage.test.ts` covering the context-window usage hook.
- Assert that resetting conversation metrics hides usage from the previous conversation.

## Issue Number

#17271

## How to Test

Run the test suite for `__tests__/hooks/use-context-window-usage.test.ts`. The `test-and-build (ubuntu)` and `test-and-build (windows)` jobs run it in CI and both pass on this branch.

## Video/Screenshots

Not applicable — test-only change, no visual state.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Test-only; no production code changed.
