### PR TITLE
fix(chat): support automatic RTL message direction

### DIFF
--- a/__tests__/components/chat-message.test.tsx
+++ b/__tests__/components/chat-message.test.tsx
@@ -135,6 +135,19 @@ describe("ChatMessage", () => {
     expect(screen.getByText("Hello, World!")).toBeInTheDocument();
   });
 
+  it.each(["user", "agent"] as const)(
+    "lets the browser resolve direction for a %s message",
+    (type) => {
+      render(<ChatMessage type={type} message="سلام C:\\workspace" />);
+
+      expect(screen.getByTestId(`${type}-message`)).toHaveAttribute(
+        "dir",
+        "auto",
+      );
+      expect(screen.getByTestId(`${type}-message`)).toHaveClass("text-start");
+    },
+  );
+
   it("should support code syntax highlighting", () => {
     const code = "```js\nconsole.log('Hello, World!')\n```";
     render(<ChatMessage type="user" message={code} />);

--- a/__tests__/components/features/chat/components/chat-input-field.test.tsx
+++ b/__tests__/components/features/chat/components/chat-input-field.test.tsx
@@ -18,6 +18,13 @@ function Harness({ disabled }: { disabled: boolean }) {
 }
 
 describe("ChatInputField auto-focus", () => {
+  it("lets the browser resolve input direction from the entered text", () => {
+    renderWithProviders(<Harness disabled={false} />);
+
+    expect(screen.getByTestId("chat-input")).toHaveAttribute("dir", "auto");
+    expect(screen.getByTestId("chat-input")).toHaveClass("text-start");
+  });
+
   it("focuses the chat input on mount when enabled", () => {
     renderWithProviders(<Harness disabled={false} />);
 

--- a/__tests__/components/features/markdown/code.test.tsx
+++ b/__tests__/components/features/markdown/code.test.tsx
@@ -7,7 +7,8 @@ describe("code (markdown)", () => {
   it("should render inline code without a copy button", () => {
     render(<Code>inline snippet</Code>);
 
-    expect(screen.getByText("inline snippet")).toBeInTheDocument();
+    expect(screen.getByText("inline snippet")).toHaveAttribute("dir", "ltr");
+    expect(screen.getByText("inline snippet")).toHaveClass("text-left");
     expect(screen.queryByTestId("copy-to-clipboard")).not.toBeInTheDocument();
   });
 
@@ -15,12 +16,19 @@ describe("code (markdown)", () => {
     render(<Code>{"line1\nline2"}</Code>);
 
     expect(screen.getByText("line1 line2")).toBeInTheDocument();
+    expect(screen.getByText("line1 line2").closest("pre")).toHaveAttribute(
+      "dir",
+      "ltr",
+    );
     expect(screen.getByTestId("copy-to-clipboard")).toBeInTheDocument();
   });
 
   it("should render a syntax-highlighted block with a copy button", () => {
-    render(<Code className="language-js">{"console.log('hi')"}</Code>);
+    const { container } = render(
+      <Code className="language-js">{"console.log('hi')"}</Code>,
+    );
 
+    expect(container.querySelector('[dir="ltr"]')).toHaveClass("text-left");
     expect(screen.getByTestId("copy-to-clipboard")).toBeInTheDocument();
   });
 

--- a/__tests__/components/features/markdown/table.test.tsx
+++ b/__tests__/components/features/markdown/table.test.tsx
@@ -67,6 +67,15 @@ describe("table (markdown)", () => {
     expect(headers[2]).toHaveTextContent("Claude Code");
   });
 
+  it("uses logical alignment for headers so RTL tables align correctly", () => {
+    render(<MarkdownRenderer>{GFM_TABLE}</MarkdownRenderer>);
+
+    for (const header of screen.getAllByRole("columnheader")) {
+      expect(header).toHaveClass("text-start");
+      expect(header).not.toHaveClass("text-left");
+    }
+  });
+
   it("should render body cells as <td> elements with correct content", () => {
     render(<MarkdownRenderer>{GFM_TABLE}</MarkdownRenderer>);
 

--- a/src/components/features/chat/chat-message.tsx
+++ b/src/components/features/chat/chat-message.tsx
@@ -146,10 +146,11 @@ export function ChatMessage({
     <article
       data-testid={`${type}-message`}
       data-pending-status={pendingStatus}
+      dir="auto"
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       className={cn(
-        "rounded-xl relative w-fit max-w-full flex flex-col",
+        "rounded-xl relative w-fit max-w-full flex flex-col text-start",
         hasBubbleChildren && "gap-2",
         type === "user" && "mt-6 bg-tertiary self-end px-4 py-2.5",
         type === "agent" && "mt-6 w-full max-w-full bg-transparent",

--- a/src/components/features/chat/components/chat-input-field.tsx
+++ b/src/components/features/chat/components/chat-input-field.tsx
@@ -45,11 +45,12 @@ export function ChatInputField({
       className="box-border content-stretch flex flex-row items-center justify-start min-h-6 p-0 relative shrink-0 flex-1"
       data-name="Text & caret"
     >
-      <div className="basis-0 flex flex-col font-normal grow justify-center leading-[0] min-h-px min-w-px overflow-ellipsis overflow-hidden relative shrink-0 text-[var(--oh-text-tertiary)] text-[16px] text-left">
+      <div className="basis-0 flex flex-col font-normal grow justify-center leading-[0] min-h-px min-w-px overflow-ellipsis overflow-hidden relative shrink-0 text-[var(--oh-text-tertiary)] text-[16px]">
         <div
           ref={chatInputRef}
+          dir="auto"
           className={cn(
-            "chat-input bg-transparent text-white text-[16px] font-normal leading-[20px] outline-none resize-none custom-scrollbar min-h-[20px] max-h-[400px] [text-overflow:inherit] [text-wrap-mode:inherit] [white-space-collapse:inherit] block whitespace-pre-wrap",
+            "chat-input bg-transparent text-white text-[16px] text-start font-normal leading-[20px] outline-none resize-none custom-scrollbar min-h-[20px] max-h-[400px] [text-overflow:inherit] [text-wrap-mode:inherit] [white-space-collapse:inherit] block whitespace-pre-wrap",
             disabled && "cursor-not-allowed opacity-50",
           )}
           contentEditable={!disabled}

--- a/src/components/features/markdown/code.tsx
+++ b/src/components/features/markdown/code.tsx
@@ -25,9 +25,10 @@ export function code({
     if (!isMultiline) {
       return (
         <code
+          dir="ltr"
           className={cn(
             className,
-            "bg-surface-raised text-foreground border border-surface-raised rounded px-[0.4em] py-[0.2em]",
+            "bg-surface-raised text-foreground border border-surface-raised rounded px-[0.4em] py-[0.2em] text-left",
           )}
         >
           {children}
@@ -37,7 +38,10 @@ export function code({
 
     return (
       <CopyableContentWrapper text={codeString}>
-        <pre className="bg-surface-raised text-foreground border border-surface-raised rounded p-[1em] overflow-auto">
+        <pre
+          dir="ltr"
+          className="bg-surface-raised text-foreground border border-surface-raised rounded p-[1em] overflow-auto text-left"
+        >
           <code className={className}>{codeString}</code>
         </pre>
       </CopyableContentWrapper>
@@ -46,14 +50,16 @@ export function code({
 
   return (
     <CopyableContentWrapper text={codeString}>
-      <SyntaxHighlighter
-        className="rounded-lg"
-        style={vscDarkPlus}
-        language={match?.[1]}
-        PreTag="div"
-      >
-        {codeString}
-      </SyntaxHighlighter>
+      <div dir="ltr" className="text-left">
+        <SyntaxHighlighter
+          className="rounded-lg"
+          style={vscDarkPlus}
+          language={match?.[1]}
+          PreTag="div"
+        >
+          {codeString}
+        </SyntaxHighlighter>
+      </div>
     </CopyableContentWrapper>
   );
 }

--- a/src/components/features/markdown/table.tsx
+++ b/src/components/features/markdown/table.tsx
@@ -31,7 +31,7 @@ export function th({
   React.ThHTMLAttributes<HTMLTableCellElement> &
   ExtraProps) {
   return (
-    <th className="whitespace-nowrap border-[var(--oh-border)] bg-[var(--oh-surface)] px-3 py-2 text-left font-semibold text-white">
+    <th className="whitespace-nowrap border-[var(--oh-border)] bg-[var(--oh-surface)] px-3 py-2 text-start font-semibold text-white">
       {children}
     </th>
   );


### PR DESCRIPTION
HUMAN:

I verified the chat UI with Persian and English messages. Persian content renders RTL, while English text and code blocks remain LTR, with table headers aligned correctly.

---

AGENT:

## Why

Chat messages and the composer currently use fixed left-to-right alignment, which makes Persian and Arabic conversations difficult to read. Message direction should follow the content while embedded code stays left-to-right.

## Summary

- Let user and agent messages, plus the composer, resolve direction from their content.
- Use logical alignment for Markdown table headers while keeping inline, multiline, and highlighted code explicitly LTR.
- Add focused regressions for message, input, table, and code direction behavior.

## Issue Number

Fixes #17287

## How to Test

1. Install the locked dependency tree with `npm ci`.
2. Run `npm test -- __tests__/components/chat-message.test.tsx __tests__/components/features/chat/components/chat-input-field.test.tsx __tests__/components/features/markdown/code.test.tsx __tests__/components/features/markdown/table.test.tsx`.
3. Run `npm run typecheck:staged`.
4. Run `npm run build:mock`.
5. Run `npm run dev:mock -- --host 127.0.0.1`, configure the local mock backend, open `/conversations/table-demo?backend=default-local`, and inspect Persian and English messages, a code block, and a table.

Observed results: all 34 focused tests passed, type checking passed, and the mock production build passed. On the real mock route, Persian user and agent messages resolved to RTL with logical start alignment; English messages remained LTR; code remained LTR and left-aligned; and the Persian table header used logical start alignment.

## Video/Screenshots

![Persian RTL and English LTR chat rendering verification](https://raw.githubusercontent.com/zyz619963502zyz/OpenHands/pr-assets/openhands-17294/rtl-ltr-chat-route.png)

Verified on the real mock route with Persian and English messages, a shell code block, and a Persian table header.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No dependencies, lockfiles, configuration, or API contracts changed.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.52s · commit 2f63d77  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 10/10 hunks, 8/8 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 2.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 2.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 9.0% | No direct hunk selected |
| Data loss | 2.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 98.0% | No primary concern to locate |

</details>


<!-- jev-input-signature f150676cce2000eb36d5cc327bc3d6a7dd068a91e0b70bc48873b2fe843aef4f -->
<!-- jev-fast-audit:end -->
