### PR TITLE
fix: send the bundled skill set on agent-profile launches too

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1518,6 +1518,36 @@ describe("agent_settings runtime services suffix", () => {
     ).toContain("http://localhost:18001");
   });
 
+  it("sends the same enabled skills on the profile path as the inline path injects", () => {
+    // The profile path carries no agent_settings, and the server resolves
+    // public skills from a clone this client does not rely on, so they ride
+    // agent_launch_additions instead (software-agent-sdk#3979).
+    const inline = buildStartConversationRequest({
+      settings: DEFAULT_SETTINGS,
+      query: "hello",
+    }) as unknown as {
+      agent_settings: { agent_context: { skills: { name: string }[] } };
+    };
+    const inlineNames = inline.agent_settings.agent_context.skills
+      .map((skill) => skill.name)
+      .sort();
+
+    const viaProfile = buildStartConversationRequest({
+      settings: DEFAULT_SETTINGS,
+      query: "hello",
+      agentProfileId: "profile-openhands",
+      agentProfileKind: "openhands",
+    }) as {
+      agent_launch_additions?: { skills?: { name: string }[] };
+    };
+    const profileNames = (viaProfile.agent_launch_additions?.skills ?? [])
+      .map((skill) => skill.name)
+      .sort();
+
+    expect(profileNames.length).toBeGreaterThan(0);
+    expect(profileNames).toEqual(inlineNames);
+  });
+
   it("omits the additions entirely when there is no runtime services info", () => {
     // A deployment without them must send no deployment context at all, not an
     // empty string the server would append as a blank line.
@@ -1526,8 +1556,13 @@ describe("agent_settings runtime services suffix", () => {
       query: "hello",
       agentProfileId: "profile-openhands",
       agentProfileKind: "openhands",
-    }) as { agent_launch_additions?: unknown };
-    expect(payload.agent_launch_additions).toBeUndefined();
+    }) as {
+      agent_launch_additions?: { system_message_suffix_append?: string };
+    };
+    // Skills still ride along; only the deployment context is absent.
+    expect(
+      payload.agent_launch_additions?.system_message_suffix_append,
+    ).toBeUndefined();
   });
 });
 

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -821,6 +821,25 @@ function buildBundledSkills(): BundledSkill[] {
   });
 }
 
+/**
+ * The public skills a launch should carry: the bundled catalog filtered by the
+ * user's enablement, exactly as {@link buildAgentContext} injects them inline.
+ *
+ * Split out so the ``agent_profile_id`` path can send the same set through
+ * ``agent_launch_additions``. It has no other way to: that launch carries no
+ * ``agent_settings``, and the server resolves public skills from a git clone
+ * this client deliberately does not rely on (software-agent-sdk#3979).
+ */
+function buildEnabledBundledSkills(
+  enablement: SkillEnablement = {},
+  invokedCatalogSkill?: string,
+): BundledSkill[] {
+  const isSkillEnabled = buildSkillEnablementFilter(enablement);
+  return buildBundledSkills().filter(
+    (skill) => skill.name === invokedCatalogSkill || isSkillEnabled(skill.name),
+  );
+}
+
 function buildAgentContext(
   agentSettings: SettingsRecord,
   runtimeServicesInfo?: RuntimeServicesInfo | null,
@@ -838,7 +857,6 @@ function buildAgentContext(
     : [];
   const disabledSkills = enablement.disabledSkills ?? [];
   const disabledSkillNames = new Set(disabledSkills);
-  const isSkillEnabled = buildSkillEnablementFilter(enablement);
 
   // The bundled catalog is allow-listed, not deny-listed: it is a build-time
   // snapshot of ~60 skills, so a deny-list puts every future addition into
@@ -850,10 +868,7 @@ function buildAgentContext(
       (skill) =>
         typeof skill.name !== "string" || !disabledSkillNames.has(skill.name),
     ),
-    ...buildBundledSkills().filter(
-      (skill) =>
-        skill.name === invokedCatalogSkill || isSkillEnabled(skill.name),
-    ),
+    ...buildEnabledBundledSkills(enablement, invokedCatalogSkill),
   ];
 
   return {
@@ -1104,7 +1119,10 @@ type AgentSettingsStartConversationPayload = StartConversationPayloadBase & {
   // Deployment context appended to the *resolved* agent's system-message
   // suffix, so it survives the profile path where ``agent_settings`` cannot be
   // sent (``AgentLaunchAdditions``, software-agent-sdk#4030).
-  agent_launch_additions?: { system_message_suffix_append?: string };
+  agent_launch_additions?: {
+    system_message_suffix_append?: string;
+    skills?: BundledSkill[];
+  };
   agent?: never;
 };
 
@@ -1193,10 +1211,16 @@ export function buildStartConversationRequest(
     options.runtimeServicesInfo,
     options.query,
   );
-  // Folded into ``agent_settings`` on the inline path; on the profile path it
-  // has to ride ``agent_launch_additions`` instead (see below).
+  // Folded into ``agent_settings`` on the inline path; on the profile path they
+  // have to ride ``agent_launch_additions`` instead (see below).
   const runtimeServicesSuffix = buildRuntimeServicesSystemSuffix(
     options.runtimeServicesInfo,
+  );
+  // Same inputs the inline path feeds buildAgentContext, so the two paths
+  // resolve an identical set.
+  const launchSkills = buildEnabledBundledSkills(
+    toSkillEnablement(options.settings),
+    findInvokedCatalogSkill(options.query),
   );
   const acpServerTag = acpMode
     ? getAcpServerTag(sourceAgentSettings)
@@ -1247,10 +1271,13 @@ export function buildStartConversationRequest(
     ...(options.agentProfileId
       ? {
           agent_profile_id: options.agentProfileId,
-          ...(runtimeServicesSuffix
+          ...(runtimeServicesSuffix || launchSkills.length
             ? {
                 agent_launch_additions: {
-                  system_message_suffix_append: runtimeServicesSuffix,
+                  ...(runtimeServicesSuffix
+                    ? { system_message_suffix_append: runtimeServicesSuffix }
+                    : {}),
+                  ...(launchSkills.length ? { skills: launchSkills } : {}),
                 },
               }
             : {}),


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

<!-- Human contributors: add a short note about your testing. -->

---

AGENT:

> **Stacked on #17279** — review that first; the diff here is the last commit only.
> **Requires OpenHands/software-agent-sdk#4960**, which adds the channel this uses.

## Why

A conversation launched from an agent profile received **no public skills**, while the same launch through `agent_settings` received the enabled catalog set. Measured on a stock local stack:

| launch path | public skills |
|---|---|
| inline `agent_settings` | the **11** default-enabled catalog skills |
| `agent_profile_id` | **0** |

Not a bug in either piece — they are two different supply pipelines. Canvas bundles the catalog from `@openhands/extensions` at build time and sets `load_public_skills: false` so the server does not also clone it; the profile path has the server resolve skills itself, from a git clone of that repo which is unpopulated in a dev environment.

The catalog is also smaller than it looks: it holds 60 skills but is *allow-listed*, so a launch injects `DEFAULT_ENABLED_SKILL_NAMES` — 11 — unless the user has set an explicit `enabled_skills`. That was deliberate (#16302): with a build-time snapshot, a deny-list would push every future catalog addition into every system prompt.

This gap is the remaining reason `useCreateConversation` routes the seeded `default` profile around the profile path, which in turn is why per-profile fields set on `default` save cleanly and are then ignored at launch.

## Summary

- `buildEnabledBundledSkills()` — the bundled catalog filtered by the user's enablement — is now the single definition of "which public skills does a launch carry".
- The inline path keeps folding it into `agent_context`; the profile path sends the same list through `agent_launch_additions.skills`, alongside the deployment context #17279 put there.
- Both derive it from the same inputs (`toSkillEnablement(settings)`, `findInvokedCatalogSkill(query)`), so an explicit `enabled_skills`, a deny-listed skill, and a skill invoked by name in the opening message all behave identically on either path.

Server-side merge rules (software-agent-sdk#4960): the resolved agent wins a name collision, and the profile's `disabled_skills` deny-list is re-applied after the merge — so this cannot reintroduce a skill the profile turned off.

## Issue Number

Part of OpenHands/software-agent-sdk#3979

## How to Test

```bash
npm ci && npm test && npm run lint     # 5631 tests pass; lint + typecheck clean
```

End-to-end needs an agent-server built from software-agent-sdk#4960:

```bash
OH_AGENT_SERVER_LOCAL_PATH=/path/to/software-agent-sdk npm run dev:minimal
```

Create a named agent profile, start a conversation from it, and check the conversation's `agent.agent_context.skills` — it should hold the same set an inline launch gets, rather than being empty.

## Video/Screenshots

The parity is asserted directly rather than described — the test builds both payloads from identical inputs and compares the resolved names:

```ts
const inlineNames  = inline.agent_settings.agent_context.skills.map(s => s.name).sort();
const profileNames = viaProfile.agent_launch_additions?.skills?.map(s => s.name).sort();

expect(profileNames.length).toBeGreaterThan(0);
expect(profileNames).toEqual(inlineNames);
```

It fails if either path drifts, which is the property worth holding rather than a fixed count that would rot as the catalog changes.

Suite: **5631 passed**, lint and typecheck clean.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **This does not itself settle which catalog wins.** It makes the client's bundle reach both of the client's own launch paths. Whether the server's clone should own the catalog instead is OpenHands/software-agent-sdk#3979, where I have added the measured trade-off — the bundle exists because the clone has latency, and the two can drift in *version*, not only content.
- **The `default`-profile branch can go once this lands**, since both of its stated reasons are then handled. I have left it in place here: removing it changes the home-launch path for every local user, which deserves its own change rather than riding along with a skills fix.
- **Merge order:** software-agent-sdk#4960 released → bump the agent-server pin → this. Until then the field is simply ignored by an older server, so this is additive rather than breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
