### PR TITLE
fix: recognize Azure DevOps SSH remotes

### DIFF
--- a/__tests__/utils/azure-devops-remote-links.test.ts
+++ b/__tests__/utils/azure-devops-remote-links.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseGitRemoteUrl } from "#/utils/parse-git-remote-url";
+import { constructBranchUrl } from "#/utils/utils";
+
+// Spans both modules on purpose: a remote is only useful once the parsed
+// fields reach a link builder, and an Azure DevOps SSH remote used to parse
+// into values `constructBranchUrl` could not build from.
+function branchLinkFor(remoteUrl: string, branch: string): string {
+  const parsed = parseGitRemoteUrl(remoteUrl);
+  if (!parsed?.provider) return "";
+  return constructBranchUrl(
+    parsed.provider,
+    parsed.repository ?? "",
+    branch,
+    parsed.host,
+  );
+}
+
+describe("Azure DevOps remotes resolve a browsable branch link", () => {
+  const expected =
+    "https://dev.azure.com/myorg/myproject/_git/myrepo?version=GBmain";
+
+  it("builds a branch link from an HTTPS remote", () => {
+    expect(
+      branchLinkFor(
+        "https://dev.azure.com/myorg/myproject/_git/myrepo",
+        "main",
+      ),
+    ).toBe(expected);
+  });
+
+  it("builds the same branch link from the SSH remote", () => {
+    expect(
+      branchLinkFor("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo", "main"),
+    ).toBe(expected);
+  });
+
+  it("builds the same branch link from a legacy visualstudio.com SSH remote", () => {
+    expect(
+      branchLinkFor(
+        "git@vs-ssh.visualstudio.com:v3/myorg/myproject/myrepo",
+        "main",
+      ),
+    ).toBe(expected);
+  });
+});

--- a/__tests__/utils/parse-git-remote-url.test.ts
+++ b/__tests__/utils/parse-git-remote-url.test.ts
@@ -127,6 +127,15 @@ describe("parseGitRemoteUrl", () => {
     expect(result?.repository).toBe("org/project/repo");
   });
 
+  it("parses Azure DevOps ssh:// URLs that carry an explicit port", () => {
+    const result = parseGitRemoteUrl(
+      "ssh://git@ssh.dev.azure.com:22/v3/org/project/repo",
+    );
+    expect(result?.host).toBe("dev.azure.com");
+    expect(result?.provider).toBe("azure_devops");
+    expect(result?.repository).toBe("org/project/repo");
+  });
+
   it("parses legacy visualstudio.com SSH URLs", () => {
     const result = parseGitRemoteUrl(
       "git@vs-ssh.visualstudio.com:v3/org/project/repo",

--- a/__tests__/utils/parse-git-remote-url.test.ts
+++ b/__tests__/utils/parse-git-remote-url.test.ts
@@ -135,6 +135,13 @@ describe("parseGitRemoteUrl", () => {
     expect(result?.repository).toBe("org/project/repo");
   });
 
+  it("keeps an Azure DevOps organization actually named v3", () => {
+    const result = parseGitRemoteUrl(
+      "https://dev.azure.com/v3/project/_git/repo",
+    );
+    expect(result?.repository).toBe("v3/project/repo");
+  });
+
   it("preserves nested paths for unknown self-hosted hosts", () => {
     const result = parseGitRemoteUrl(
       "https://git.example.com/group/subgroup/repo.git",
@@ -153,5 +160,11 @@ describe("parseGitRemoteUrl", () => {
 
   it("returns null for unparseable strings", () => {
     expect(parseGitRemoteUrl("not a url")).toBeNull();
+  });
+
+  it("treats a host named after an Object.prototype member as a plain host", () => {
+    const result = parseGitRemoteUrl("http://constructor/owner/repo.git");
+    expect(result?.host).toBe("constructor");
+    expect(result?.repository).toBe("owner/repo");
   });
 });

--- a/__tests__/utils/parse-git-remote-url.test.ts
+++ b/__tests__/utils/parse-git-remote-url.test.ts
@@ -110,6 +110,31 @@ describe("parseGitRemoteUrl", () => {
     expect(result?.repository).toBe("org/project/repo");
   });
 
+  it("parses Azure DevOps SSH URLs, dropping the v3 prefix", () => {
+    const result = parseGitRemoteUrl(
+      "git@ssh.dev.azure.com:v3/org/project/repo",
+    );
+    expect(result?.provider).toBe("azure_devops");
+    expect(result?.repository).toBe("org/project/repo");
+  });
+
+  it("parses Azure DevOps ssh:// URLs", () => {
+    const result = parseGitRemoteUrl(
+      "ssh://git@ssh.dev.azure.com/v3/org/project/repo",
+    );
+    expect(result?.host).toBe("dev.azure.com");
+    expect(result?.provider).toBe("azure_devops");
+    expect(result?.repository).toBe("org/project/repo");
+  });
+
+  it("parses legacy visualstudio.com SSH URLs", () => {
+    const result = parseGitRemoteUrl(
+      "git@vs-ssh.visualstudio.com:v3/org/project/repo",
+    );
+    expect(result?.provider).toBe("azure_devops");
+    expect(result?.repository).toBe("org/project/repo");
+  });
+
   it("preserves nested paths for unknown self-hosted hosts", () => {
     const result = parseGitRemoteUrl(
       "https://git.example.com/group/subgroup/repo.git",

--- a/src/utils/parse-git-remote-url.ts
+++ b/src/utils/parse-git-remote-url.ts
@@ -3,7 +3,11 @@ import { Provider } from "#/types/settings";
 export interface ParsedGitRemoteUrl {
   /** Original URL, trimmed. */
   url: string;
-  /** Hostname of the remote (e.g. `github.com`, `git.example.com`). */
+  /**
+   * Browsable hostname of the remote (e.g. `github.com`, `git.example.com`).
+   * Hosts that only serve SSH are mapped to their web equivalent, so callers
+   * can build links from this directly. `url` keeps the original remote.
+   */
   host: string | null;
   /** Path-style identifier, normalized to `owner/repo` (no leading slash, no `.git` suffix). */
   repository: string | null;
@@ -18,6 +22,19 @@ const KNOWN_HOSTS: Record<string, Provider> = {
   "dev.azure.com": "azure_devops",
 };
 
+// Hosts that serve git over SSH only, mapped to the host that serves the same
+// repositories over the web. Azure DevOps hands out `ssh.dev.azure.com` (and
+// `vs-ssh.visualstudio.com` for legacy organizations) in its SSH clone URLs,
+// neither of which resolves a browsable page.
+const SSH_WEB_HOSTS: Record<string, string> = {
+  "ssh.dev.azure.com": "dev.azure.com",
+  "vs-ssh.visualstudio.com": "dev.azure.com",
+};
+
+function toWebHost(host: string): string {
+  return SSH_WEB_HOSTS[host.toLowerCase()] ?? host;
+}
+
 function stripGitSuffix(path: string): string {
   return path.replace(/\.git$/, "");
 }
@@ -28,10 +45,11 @@ function detectProvider(host: string | null): Provider | null {
 }
 
 function normalizeAzureDevOpsPath(path: string): string {
-  // Azure paths look like `org/project/_git/repo` or `org/_git/repo`.
-  // Normalize to `org/project/repo` (or `org/repo`) so it lines up with
-  // constructBranchUrl's expectations.
+  // Azure paths look like `org/project/_git/repo` or `org/_git/repo` over
+  // HTTPS, and `v3/org/project/repo` over SSH. Normalize to `org/project/repo`
+  // (or `org/repo`) so it lines up with constructBranchUrl's expectations.
   const segments = path.split("/").filter(Boolean);
+  if (segments[0] === "v3") segments.shift();
   const gitIndex = segments.indexOf("_git");
   if (gitIndex === -1) return segments.join("/");
   return [...segments.slice(0, gitIndex), ...segments.slice(gitIndex + 1)].join(
@@ -41,9 +59,10 @@ function normalizeAzureDevOpsPath(path: string): string {
 
 function buildParsedGitRemoteUrl(
   url: string,
-  host: string | null,
+  rawHost: string | null,
   rawPath: string,
 ): ParsedGitRemoteUrl {
+  const host = rawHost ? toWebHost(rawHost) : rawHost;
   const path = stripGitSuffix(rawPath.replace(/^\/+|\/+$/g, ""));
   const provider = detectProvider(host);
   const repository =

--- a/src/utils/parse-git-remote-url.ts
+++ b/src/utils/parse-git-remote-url.ts
@@ -32,7 +32,10 @@ const SSH_WEB_HOSTS: Record<string, string> = {
 };
 
 function toWebHost(host: string): string {
-  return SSH_WEB_HOSTS[host.toLowerCase()] ?? host;
+  const lower = host.toLowerCase();
+  // hasOwn, so a host named after an Object.prototype member (`constructor`)
+  // resolves to itself rather than to an inherited value.
+  return Object.hasOwn(SSH_WEB_HOSTS, lower) ? SSH_WEB_HOSTS[lower] : host;
 }
 
 function stripGitSuffix(path: string): string {
@@ -49,9 +52,13 @@ function normalizeAzureDevOpsPath(path: string): string {
   // HTTPS, and `v3/org/project/repo` over SSH. Normalize to `org/project/repo`
   // (or `org/repo`) so it lines up with constructBranchUrl's expectations.
   const segments = path.split("/").filter(Boolean);
-  if (segments[0] === "v3") segments.shift();
   const gitIndex = segments.indexOf("_git");
-  if (gitIndex === -1) return segments.join("/");
+  if (gitIndex === -1) {
+    // Only the SSH form carries the `v3` prefix, and it never carries `_git`.
+    // Checking that first leaves an organization actually named `v3` alone.
+    if (segments[0] === "v3") segments.shift();
+    return segments.join("/");
+  }
   return [...segments.slice(0, gitIndex), ...segments.slice(gitIndex + 1)].join(
     "/",
   );


### PR DESCRIPTION
HUMAN:

Tested locally: I pointed a throwaway repo's origin at an Azure DevOps SSH URL
and opened it as a workspace. Before the change the control bar showed the repo
as `v3/myorg/myproject/myrepo` with no branch link; after it, the name is right
and the Pull / Push / Pull Request actions show up. Screenshots below.

---

AGENT:

## Why

Azure DevOps serves SSH clones from a different host than its web UI:

```
git@ssh.dev.azure.com:v3/myorg/myproject/myrepo
```

`parseGitRemoteUrl` only knew the HTTPS host `dev.azure.com`, so an SSH remote
took the unknown-host branch: `provider` came back `null` and the `v3/` stayed
in the repository string.

Both link builders read those fields, so a workspace on an Azure SSH remote
showed `v3/myorg/myproject/myrepo` as its repository name and got no branch
link. `constructBranchUrl` wants three segments for `azure_devops` and got
four, so it returned `""`. `browseUrlFor` in the Git Sync section built
`https://ssh.dev.azure.com/v3/...`, against a host that only speaks SSH.

## Summary

- Map SSH-only hosts to their web equivalent before detecting the provider, so
  `ssh.dev.azure.com` (and legacy `vs-ssh.visualstudio.com`) resolve
  `azure_devops` and hand callers a host they can build links from.
- Drop a leading `v3` segment when normalizing Azure paths, but only when the
  path carries no `_git`, so an organization actually named `v3` on an HTTPS
  remote is left alone.
- Add tests for the three SSH forms, for the `v3` organization case, and one
  test that both remote forms for the same repo produce the same branch link.

HTTPS Azure remotes and the other providers are untouched. `url` still carries
the original remote, so the real SSH host isn't lost.

## Issue Number

Fixes #17373

## How to Test

No Azure DevOps account needed: the remote URL is only ever read
(`git remote get-url origin`), never contacted.

```bash
mkdir azure-ssh-repro && cd azure-ssh-repro
git init -b main && git commit --allow-empty -m "init"
git remote add origin git@ssh.dev.azure.com:v3/myorg/myproject/myrepo
```

Then `npm install && npm run dev`, open http://localhost:8000, add that folder
as a workspace on a local backend, and start a conversation on it. The
repository chip reads `myorg/myproject/myrepo` and the branch chip links to
`https://dev.azure.com/myorg/myproject/_git/myrepo?version=GBmain`.

Unit tests:

```bash
npm run make-i18n && npx vitest run __tests__/utils/parse-git-remote-url.test.ts __tests__/utils/azure-devops-remote-links.test.ts
```

Full suite is green: 654 files, 5667 tests.

## Video/Screenshots

**Before (on `main`)** — the repository chip carries the `v3/` prefix and the
branch chip has no link:

<img width="1866" height="452" alt="azure-ssh-bug-avant" src="https://github.com/user-attachments/assets/52cb8a11-2b48-4651-ad8d-1bbfedc9d7a2" />


**After (this branch)** — correct repository name, and the git actions appear:

<img width="1628" height="414" alt="azure-ssh-bug-apres" src="https://github.com/user-attachments/assets/8c7f4c66-d7d6-453a-b053-b23ff39244cf" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change

