### PR TITLE
fix: secrets settings — don't discard failed saves, surface real errors, don't hide load failures

### DIFF
--- a/__tests__/api/secrets-service.test.ts
+++ b/__tests__/api/secrets-service.test.ts
@@ -132,4 +132,29 @@ describe("SecretsService", () => {
     });
     expect(mockDeleteSecret).toHaveBeenCalledWith("Old_Key");
   });
+
+  it("surfaces a distinct, actionable error when the rename's cleanup delete fails", async () => {
+    // Regression: the new entry saves successfully, but if removing the old
+    // one then fails, this must not look like the whole rename failed (it
+    // didn't — the new secret exists) or succeed silently (the old, now
+    // possibly-stale entry keeps existing indefinitely with no visible
+    // sign). The caller needs to know exactly what happened.
+    mockGetSecret.mockResolvedValue("original-value");
+    mockUpsertSecret.mockResolvedValue({
+      name: "New_Key",
+      description: "Renamed",
+    });
+    mockDeleteSecret.mockRejectedValue(new Error("500 Internal Server Error"));
+
+    await expect(
+      SecretsService.updateSecret("Old_Key", "New_Key", "Renamed"),
+    ).rejects.toThrow(/New_Key.*Old_Key.*500 Internal Server Error/s);
+
+    // The new entry was still created — this isn't a total failure.
+    expect(mockUpsertSecret).toHaveBeenCalledWith({
+      name: "New_Key",
+      value: "original-value",
+      description: "Renamed",
+    });
+  });
 });

--- a/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
+++ b/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
@@ -664,6 +664,28 @@ describe("SdkSectionPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides the basic toggle when hideBasicView is set, even for a critical schema", async () => {
+    // A section whose Basic-tier controls can't represent the current value
+    // at all (e.g. an LLM profile linked to a provider connection) needs
+    // Basic unreachable, not just skipped on initial load — its schema still
+    // has critical fields, so showBasic alone would keep the tab clickable.
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSavableSettings(),
+    );
+
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
+      hideBasicView: true,
+    });
+
+    await screen.findByTestId("sdk-settings-llm.endpoint");
+    expect(
+      screen.queryByTestId("sdk-section-basic-toggle"),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the all toggle instead of an empty advanced tier for minor-only schemas", async () => {
     const schema: NonNullable<Settings["agent_settings_schema"]> = {
       model_name: "AgentSettings",

--- a/__tests__/components/features/settings/secrets-settings/secret-form.test.tsx
+++ b/__tests__/components/features/settings/secrets-settings/secret-form.test.tsx
@@ -6,7 +6,7 @@ import { SecretForm } from "#/components/features/settings/secrets-settings/secr
 import { renderWithProviders } from "../../../../../test-utils";
 
 const renderEditForm = async () => {
-  vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
+  vi.spyOn(SecretsService, "getSecretsOrThrow").mockResolvedValue([
     { name: "API_KEY", description: "Demo secret" },
   ]);
   const updateSecret = vi
@@ -80,5 +80,40 @@ describe("SecretForm in edit mode", () => {
         "sk-new-value",
       ),
     );
+  });
+
+  it("stays on the form and shows the real error when the save fails, instead of navigating away like a success", async () => {
+    // Regression: onSettled fired on both success and error, so a failed
+    // save closed the form and returned to the list exactly as if it had
+    // saved — the typed value was gone with no visible sign anything failed.
+    vi.spyOn(SecretsService, "getSecretsOrThrow").mockResolvedValue([
+      { name: "API_KEY", description: "Demo secret" },
+    ]);
+    vi.spyOn(SecretsService, "updateSecret").mockRejectedValue(
+      new Error("Secret name already in use"),
+    );
+    const onCancel = vi.fn();
+
+    renderWithProviders(
+      <SecretForm mode="edit" selectedSecret="API_KEY" onCancel={onCancel} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("description-input")).toHaveValue(
+        "Demo secret",
+      ),
+    );
+
+    await userEvent.type(screen.getByTestId("value-input"), "sk-new-value");
+    await userEvent.click(screen.getByTestId("submit-button"));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Secret name already in use"),
+      ).toBeInTheDocument(),
+    );
+    expect(onCancel).not.toHaveBeenCalled();
+    // The typed value is still there — nothing was discarded.
+    expect(screen.getByTestId("value-input")).toHaveValue("sk-new-value");
   });
 });

--- a/__tests__/components/features/settings/secrets-settings/secret-list-item.test.tsx
+++ b/__tests__/components/features/settings/secrets-settings/secret-list-item.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SecretListItem } from "#/components/features/settings/secrets-settings/secret-list-item";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const translations: Record<string, string> = {
+        SECRETS$EDIT_SECRET_ARIA: params?.name ? `Edit ${params.name}` : "Edit",
+        SECRETS$DELETE_SECRET_ARIA: params?.name
+          ? `Delete ${params.name}`
+          : "Delete",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe("SecretListItem", () => {
+  it("labels the edit and delete buttons through i18n, with the secret name interpolated", () => {
+    // Regression: these were hardcoded English template literals
+    // (`Edit ${title}` / `Delete ${title}`), the only place in this feature
+    // area that bypassed t()/I18nKey.
+    render(
+      <table>
+        <tbody>
+          <SecretListItem
+            title="OPENAI_API_KEY"
+            description="Demo"
+            onEdit={vi.fn()}
+            onDelete={vi.fn()}
+          />
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.getByTestId("edit-secret-button")).toHaveAttribute(
+      "aria-label",
+      "Edit OPENAI_API_KEY",
+    );
+    expect(screen.getByTestId("delete-secret-button")).toHaveAttribute(
+      "aria-label",
+      "Delete OPENAI_API_KEY",
+    );
+  });
+});

--- a/__tests__/components/settings/key-status-icon.test.tsx
+++ b/__tests__/components/settings/key-status-icon.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { KeyStatusIcon } from "#/components/features/settings/key-status-icon";
+
+describe("KeyStatusIcon", () => {
+  it("exposes accessible text for the set state by default", () => {
+    render(<KeyStatusIcon isSet />);
+    const icon = screen.getByTestId("set-indicator");
+    expect(icon).toHaveAttribute("aria-label", "API key set");
+    expect(icon).toHaveAttribute("title", "API key set");
+  });
+
+  it("exposes accessible text for the unset state by default", () => {
+    render(<KeyStatusIcon isSet={false} />);
+    const icon = screen.getByTestId("unset-indicator");
+    expect(icon).toHaveAttribute("aria-label", "API key not set");
+    expect(icon).toHaveAttribute("title", "API key not set");
+  });
+
+  it("uses a caller-supplied label instead of the generic default", () => {
+    // A standalone status icon (no adjacent key field for context, e.g. a
+    // provider connection row) needs a label that doesn't imply more than
+    // "a key string is stored" — this never pings the provider.
+    const label = "API key stored (not verified against the provider)";
+    render(<KeyStatusIcon isSet label={label} />);
+    const icon = screen.getByTestId("set-indicator");
+    expect(icon).toHaveAttribute(
+      "aria-label",
+      "API key stored (not verified against the provider)",
+    );
+  });
+});

--- a/__tests__/components/settings/llm-profiles/bulk-add-models-modal.test.tsx
+++ b/__tests__/components/settings/llm-profiles/bulk-add-models-modal.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BulkAddModelsModal } from "#/components/features/settings/llm-profiles/bulk-add-models-modal";
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
+import ProfilesService from "#/api/profiles-service/profiles-service.api";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const translations: Record<string, string> = {
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TITLE: "Bulk add models",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TEXTAREA_LABEL: "Model IDs",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_HINT: "Paste model IDs.",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_PREVIEW:
+          "{{create}} new, {{skip}} already exist",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_SUBMIT:
+          "Create {{count}} profile(s)",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_CREATED:
+          "Created {{count}} profile(s)",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_FAILED:
+          "Failed: {{names}}",
+        BUTTON$CANCEL: "Cancel",
+        BUTTON$CLOSE: "Close",
+        ERROR$GENERIC: "An error occurred",
+      };
+      let result = translations[key] || key;
+      if (params) {
+        for (const [paramKey, value] of Object.entries(params)) {
+          result = result.replace(`{{${paramKey}}}`, String(value));
+        }
+      }
+      return result;
+    },
+  }),
+}));
+
+vi.mock("#/api/profiles-service/profiles-service.api");
+
+const connection: ProviderConnection = {
+  id: "conn-1",
+  display_name: "Ollama Cloud",
+  provider: "openai",
+  base_url: "https://ollama.com/v1",
+  created_at: 1,
+  updated_at: 2,
+  api_key_set: true,
+};
+
+describe("BulkAddModelsModal", () => {
+  let queryClient: QueryClient;
+
+  const renderModal = (
+    props: Partial<Parameters<typeof BulkAddModelsModal>[0]> = {},
+  ) =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BulkAddModelsModal
+          connection={connection}
+          existingProfileNames={new Set()}
+          onClose={vi.fn()}
+          {...props}
+        />
+      </QueryClientProvider>,
+    );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns null when connection is null", () => {
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <BulkAddModelsModal
+          connection={null}
+          existingProfileNames={new Set()}
+          onClose={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("parses newline- and comma-separated model ids and previews new vs skipped", async () => {
+    const user = userEvent.setup();
+    renderModal({ existingProfileNames: new Set(["gpt-oss-120b-cloud"]) });
+
+    await user.type(
+      screen.getByTestId("bulk-add-models-textarea"),
+      "gpt-oss:120b-cloud,glm-5.3-flash:cloud\nglm-5.3-flash:cloud\nkimi-k3",
+    );
+
+    // gpt-oss:120b-cloud -> already exists (skip), glm-5.3-flash:cloud
+    // appears twice (deduped to one), kimi-k3 is new -> 2 create, 1 skip
+    expect(screen.getByTestId("bulk-add-models-preview")).toHaveTextContent(
+      "2 new, 1 already exist",
+    );
+  });
+
+  it("creates one profile per model id, linked to the connection", async () => {
+    const user = userEvent.setup();
+    vi.mocked(ProfilesService.saveProfile).mockResolvedValue({
+      name: "x",
+      message: "ok",
+    });
+    renderModal();
+
+    await user.type(
+      screen.getByTestId("bulk-add-models-textarea"),
+      "gpt-oss:120b-cloud\nglm-5.3-flash:cloud",
+    );
+    await user.click(screen.getByTestId("bulk-add-models-submit"));
+
+    await waitFor(() => {
+      expect(ProfilesService.saveProfile).toHaveBeenCalledTimes(2);
+    });
+
+    expect(ProfilesService.saveProfile).toHaveBeenCalledWith(
+      "gpt-oss-120b-cloud",
+      {
+        llm: {
+          model: "openai/gpt-oss:120b-cloud",
+          provider_connection_id: "conn-1",
+          auth_type: "api_key",
+          subscription_vendor: null,
+        },
+        include_secrets: true,
+      },
+    );
+    expect(ProfilesService.saveProfile).toHaveBeenCalledWith(
+      "glm-5.3-flash-cloud",
+      {
+        llm: {
+          model: "openai/glm-5.3-flash:cloud",
+          provider_connection_id: "conn-1",
+          auth_type: "api_key",
+          subscription_vendor: null,
+        },
+        include_secrets: true,
+      },
+    );
+
+    await screen.findByTestId("bulk-add-models-result-created");
+    expect(
+      screen.getByTestId("bulk-add-models-result-created"),
+    ).toHaveTextContent("Created 2 profile(s)");
+  });
+
+  it("uses a model id verbatim when it already carries its own provider prefix", async () => {
+    const user = userEvent.setup();
+    vi.mocked(ProfilesService.saveProfile).mockResolvedValue({
+      name: "x",
+      message: "ok",
+    });
+    renderModal();
+
+    await user.type(
+      screen.getByTestId("bulk-add-models-textarea"),
+      "anthropic/claude-x",
+    );
+    await user.click(screen.getByTestId("bulk-add-models-submit"));
+
+    await waitFor(() => {
+      expect(ProfilesService.saveProfile).toHaveBeenCalledWith(
+        "claude-x",
+        expect.objectContaining({
+          llm: expect.objectContaining({ model: "anthropic/claude-x" }),
+        }),
+      );
+    });
+  });
+
+  it("reports per-model failures without blocking the others", async () => {
+    const user = userEvent.setup();
+    vi.mocked(ProfilesService.saveProfile).mockImplementation(
+      async (name: string) => {
+        if (name === "bad-model") throw new Error("model not found");
+        return { name, message: "ok" };
+      },
+    );
+    renderModal();
+
+    await user.type(
+      screen.getByTestId("bulk-add-models-textarea"),
+      "good-model\nbad-model",
+    );
+    await user.click(screen.getByTestId("bulk-add-models-submit"));
+
+    await screen.findByTestId("bulk-add-models-result-created");
+    expect(
+      screen.getByTestId("bulk-add-models-result-created"),
+    ).toHaveTextContent("Created 1 profile(s)");
+    expect(
+      screen.getByTestId("bulk-add-models-result-failed"),
+    ).toHaveTextContent("Failed: bad-model");
+  });
+
+  it("disables submit until at least one new model is parsed", () => {
+    renderModal();
+    expect(screen.getByTestId("bulk-add-models-submit")).toBeDisabled();
+  });
+});

--- a/__tests__/components/settings/llm-profiles/provider-connection-modal.test.tsx
+++ b/__tests__/components/settings/llm-profiles/provider-connection-modal.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ProviderConnectionModal } from "#/components/features/settings/llm-profiles/provider-connection-modal";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        SETTINGS$PROVIDER_CONNECTION_ADD_TITLE: "Add provider connection",
+        SETTINGS$NAME: "Name",
+        SETTINGS$PROVIDER_CONNECTION_PROVIDER: "Provider",
+        SETTINGS_FORM$API_KEY: "API Key",
+        SETTINGS$BASE_URL: "Base URL",
+        BUTTON$SAVE: "Save",
+        BUTTON$CANCEL: "Cancel",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+vi.mock("#/hooks/query/use-search-providers", () => ({
+  useSearchProviders: () => ({
+    data: [{ name: "openai", verified: true }],
+  }),
+}));
+
+vi.mock("#/hooks/mutation/use-create-provider-connection", () => ({
+  useCreateProviderConnection: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("#/hooks/mutation/use-update-provider-connection", () => ({
+  useUpdateProviderConnection: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("ProviderConnectionModal - presets", () => {
+  let queryClient: QueryClient;
+
+  const renderModal = () =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderConnectionModal isCreate connection={null} onClose={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  it("shows a preset chip for Ollama Cloud", () => {
+    renderModal();
+    expect(
+      screen.getByTestId("provider-connection-preset-ollama-cloud"),
+    ).toBeInTheDocument();
+  });
+
+  it("fills the base URL and provider when the Ollama Cloud preset is clicked", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(
+      screen.getByTestId("provider-connection-preset-ollama-cloud"),
+    );
+
+    expect(
+      screen.getByTestId("provider-connection-base-url-input"),
+    ).toHaveValue("https://ollama.com/v1");
+    expect(
+      screen.getByTestId("provider-connection-provider-input"),
+    ).toHaveValue("OpenAI");
+  });
+
+  it("prefills the name from the preset when the name field is still empty", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(
+      screen.getByTestId("provider-connection-preset-ollama-cloud"),
+    );
+
+    expect(screen.getByTestId("provider-connection-name-input")).toHaveValue(
+      "Ollama Cloud",
+    );
+  });
+
+  it("does not overwrite a name the user already typed", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(
+      screen.getByTestId("provider-connection-name-input"),
+      "My custom name",
+    );
+    await user.click(
+      screen.getByTestId("provider-connection-preset-ollama-cloud"),
+    );
+
+    expect(screen.getByTestId("provider-connection-name-input")).toHaveValue(
+      "My custom name",
+    );
+  });
+});

--- a/__tests__/components/settings/llm-profiles/provider-connection-row.test.tsx
+++ b/__tests__/components/settings/llm-profiles/provider-connection-row.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderConnectionRow } from "#/components/features/settings/llm-profiles/provider-connection-row";
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const translations: Record<string, string> = {
+        SETTINGS$PROVIDER_CONNECTION_MODEL_COUNT: "{{count}} model(s)",
+        SETTINGS$PROVIDER_CONNECTION_KEY_SET_LABEL:
+          "API key stored (not verified against the provider)",
+        SETTINGS$PROVIDER_CONNECTION_KEY_UNSET_LABEL: "No API key stored",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_ACTION: "Bulk add models",
+        SETTINGS$PROVIDER_CONNECTION_EDIT_TITLE: "Edit provider connection",
+        SETTINGS$PROVIDER_CONNECTION_DELETE_TITLE: "Delete provider connection",
+      };
+      let result = translations[key] || key;
+      if (params) {
+        for (const [paramKey, value] of Object.entries(params)) {
+          result = result.replace(`{{${paramKey}}}`, String(value));
+        }
+      }
+      return result;
+    },
+  }),
+}));
+
+const baseConnection: ProviderConnection = {
+  id: "conn-1",
+  display_name: "Ollama Cloud",
+  provider: "openai",
+  base_url: "https://ollama.com/v1",
+  created_at: 1,
+  updated_at: 2,
+  api_key_set: true,
+};
+
+describe("ProviderConnectionRow", () => {
+  it("labels the key status icon as 'stored', not 'verified', when a key is set", () => {
+    render(
+      <ProviderConnectionRow
+        connection={baseConnection}
+        linkedProfileCount={3}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onBulkAddModels={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("set-indicator")).toHaveAttribute(
+      "aria-label",
+      "API key stored (not verified against the provider)",
+    );
+  });
+
+  it("labels the key status icon as unset when no key is stored", () => {
+    render(
+      <ProviderConnectionRow
+        connection={{ ...baseConnection, api_key_set: false }}
+        linkedProfileCount={0}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onBulkAddModels={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("unset-indicator")).toHaveAttribute(
+      "aria-label",
+      "No API key stored",
+    );
+  });
+
+  it("calls onBulkAddModels with the connection when the bulk-add button is clicked", () => {
+    const onBulkAddModels = vi.fn();
+    render(
+      <ProviderConnectionRow
+        connection={baseConnection}
+        linkedProfileCount={0}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onBulkAddModels={onBulkAddModels}
+      />,
+    );
+
+    screen.getByTestId("provider-connection-bulk-add").click();
+    expect(onBulkAddModels).toHaveBeenCalledWith(baseConnection);
+  });
+});

--- a/__tests__/routes/llm-settings.test.tsx
+++ b/__tests__/routes/llm-settings.test.tsx
@@ -517,6 +517,35 @@ describe("LlmSettingsScreen - provider connection selector", () => {
       "openai/glm-5.3-flash:cloud",
     );
   });
+
+  it("makes the Basic tab unreachable for a profile linked to a provider connection", async () => {
+    // Companion to the initial-view fix above: even if something else were to
+    // land the form on Basic, the tab itself shouldn't be reachable for a
+    // connection-linked profile — that tier has no way to represent the
+    // connection at all, and its Model dropdown renders blank for any model
+    // absent from the resolved provider's catalog.
+    vi.spyOn(activeBackendContext, "useActiveBackend").mockReturnValue({
+      backend: mockLocalBackend,
+    } as ReturnType<typeof activeBackendContext.useActiveBackend>);
+    vi.spyOn(ProviderConnectionsService, "list").mockResolvedValue([
+      connection,
+    ]);
+
+    renderLlmSettingsScreen({
+      embedded: true,
+      hideSaveButton: true,
+      showProviderConnection: true,
+      initialValueOverrides: {
+        "llm.model": "openai/glm-5.3-flash:cloud",
+        "llm.provider_connection_id": "conn-1",
+      },
+    });
+
+    await screen.findByTestId("llm-settings-screen");
+    expect(
+      screen.queryByTestId("sdk-section-basic-toggle"),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("LlmSettingsScreen - OpenHands provider on cloud", () => {

--- a/__tests__/routes/llm-settings.test.tsx
+++ b/__tests__/routes/llm-settings.test.tsx
@@ -481,6 +481,42 @@ describe("LlmSettingsScreen - provider connection selector", () => {
       await screen.findByTestId("llm-provider-connection-input"),
     ).toBeInTheDocument();
   });
+
+  it("opens on a non-Basic tab when linked to a provider connection, even if the active settings look like Basic defaults (bug repro)", async () => {
+    // Regression: getInitialView used to infer the tab from the globally
+    // active settings only, ignoring initialValueOverrides entirely. A
+    // profile linked to a connection (whose credential/base_url live off
+    // the profile, not inline) would then silently open on the Basic tab
+    // whenever the *active* settings happened to look like a plain default
+    // model — regardless of what the profile being edited actually
+    // contains. On the Basic tab, ModelSelector binds its Model dropdown to
+    // a key absent from the resolved provider's real catalog for any model
+    // string not in that catalog, and HeroUI's Autocomplete silently
+    // rewrites it to an unrelated model once the list loads — corrupting
+    // `llm.model`.
+    vi.spyOn(activeBackendContext, "useActiveBackend").mockReturnValue({
+      backend: mockLocalBackend,
+    } as ReturnType<typeof activeBackendContext.useActiveBackend>);
+    vi.spyOn(ProviderConnectionsService, "list").mockResolvedValue([
+      connection,
+    ]);
+
+    renderLlmSettingsScreen({
+      embedded: true,
+      hideSaveButton: true,
+      showProviderConnection: true,
+      initialValueOverrides: {
+        "llm.model": "openai/glm-5.3-flash:cloud",
+        "llm.provider_connection_id": "conn-1",
+      },
+    });
+
+    await screen.findByTestId("llm-settings-screen");
+    expect(screen.queryByTestId("llm-provider-input")).not.toBeInTheDocument();
+    expect(await screen.findByTestId("llm-custom-model-input")).toHaveValue(
+      "openai/glm-5.3-flash:cloud",
+    );
+  });
 });
 
 describe("LlmSettingsScreen - OpenHands provider on cloud", () => {

--- a/__tests__/routes/secrets-settings.test.tsx
+++ b/__tests__/routes/secrets-settings.test.tsx
@@ -9,9 +9,11 @@ function renderSecretsSettingsScreen() {
   return render(<SecretsSettingsScreen />, {
     wrapper: ({ children }) => (
       <QueryClientProvider
-        client={new QueryClient({
-          defaultOptions: { queries: { retry: false } },
-        })}
+        client={
+          new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+          })
+        }
       >
         {children}
       </QueryClientProvider>
@@ -25,8 +27,8 @@ describe("SecretsSettingsScreen", () => {
   });
 
   it("renders the OSS secrets list for local secrets management", async () => {
-    // Mock getSecrets (used by useSearchSecrets internally)
-    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
+    // Mock getSecretsOrThrow (used by useSearchSecrets internally)
+    vi.spyOn(SecretsService, "getSecretsOrThrow").mockResolvedValue([
       {
         name: "MY_SECRET",
         description: "Demo secret",
@@ -41,7 +43,7 @@ describe("SecretsSettingsScreen", () => {
   });
 
   it("disables Add Secret submit until required fields are filled", async () => {
-    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([]);
+    vi.spyOn(SecretsService, "getSecretsOrThrow").mockResolvedValue([]);
     const user = userEvent.setup();
 
     renderSecretsSettingsScreen();
@@ -63,7 +65,7 @@ describe("SecretsSettingsScreen", () => {
   });
 
   it("disables Edit Secret submit until a field changes", async () => {
-    vi.spyOn(SecretsService, "getSecrets").mockResolvedValue([
+    vi.spyOn(SecretsService, "getSecretsOrThrow").mockResolvedValue([
       {
         name: "MY_SECRET",
         description: "Demo secret",
@@ -84,5 +86,21 @@ describe("SecretsSettingsScreen", () => {
 
     await user.type(descriptionInput, " updated");
     expect(submitButton).not.toBeDisabled();
+  });
+
+  it("shows a load-error state instead of the empty state when fetching secrets fails", async () => {
+    // Regression: the hook used to swallow a fetch failure into an empty
+    // array, so a real error (network, backend down) rendered as the plain
+    // "you have no secrets yet" empty state with no indication anything
+    // went wrong.
+    vi.spyOn(SecretsService, "getSecretsOrThrow").mockRejectedValue(
+      new Error("network down"),
+    );
+
+    renderSecretsSettingsScreen();
+
+    await screen.findByTestId("secrets-settings-screen");
+    expect(await screen.findByTestId("secrets-load-error")).toBeInTheDocument();
+    expect(screen.queryByTestId("secrets-empty")).not.toBeInTheDocument();
   });
 });

--- a/src/api/secrets-service.ts
+++ b/src/api/secrets-service.ts
@@ -116,7 +116,25 @@ export class SecretsService {
     );
 
     if (name !== secretToEdit) {
-      await this.deleteSecret(secretToEdit);
+      // Upsert-then-delete, not the reverse: if this delete fails, the
+      // caller ends up with an extra (stale-named) entry to clean up
+      // manually — bad, but recoverable. Deleting first and having the
+      // upsert then fail would lose the secret's value outright, which is
+      // worse. Either way, a delete failure here must not look like the
+      // whole rename failed (the new entry did save) or succeed silently
+      // (the old, possibly since-rotated value would keep existing under
+      // its old name indefinitely with no visible sign anything went
+      // wrong) — surface it as its own distinct, actionable error.
+      try {
+        await this.deleteSecret(secretToEdit);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Secret saved as "${name}", but the previous entry "${secretToEdit}" ` +
+            `could not be removed (${detail}). Delete it manually to avoid ` +
+            `keeping a stale copy.`,
+        );
+      }
     }
   }
 

--- a/src/components/features/settings/key-status-icon.tsx
+++ b/src/components/features/settings/key-status-icon.tsx
@@ -4,11 +4,24 @@ import { cn } from "#/utils/utils";
 interface KeyStatusIconProps {
   testId?: string;
   isSet: boolean;
+  /**
+   * Accessible/visible-on-hover text. Defaults to a plain "a key string is
+   * stored" reading, which is all this icon actually checks — it never pings
+   * the provider. Override with a context-specific label anywhere the icon
+   * sits apart from the key field itself (e.g. a connection row), where
+   * "stored" on its own could read as "verified working."
+   */
+  label?: string;
 }
 
-export function KeyStatusIcon({ testId, isSet }: KeyStatusIconProps) {
+export function KeyStatusIcon({ testId, isSet, label }: KeyStatusIconProps) {
+  const resolvedLabel = label ?? (isSet ? "API key set" : "API key not set");
   return (
-    <span data-testid={testId || (isSet ? "set-indicator" : "unset-indicator")}>
+    <span
+      data-testid={testId || (isSet ? "set-indicator" : "unset-indicator")}
+      title={resolvedLabel}
+      aria-label={resolvedLabel}
+    >
       <SuccessIcon className={cn(isSet ? "text-success" : "text-danger")} />
     </span>
   );

--- a/src/components/features/settings/llm-profiles/bulk-add-models-modal.tsx
+++ b/src/components/features/settings/llm-profiles/bulk-add-models-modal.tsx
@@ -1,0 +1,243 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { BrandButton } from "#/components/features/settings/brand-button";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
+import { ApiKeyModalBase } from "#/components/features/settings/api-key-modal-base";
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
+import { useSaveLlmProfile } from "#/hooks/mutation/use-save-llm-profile";
+import { deriveProfileNameFromModel } from "#/utils/derive-profile-name";
+import { getApiErrorMessage } from "#/utils/api-error-message";
+import { I18nKey } from "#/i18n/declaration";
+
+interface BulkAddModelsModalProps {
+  /** When `null` the modal is closed. */
+  connection: ProviderConnection | null;
+  /** Names of profiles that already exist, so pasted models that would
+   * collide are skipped instead of erroring. */
+  existingProfileNames: Set<string>;
+  onClose: () => void;
+}
+
+/** One parsed model id from the textarea, paired with its derived profile name. */
+interface ParsedModel {
+  modelId: string;
+  profileName: string;
+}
+
+type ResultStatus = "created" | "failed";
+
+/**
+ * Splits pasted text into model ids: newline- or comma-separated, trimmed,
+ * empty entries dropped, duplicates collapsed (first occurrence wins).
+ */
+function parseModelIds(raw: string): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const line of raw.split(/[\n,]/)) {
+    const trimmed = line.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    ids.push(trimmed);
+  }
+  return ids;
+}
+
+/**
+ * A model id pasted with its own provider prefix (e.g. "openai/gpt-4o") is
+ * used verbatim; a bare id (e.g. "gpt-oss:120b") is prefixed with the
+ * connection's provider so it routes through the connection correctly.
+ */
+function buildModelString(connection: ProviderConnection, modelId: string) {
+  return modelId.includes("/") ? modelId : `${connection.provider}/${modelId}`;
+}
+
+/**
+ * Creates one LLM profile per pasted model id, all linked to the same
+ * provider connection. There is no live "discover this connection's models"
+ * endpoint (that needs a server-side proxy that doesn't exist here — a
+ * browser `fetch` to an arbitrary base URL is blocked by CORS), so the user
+ * supplies the id list themselves — e.g. from their own `curl .../v1/models`
+ * output or the provider's docs.
+ */
+export function BulkAddModelsModal({
+  connection,
+  existingProfileNames,
+  onClose,
+}: BulkAddModelsModalProps) {
+  const { t } = useTranslation("openhands");
+  const saveProfile = useSaveLlmProfile();
+  const [rawInput, setRawInput] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [results, setResults] = useState<
+    { modelId: string; status: ResultStatus; error?: string }[] | null
+  >(null);
+
+  const { toCreate, toSkip }: { toCreate: ParsedModel[]; toSkip: string[] } =
+    useMemo(() => {
+      const create: ParsedModel[] = [];
+      const skip: string[] = [];
+      for (const modelId of parseModelIds(rawInput)) {
+        const profileName = deriveProfileNameFromModel(modelId);
+        if (existingProfileNames.has(profileName)) {
+          skip.push(modelId);
+        } else {
+          create.push({ modelId, profileName });
+        }
+      }
+      return { toCreate: create, toSkip: skip };
+    }, [rawInput, existingProfileNames]);
+
+  if (!connection) return null;
+
+  const handleClose = () => {
+    if (isSubmitting) return;
+    setRawInput("");
+    setResults(null);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (toCreate.length === 0 || isSubmitting) return;
+    setIsSubmitting(true);
+    // Sequential, not Promise.all: keeps this from hammering the agent-server
+    // with a burst of concurrent saves, and each result is attributable to
+    // its own model as it lands rather than resolved all-at-once.
+    const outcomes: {
+      modelId: string;
+      status: ResultStatus;
+      error?: string;
+    }[] = [];
+    for (const { modelId, profileName } of toCreate) {
+      try {
+        await saveProfile.mutateAsync({
+          name: profileName,
+          request: {
+            llm: {
+              model: buildModelString(connection, modelId),
+              provider_connection_id: connection.id,
+              auth_type: "api_key",
+              subscription_vendor: null,
+            },
+            include_secrets: true,
+          },
+        });
+        outcomes.push({ modelId, status: "created" });
+      } catch (error) {
+        outcomes.push({
+          modelId,
+          status: "failed",
+          error: getApiErrorMessage(error, t(I18nKey.ERROR$GENERIC)),
+        });
+      }
+    }
+    setResults(outcomes);
+    setIsSubmitting(false);
+  };
+
+  const createdCount =
+    results?.filter((r) => r.status === "created").length ?? 0;
+  const failed = results?.filter((r) => r.status === "failed") ?? [];
+
+  const footer = results ? (
+    <BrandButton
+      testId="bulk-add-models-done"
+      type="button"
+      variant="primary"
+      onClick={handleClose}
+    >
+      {t(I18nKey.BUTTON$CLOSE)}
+    </BrandButton>
+  ) : (
+    <>
+      <BrandButton
+        type="button"
+        variant="tertiary"
+        onClick={handleClose}
+        isDisabled={isSubmitting}
+      >
+        {t(I18nKey.BUTTON$CANCEL)}
+      </BrandButton>
+      <BrandButton
+        testId="bulk-add-models-submit"
+        type="button"
+        variant="primary"
+        onClick={handleSubmit}
+        isDisabled={isSubmitting || toCreate.length === 0}
+        aria-busy={isSubmitting}
+      >
+        {isSubmitting ? (
+          <LoadingSpinner size="small" />
+        ) : (
+          t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_SUBMIT, {
+            count: toCreate.length,
+          })
+        )}
+      </BrandButton>
+    </>
+  );
+
+  return (
+    <ApiKeyModalBase
+      isOpen
+      title={t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TITLE)}
+      footer={footer}
+      onClose={handleClose}
+    >
+      <div data-testid="bulk-add-models-modal" className="flex flex-col gap-4">
+        {results ? (
+          <div className="flex flex-col gap-2 text-sm">
+            <p data-testid="bulk-add-models-result-created">
+              {t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_CREATED, {
+                count: createdCount,
+              })}
+            </p>
+            {failed.length > 0 ? (
+              <p
+                data-testid="bulk-add-models-result-failed"
+                className="text-danger"
+              >
+                {t(
+                  I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_FAILED,
+                  { names: failed.map((f) => f.modelId).join(", ") },
+                )}
+              </p>
+            ) : null}
+          </div>
+        ) : (
+          <>
+            <fieldset className="flex flex-col gap-2.5 w-full">
+              <label className="text-sm" htmlFor="bulk-add-models-textarea">
+                {t(
+                  I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TEXTAREA_LABEL,
+                )}
+              </label>
+              <textarea
+                id="bulk-add-models-textarea"
+                data-testid="bulk-add-models-textarea"
+                className="w-full min-h-32 rounded-lg border border-[var(--oh-border)] bg-base-secondary px-3 py-2 text-sm text-white"
+                value={rawInput}
+                onChange={(event) => setRawInput(event.target.value)}
+                // eslint-disable-next-line i18next/no-literal-string -- example value, not translatable
+                placeholder={"gpt-oss:120b-cloud\nglm-5.3-flash:cloud"}
+              />
+              <p className="text-xs text-[var(--oh-muted)]">
+                {t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_HINT)}
+              </p>
+            </fieldset>
+            {toCreate.length > 0 || toSkip.length > 0 ? (
+              <p
+                data-testid="bulk-add-models-preview"
+                className="text-xs text-[var(--oh-muted)]"
+              >
+                {t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_PREVIEW, {
+                  create: toCreate.length,
+                  skip: toSkip.length,
+                })}
+              </p>
+            ) : null}
+          </>
+        )}
+      </div>
+    </ApiKeyModalBase>
+  );
+}

--- a/src/components/features/settings/llm-profiles/llm-profiles-manager.tsx
+++ b/src/components/features/settings/llm-profiles/llm-profiles-manager.tsx
@@ -71,6 +71,10 @@ export function LlmProfilesManager({
     }
     return counts;
   }, [profiles]);
+  const existingProfileNames = useMemo(
+    () => new Set(profiles.map((p) => p.name)),
+    [profiles],
+  );
 
   const handleActivate = async (name: string) => {
     try {
@@ -162,6 +166,7 @@ export function LlmProfilesManager({
           <ProviderConnectionsManager
             connections={connectionList}
             linkedCountById={linkedCountById}
+            existingProfileNames={existingProfileNames}
             isLoading={isLoadingConnections}
             loadError={connectionsError ?? null}
           />

--- a/src/components/features/settings/llm-profiles/provider-connection-modal.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connection-modal.tsx
@@ -26,6 +26,27 @@ import { heroUiAutocompleteSelectorButtonClassName } from "#/ui/combobox-caret";
 
 const DEFAULT_PROVIDER = "custom";
 
+/**
+ * OpenAI-API-compatible cloud services that aren't their own litellm
+ * provider (so they're reached via `provider: "openai"` + a custom
+ * `base_url`, not picked from the main Provider dropdown). Kept short and
+ * limited to base URLs actually verified against the live service — a wrong
+ * or stale preset silently misconfigures a credential, which is worse than
+ * no preset at all. Extend this list only from a source that's been tested,
+ * not copied from docs.
+ */
+const OPENAI_COMPATIBLE_PRESETS: {
+  id: string;
+  label: string;
+  baseUrl: string;
+}[] = [
+  {
+    id: "ollama-cloud",
+    label: "Ollama Cloud",
+    baseUrl: "https://ollama.com/v1",
+  },
+];
+
 interface ProviderConnectionModalProps {
   /** When `null` the modal is closed; otherwise it edits that connection. */
   connection?: ProviderConnection | null;
@@ -96,6 +117,14 @@ export function ProviderConnectionModal({
 
   const handleClose = () => {
     if (!isPending) onClose();
+  };
+
+  const handleApplyPreset = (
+    preset: (typeof OPENAI_COMPATIBLE_PRESETS)[number],
+  ) => {
+    setProvider("openai");
+    setBaseUrl(preset.baseUrl);
+    if (!displayName.trim()) setDisplayName(preset.label);
   };
 
   const handleSubmit = async () => {
@@ -263,17 +292,35 @@ export function ProviderConnectionModal({
               : undefined
           }
         />
-        <SettingsInput
-          testId="provider-connection-base-url-input"
-          label={t(I18nKey.SETTINGS$BASE_URL)}
-          type="text"
-          className="w-full"
-          value={baseUrl}
-          // eslint-disable-next-line i18next/no-literal-string -- example value, not translatable
-          placeholder="https://api.openai.com"
-          onChange={setBaseUrl}
-          showOptionalTag
-        />
+        <div className="flex flex-col gap-2">
+          <SettingsInput
+            testId="provider-connection-base-url-input"
+            label={t(I18nKey.SETTINGS$BASE_URL)}
+            type="text"
+            className="w-full"
+            value={baseUrl}
+            // eslint-disable-next-line i18next/no-literal-string -- example value, not translatable
+            placeholder="https://api.openai.com"
+            onChange={setBaseUrl}
+            showOptionalTag
+          />
+          <div
+            className="flex flex-wrap gap-2"
+            data-testid="provider-connection-presets"
+          >
+            {OPENAI_COMPATIBLE_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                data-testid={`provider-connection-preset-${preset.id}`}
+                onClick={() => handleApplyPreset(preset)}
+                className="rounded-full border border-[var(--oh-border)] px-3 py-1 text-xs text-[var(--oh-muted)] hover:text-white hover:border-white/40"
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
     </ApiKeyModalBase>
   );

--- a/src/components/features/settings/llm-profiles/provider-connection-row.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connection-row.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import EditIcon from "#/icons/u-edit.svg?react";
 import DeleteIcon from "#/icons/u-delete.svg?react";
+import PlusIcon from "#/icons/u-plus.svg?react";
 import { KeyStatusIcon } from "#/components/features/settings/key-status-icon";
 import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
 import { cn } from "#/utils/utils";
@@ -16,6 +17,7 @@ interface ProviderConnectionRowProps {
   linkedProfileCount: number;
   onEdit: (connection: ProviderConnection) => void;
   onDelete: (connection: ProviderConnection) => void;
+  onBulkAddModels: (connection: ProviderConnection) => void;
 }
 
 export function ProviderConnectionRow({
@@ -23,6 +25,7 @@ export function ProviderConnectionRow({
   linkedProfileCount,
   onEdit,
   onDelete,
+  onBulkAddModels,
 }: ProviderConnectionRowProps) {
   const { t } = useTranslation("openhands");
 
@@ -49,6 +52,15 @@ export function ProviderConnectionRow({
         <KeyStatusIcon isSet={connection.api_key_set} />
       </div>
       <div className="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          data-testid="provider-connection-bulk-add"
+          aria-label={t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_ACTION)}
+          className={settingsListIconActionButtonClassName}
+          onClick={() => onBulkAddModels(connection)}
+        >
+          <PlusIcon width={16} height={16} />
+        </button>
         <button
           type="button"
           data-testid="provider-connection-edit"

--- a/src/components/features/settings/llm-profiles/provider-connection-row.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connection-row.tsx
@@ -49,7 +49,14 @@ export function ProviderConnectionRow({
             count: linkedProfileCount,
           })}
         </span>
-        <KeyStatusIcon isSet={connection.api_key_set} />
+        <KeyStatusIcon
+          isSet={connection.api_key_set}
+          label={t(
+            connection.api_key_set
+              ? I18nKey.SETTINGS$PROVIDER_CONNECTION_KEY_SET_LABEL
+              : I18nKey.SETTINGS$PROVIDER_CONNECTION_KEY_UNSET_LABEL,
+          )}
+        />
       </div>
       <div className="flex shrink-0 items-center gap-1">
         <button

--- a/src/components/features/settings/llm-profiles/provider-connections-manager.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connections-manager.tsx
@@ -4,6 +4,7 @@ import { BrandButton } from "#/components/features/settings/brand-button";
 import { ProviderConnectionRow } from "./provider-connection-row";
 import { ProviderConnectionModal } from "./provider-connection-modal";
 import { DeleteProviderConnectionModal } from "./delete-provider-connection-modal";
+import { BulkAddModelsModal } from "./bulk-add-models-modal";
 import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
 import { cn } from "#/utils/utils";
 import {
@@ -17,6 +18,8 @@ interface ProviderConnectionsManagerProps {
   connections: ProviderConnection[];
   /** Number of LLM profiles linked to each connection id. */
   linkedCountById: Record<string, number>;
+  /** Existing profile names, so bulk-add can skip ones that already exist. */
+  existingProfileNames?: Set<string>;
   isLoading: boolean;
   loadError: Error | null;
 }
@@ -29,6 +32,7 @@ interface ProviderConnectionsManagerProps {
 export function ProviderConnectionsManager({
   connections,
   linkedCountById,
+  existingProfileNames = new Set(),
   isLoading,
   loadError,
 }: ProviderConnectionsManagerProps) {
@@ -37,6 +41,8 @@ export function ProviderConnectionsManager({
   const [connectionToEdit, setConnectionToEdit] =
     useState<ProviderConnection | null>(null);
   const [connectionToDelete, setConnectionToDelete] =
+    useState<ProviderConnection | null>(null);
+  const [connectionToBulkAdd, setConnectionToBulkAdd] =
     useState<ProviderConnection | null>(null);
 
   const renderBody = () => {
@@ -82,6 +88,7 @@ export function ProviderConnectionsManager({
             linkedProfileCount={linkedCountById[connection.id] ?? 0}
             onEdit={setConnectionToEdit}
             onDelete={setConnectionToDelete}
+            onBulkAddModels={setConnectionToBulkAdd}
           />
         ))}
       </div>
@@ -128,6 +135,11 @@ export function ProviderConnectionsManager({
       <DeleteProviderConnectionModal
         connection={connectionToDelete}
         onClose={() => setConnectionToDelete(null)}
+      />
+      <BulkAddModelsModal
+        connection={connectionToBulkAdd}
+        existingProfileNames={existingProfileNames}
+        onClose={() => setConnectionToBulkAdd(null)}
       />
     </>
   );

--- a/src/components/features/settings/sdk-settings/sdk-section-page.tsx
+++ b/src/components/features/settings/sdk-settings/sdk-section-page.tsx
@@ -193,6 +193,7 @@ export function SdkSectionPage({
   getInitialView,
   forceShowAdvancedView = false,
   allowAllView = true,
+  hideBasicView = false,
   initialValueOverrides,
   markInitialOverridesDirty = true,
   embedded = false,
@@ -226,6 +227,16 @@ export function SdkSectionPage({
   ) => SettingsView;
   forceShowAdvancedView?: boolean;
   allowAllView?: boolean;
+  /**
+   * Hide the Basic tab regardless of the schema's critical fields. For a
+   * section whose Basic-tier UI can't represent the current value at all
+   * (e.g. an LLM profile linked to a provider connection, or a custom model
+   * absent from the selected provider's catalog) — showing Basic there
+   * doesn't just look wrong, its controls silently overwrite the real value
+   * with the nearest thing they *can* represent. Floors the view at
+   * Advanced/All instead of letting it be reached.
+   */
+  hideBasicView?: boolean;
   /**
    * Per-field initial value overrides that win over the values derived from
    * `useSettings`. When {@link markInitialOverridesDirty} is true (default),
@@ -329,9 +340,9 @@ export function SdkSectionPage({
   // The basic tier only exists when some field renders in it; a critical-less
   // page (e.g. Memory, whose only field is major) hides the Basic tab and
   // floors its view at "advanced".
-  const showBasic = resolvedSources.some((src) =>
-    hasCriticalSettings(src.filteredSchema),
-  );
+  const showBasic =
+    !hideBasicView &&
+    resolvedSources.some((src) => hasCriticalSettings(src.filteredSchema));
   const showAdvanced =
     forceShowAdvancedView ||
     resolvedSources.some((src) => hasAdvancedSettings(src.filteredSchema));

--- a/src/components/features/settings/secrets-settings/secret-form.tsx
+++ b/src/components/features/settings/secrets-settings/secret-form.tsx
@@ -13,6 +13,7 @@ import {
 import { BrandButton } from "../brand-button";
 import { useSearchSecrets } from "#/hooks/query/use-get-secrets";
 import { OptionalTag } from "../optional-tag";
+import { getApiErrorMessage } from "#/utils/api-error-message";
 
 interface SecretFormProps {
   mode: "add" | "edit";
@@ -72,8 +73,17 @@ export function SecretForm({
     createSecret(
       { name, value, description },
       {
-        onSettled: onCancel,
-        onSuccess: invalidateSecrets,
+        // Only leave the form on an actual save — onSettled fires on error
+        // too, which previously navigated back to the list exactly as if
+        // the secret had saved, discarding the typed value with no visible
+        // failure beyond a toast the user may have missed.
+        onSuccess: () => {
+          invalidateSecrets();
+          onCancel();
+        },
+        onError: (mutationError) => {
+          setError(getApiErrorMessage(mutationError, t(I18nKey.ERROR$GENERIC)));
+        },
       },
     );
   };
@@ -87,8 +97,13 @@ export function SecretForm({
     updateSecret(
       { secretToEdit, name, description, value },
       {
-        onSettled: onCancel,
-        onSuccess: invalidateSecrets,
+        onSuccess: () => {
+          invalidateSecrets();
+          onCancel();
+        },
+        onError: (mutationError) => {
+          setError(getApiErrorMessage(mutationError, t(I18nKey.ERROR$GENERIC)));
+        },
       },
     );
   };

--- a/src/components/features/settings/secrets-settings/secret-list-item.tsx
+++ b/src/components/features/settings/secrets-settings/secret-list-item.tsx
@@ -1,5 +1,7 @@
 import { Pencil, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { cn } from "#/utils/utils";
+import { I18nKey } from "#/i18n/declaration";
 import {
   settingsListIconActionButtonClassName,
   settingsListRowClassName,
@@ -40,6 +42,8 @@ export function SecretListItem({
   onEdit,
   onDelete,
 }: SecretListItemProps) {
+  const { t } = useTranslation("openhands");
+
   return (
     <tr data-testid="secret-item" className={settingsListTableRowClassName}>
       <td
@@ -68,7 +72,7 @@ export function SecretListItem({
             data-testid="edit-secret-button"
             type="button"
             onClick={onEdit}
-            aria-label={`Edit ${title}`}
+            aria-label={t(I18nKey.SECRETS$EDIT_SECRET_ARIA, { name: title })}
             className={settingsListIconActionButtonClassName}
           >
             <Pencil aria-hidden className="size-4" strokeWidth={2} />
@@ -77,7 +81,7 @@ export function SecretListItem({
             data-testid="delete-secret-button"
             type="button"
             onClick={onDelete}
-            aria-label={`Delete ${title}`}
+            aria-label={t(I18nKey.SECRETS$DELETE_SECRET_ARIA, { name: title })}
             className={settingsListIconActionButtonClassName}
           >
             <Trash2 aria-hidden className="size-4" strokeWidth={2} />

--- a/src/hooks/query/use-get-secrets.ts
+++ b/src/hooks/query/use-get-secrets.ts
@@ -20,7 +20,12 @@ export const useSearchSecrets = (options: UseSearchSecretsOptions = {}) => {
 
   const query = useQuery<CustomSecretWithoutValue[], Error>({
     queryKey: ["secrets", active.backend.id, active.orgId],
-    queryFn: SecretsService.getSecrets,
+    // getSecretsOrThrow, not getSecrets: the latter swallows a fetch failure
+    // into an empty array, so a real error (network, backend down) rendered
+    // as the plain "you have no secrets yet" empty state with no way to
+    // tell it apart from actually having none. This hook already exposes
+    // isError for exactly this distinction — it just never used to fire.
+    queryFn: SecretsService.getSecretsOrThrow,
     enabled,
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 15,

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -41919,5 +41919,14 @@
   },
   "SETTINGS$PROVIDER_CONNECTION_KEY_UNSET_LABEL": {
     "en": "No API key stored"
+  },
+  "SECRETS$LOAD_ERROR": {
+    "en": "Failed to load secrets"
+  },
+  "SECRETS$EDIT_SECRET_ARIA": {
+    "en": "Edit {{name}}"
+  },
+  "SECRETS$DELETE_SECRET_ARIA": {
+    "en": "Delete {{name}}"
   }
 }

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -41913,5 +41913,11 @@
   },
   "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_FAILED": {
     "en": "Failed: {{names}}"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_KEY_SET_LABEL": {
+    "en": "API key stored (not verified against the provider)"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_KEY_UNSET_LABEL": {
+    "en": "No API key stored"
   }
 }

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -14262,7 +14262,6 @@
     "uk": "Повідомлено користувацькі метадані завдання.",
     "ca": "S'han informat metadades personalitzades de la tasca."
   },
-
   "AUTOMATIONS$DETAIL$VIEW_CONVERSATION_FOR_RUN": {
     "en": "View conversation for run at {{timestamp}}",
     "ja": "{{timestamp}} の実行の会話を表示",
@@ -14280,7 +14279,6 @@
     "uk": "Переглянути розмову для запуску о {{timestamp}}",
     "ca": "Mostra la conversa de l'execució a {{timestamp}}"
   },
-
   "AUTOMATIONS$DETAIL$PHASE": {
     "ar": "المرحلة",
     "ca": "Fase",
@@ -41888,5 +41886,32 @@
     "uk": "Попередній перегляд зображення в повному розмірі",
     "zh-CN": "原始尺寸图片预览",
     "zh-TW": "原始尺寸圖片預覽"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_ACTION": {
+    "en": "Bulk add models"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TITLE": {
+    "en": "Bulk add models"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TEXTAREA_LABEL": {
+    "en": "Model IDs"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_HINT": {
+    "en": "Paste model IDs, one per line (or comma-separated). Each becomes its own profile linked to this connection."
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_PREVIEW": {
+    "en": "{{create}} new, {{skip}} already exist"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_SUBMIT": {
+    "en": "Create {{count}} profile(s)"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_CREATED": {
+    "en": "Created {{count}} profile(s)"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_SKIPPED": {
+    "en": "Skipped {{count}} (already exist)"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_FAILED": {
+    "en": "Failed: {{names}}"
   }
 }

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -218,15 +218,47 @@ export function LlmSettingsScreen({
         return schemaView;
       }
 
-      const currentModel = currentSettings.llm_model ?? "";
-      const trimmedBaseUrl = currentSettings.llm_base_url?.trim() ?? "";
+      // Embedded profile forms (create/edit) seed values via
+      // `initialValueOverrides`, which this callback previously ignored —
+      // it read only the globally active settings. That let editing a
+      // profile with a custom model/base URL (or one linked to a provider
+      // connection) silently land on the Basic tab regardless of what the
+      // profile being edited actually contains. Once there, ModelSelector
+      // binds its Model dropdown to a key absent from the resolved
+      // provider's real catalog, and HeroUI's Autocomplete silently
+      // reconciles that to an unrelated model once its list loads —
+      // corrupting `llm.model`. Prefer the overrides here so the tab is
+      // inferred from the profile actually being edited.
+      const overrideConnectionId =
+        initialValueOverrides?.[LLM_PROVIDER_CONNECTION_KEY];
+      const isLinkedToConnection =
+        typeof overrideConnectionId === "string" &&
+        overrideConnectionId.length > 0;
+      // A connection-linked profile carries no inline base_url of its own
+      // (see llm-settings-local-view.tsx's save logic), so there is nothing
+      // here to compare against a provider default. The Basic tab has no
+      // concept of provider connections at all, so always defer to "all".
+      if (isLinkedToConnection) {
+        return "all";
+      }
+
+      const overrideModel = initialValueOverrides?.["llm.model"];
+      const overrideBaseUrl = initialValueOverrides?.["llm.base_url"];
+      const currentModel =
+        typeof overrideModel === "string"
+          ? overrideModel
+          : (currentSettings.llm_model ?? "");
+      const trimmedBaseUrl =
+        typeof overrideBaseUrl === "string"
+          ? overrideBaseUrl.trim()
+          : (currentSettings.llm_base_url?.trim() ?? "");
       const hasCustomBaseUrl =
         trimmedBaseUrl.length > 0 &&
         !isProviderDefaultBaseUrl(currentModel, trimmedBaseUrl);
 
       return hasCustomBaseUrl ? "all" : "basic";
     },
-    [],
+    [initialValueOverrides],
   );
 
   const buildHeader = React.useCallback(

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -654,6 +654,35 @@ export function LlmSettingsScreen({
     [schema, subscriptionModels, isCloud],
   );
 
+  // Mirrors getInitialView's own "does Basic even represent this?" check
+  // (only meaningful in embedded profile-editor mode; initialValueOverrides
+  // is empty on the standalone Settings page, so this is a no-op there).
+  // ModelSelector's Model dropdown renders blank whenever the current model
+  // isn't in the resolved provider's fetched catalog — true for any
+  // connection-linked profile (whose credential/base_url aren't on the
+  // profile itself) and for any custom model paired with a non-default base
+  // URL. Rather than let a user tab into a Basic view that can't represent
+  // their config and silently discard it, the tab isn't reachable at all.
+  const overrideConnectionId =
+    initialValueOverrides?.[LLM_PROVIDER_CONNECTION_KEY];
+  const isLinkedToConnectionOverride =
+    typeof overrideConnectionId === "string" && overrideConnectionId.length > 0;
+  const overrideModelForBasicGate = initialValueOverrides?.["llm.model"];
+  const overrideBaseUrlForBasicGate = initialValueOverrides?.["llm.base_url"];
+  const trimmedOverrideBaseUrl =
+    typeof overrideBaseUrlForBasicGate === "string"
+      ? overrideBaseUrlForBasicGate.trim()
+      : "";
+  const hasCustomBaseUrlOverride =
+    typeof overrideModelForBasicGate === "string" &&
+    trimmedOverrideBaseUrl.length > 0 &&
+    !isProviderDefaultBaseUrl(
+      overrideModelForBasicGate,
+      trimmedOverrideBaseUrl,
+    );
+  const hideBasicViewForEmbeddedProfile =
+    isLinkedToConnectionOverride || hasCustomBaseUrlOverride;
+
   return (
     <SdkSectionPage
       scope={scope}
@@ -669,6 +698,7 @@ export function LlmSettingsScreen({
       getInitialView={getInitialView}
       forceShowAdvancedView
       allowAllView
+      hideBasicView={hideBasicViewForEmbeddedProfile}
       onSaveSuccess={onSaveSuccess}
       initialValueOverrides={initialValueOverrides}
       markInitialOverridesDirty={markInitialOverridesDirty}

--- a/src/routes/secrets-settings.tsx
+++ b/src/routes/secrets-settings.tsx
@@ -32,6 +32,7 @@ export function SecretsSettingsScreen() {
   const {
     data: secrets,
     isLoading: isLoadingSecrets,
+    isError: isSecretsLoadError,
     hasNextPage,
     isFetchingNextPage,
     onLoadMore,
@@ -144,72 +145,95 @@ export function SecretsSettingsScreen() {
         </ul>
       )}
 
-      {view === "list" && !isLoadingSecrets && secrets?.length === 0 && (
+      {view === "list" && !isLoadingSecrets && isSecretsLoadError && (
         <div
-          data-testid="secrets-empty"
+          data-testid="secrets-load-error"
           className={extensionModuleEmptyStateClassName}
         >
-          <p className="text-sm text-[var(--oh-muted)]">
-            {t(I18nKey.SECRETS$EMPTY)}
+          <p className="text-sm text-red-400">
+            {t(I18nKey.SECRETS$LOAD_ERROR)}
           </p>
         </div>
       )}
 
-      {view === "list" && !isLoadingSecrets && (secrets?.length ?? 0) > 0 && (
-        <div
-          ref={tableContainerRef}
-          className={settingsListScrollContainerClassName}
-          onScroll={handleScroll}
-        >
-          <table className="w-full min-w-full table-fixed">
-            <thead className={settingsListTableHeadClassName}>
-              <tr>
-                <th
-                  className={cn(settingsListTableHeaderCellClassName, "w-1/4")}
-                >
-                  {t(I18nKey.SETTINGS$NAME)}
-                </th>
-                <th
-                  className={cn(settingsListTableHeaderCellClassName, "w-1/2")}
-                >
-                  {t(I18nKey.SECRETS$DESCRIPTION)}
-                </th>
-                <th
-                  className={cn(
-                    settingsListTableHeaderCellClassName,
-                    "w-1/4 text-right",
-                  )}
-                >
-                  {t(I18nKey.SETTINGS$ACTIONS)}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {secrets?.map((secret) => (
-                <SecretListItem
-                  key={secret.name}
-                  title={secret.name}
-                  description={secret.description}
-                  onEdit={() => {
-                    setView("edit-secret-form");
-                    setSelectedSecret(secret.name);
-                  }}
-                  onDelete={() => {
-                    setConfirmationModalIsVisible(true);
-                    setSelectedSecret(secret.name);
-                  }}
-                />
-              ))}
-            </tbody>
-          </table>
+      {view === "list" &&
+        !isLoadingSecrets &&
+        !isSecretsLoadError &&
+        secrets?.length === 0 && (
+          <div
+            data-testid="secrets-empty"
+            className={extensionModuleEmptyStateClassName}
+          >
+            <p className="text-sm text-[var(--oh-muted)]">
+              {t(I18nKey.SECRETS$EMPTY)}
+            </p>
+          </div>
+        )}
 
-          {isFetchingNextPage && (
-            <div className="flex justify-center p-4">
-              <LoadingSpinner size="small" />
-            </div>
-          )}
-        </div>
-      )}
+      {view === "list" &&
+        !isLoadingSecrets &&
+        !isSecretsLoadError &&
+        (secrets?.length ?? 0) > 0 && (
+          <div
+            ref={tableContainerRef}
+            className={settingsListScrollContainerClassName}
+            onScroll={handleScroll}
+          >
+            <table className="w-full min-w-full table-fixed">
+              <thead className={settingsListTableHeadClassName}>
+                <tr>
+                  <th
+                    className={cn(
+                      settingsListTableHeaderCellClassName,
+                      "w-1/4",
+                    )}
+                  >
+                    {t(I18nKey.SETTINGS$NAME)}
+                  </th>
+                  <th
+                    className={cn(
+                      settingsListTableHeaderCellClassName,
+                      "w-1/2",
+                    )}
+                  >
+                    {t(I18nKey.SECRETS$DESCRIPTION)}
+                  </th>
+                  <th
+                    className={cn(
+                      settingsListTableHeaderCellClassName,
+                      "w-1/4 text-right",
+                    )}
+                  >
+                    {t(I18nKey.SETTINGS$ACTIONS)}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {secrets?.map((secret) => (
+                  <SecretListItem
+                    key={secret.name}
+                    title={secret.name}
+                    description={secret.description}
+                    onEdit={() => {
+                      setView("edit-secret-form");
+                      setSelectedSecret(secret.name);
+                    }}
+                    onDelete={() => {
+                      setConfirmationModalIsVisible(true);
+                      setSelectedSecret(secret.name);
+                    }}
+                  />
+                ))}
+              </tbody>
+            </table>
+
+            {isFetchingNextPage && (
+              <div className="flex justify-center p-4">
+                <LoadingSpinner size="small" />
+              </div>
+            )}
+          </div>
+        )}
 
       {(view === "add-secret-form" || view === "edit-secret-form") && (
         <SecretForm


### PR DESCRIPTION
## Summary

Found via an evidence-based gap scan of the Secrets settings area (`src/components/features/settings/secrets-settings/`), same methodology as #17377 and #17378.

- **`SecretForm` discarded failed saves silently.** It used mutation `onSettled` to navigate back to the list — `onSettled` fires on error just as much as success, so a failed create/update closed the form and returned to the list exactly as if it had saved. The typed value was gone with no in-form indication anything failed, only a toast the user may have missed. Now only `onSuccess` navigates away; `onError` keeps the form open (the typed value was never cleared) and shows the real backend message via the same `getApiErrorMessage` pattern every other modal in this codebase uses.
- **Rename's cleanup-delete failure was indistinguishable from total failure.** `updateSecret`'s rename path (upsert-then-delete-old) keeps the safer failure-mode ordering on purpose — reversing it would risk losing the secret's value outright if the upsert then failed — but a delete failure was allowed to propagate as a generic error that reads as "nothing saved," when actually the new entry *did* save. It's now wrapped into an explicit, actionable message naming both the new entry that exists and the stale old one that needs manual cleanup.
- **A real fetch failure looked identical to "you have no secrets."** `useSearchSecrets` called the swallowing `getSecrets` (catches and returns `[]`) instead of `getSecretsOrThrow`, a variant that already existed in this same service specifically "for callers that must distinguish an unavailable list from an empty one" per its own doc comment — it just wasn't used by the one caller that needed it. The settings screen now renders a distinct load-error state instead of the empty state when the fetch actually failed.
- **Minor**: `secret-list-item.tsx`'s Edit/Delete button `aria-label`s were hardcoded English template literals — the only place in this feature area bypassing `t()`/`I18nKey`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on every changed file — clean
- [x] Full relevant vitest suite — 14/14 pass (2 new test files, 3 new tests added to existing files); 2 pre-existing tests needed their `getSecrets` mock updated to `getSecretsOrThrow` to match the fixed call path — verified this wasn't papering over a real behavior change, just aligning the mock with the corrected implementation
- [ ] Live browser check — not done; same caveat as the prior PRs in this series, the reference build available to me is a pinned release container, not this source tree

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ach3EeSEJZkWbGNHggYEAa