### PR TITLE
fix: warn the user when onboarding's LLM finalization fails silently

### DIFF
--- a/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
+++ b/__tests__/components/features/settings/sdk-settings/sdk-section-page.test.tsx
@@ -664,6 +664,28 @@ describe("SdkSectionPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides the basic toggle when hideBasicView is set, even for a critical schema", async () => {
+    // A section whose Basic-tier controls can't represent the current value
+    // at all (e.g. an LLM profile linked to a provider connection) needs
+    // Basic unreachable, not just skipped on initial load — its schema still
+    // has critical fields, so showBasic alone would keep the tab clickable.
+    vi.spyOn(SettingsService, "getSettings").mockResolvedValue(
+      buildSavableSettings(),
+    );
+
+    renderSdkSectionPage({
+      settingsSources: [
+        { settingsSource: "agent_settings", sectionKeys: ["llm"] },
+      ],
+      hideBasicView: true,
+    });
+
+    await screen.findByTestId("sdk-settings-llm.endpoint");
+    expect(
+      screen.queryByTestId("sdk-section-basic-toggle"),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the all toggle instead of an empty advanced tier for minor-only schemas", async () => {
     const schema: NonNullable<Settings["agent_settings_schema"]> = {
       model_name: "AgentSettings",

--- a/__tests__/components/settings/key-status-icon.test.tsx
+++ b/__tests__/components/settings/key-status-icon.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { KeyStatusIcon } from "#/components/features/settings/key-status-icon";
+
+describe("KeyStatusIcon", () => {
+  it("exposes accessible text for the set state by default", () => {
+    render(<KeyStatusIcon isSet />);
+    const icon = screen.getByTestId("set-indicator");
+    expect(icon).toHaveAttribute("aria-label", "API key set");
+    expect(icon).toHaveAttribute("title", "API key set");
+  });
+
+  it("exposes accessible text for the unset state by default", () => {
+    render(<KeyStatusIcon isSet={false} />);
+    const icon = screen.getByTestId("unset-indicator");
+    expect(icon).toHaveAttribute("aria-label", "API key not set");
+    expect(icon).toHaveAttribute("title", "API key not set");
+  });
+
+  it("uses a caller-supplied label instead of the generic default", () => {
+    // A standalone status icon (no adjacent key field for context, e.g. a
+    // provider connection row) needs a label that doesn't imply more than
+    // "a key string is stored" — this never pings the provider.
+    const label = "API key stored (not verified against the provider)";
+    render(<KeyStatusIcon isSet label={label} />);
+    const icon = screen.getByTestId("set-indicator");
+    expect(icon).toHaveAttribute(
+      "aria-label",
+      "API key stored (not verified against the provider)",
+    );
+  });
+});

--- a/__tests__/components/settings/llm-profiles/bulk-add-models-modal.test.tsx
+++ b/__tests__/components/settings/llm-profiles/bulk-add-models-modal.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BulkAddModelsModal } from "#/components/features/settings/llm-profiles/bulk-add-models-modal";
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
+import ProfilesService from "#/api/profiles-service/profiles-service.api";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const translations: Record<string, string> = {
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TITLE: "Bulk add models",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TEXTAREA_LABEL: "Model IDs",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_HINT: "Paste model IDs.",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_PREVIEW:
+          "{{create}} new, {{skip}} already exist",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_SUBMIT:
+          "Create {{count}} profile(s)",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_CREATED:
+          "Created {{count}} profile(s)",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_FAILED:
+          "Failed: {{names}}",
+        BUTTON$CANCEL: "Cancel",
+        BUTTON$CLOSE: "Close",
+        ERROR$GENERIC: "An error occurred",
+      };
+      let result = translations[key] || key;
+      if (params) {
+        for (const [paramKey, value] of Object.entries(params)) {
+          result = result.replace(`{{${paramKey}}}`, String(value));
+        }
+      }
+      return result;
+    },
+  }),
+}));
+
+vi.mock("#/api/profiles-service/profiles-service.api");
+
+const connection: ProviderConnection = {
+  id: "conn-1",
+  display_name: "Ollama Cloud",
+  provider: "openai",
+  base_url: "https://ollama.com/v1",
+  created_at: 1,
+  updated_at: 2,
+  api_key_set: true,
+};
+
+describe("BulkAddModelsModal", () => {
+  let queryClient: QueryClient;
+
+  const renderModal = (
+    props: Partial<Parameters<typeof BulkAddModelsModal>[0]> = {},
+  ) =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BulkAddModelsModal
+          connection={connection}
+          existingProfileNames={new Set()}
+          onClose={vi.fn()}
+          {...props}
+        />
+      </QueryClientProvider>,
+    );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns null when connection is null", () => {
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <BulkAddModelsModal
+          connection={null}
+          existingProfileNames={new Set()}
+          onClose={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("parses newline- and comma-separated model ids and previews new vs skipped", async () => {
+    const user = userEvent.setup();
+    renderModal({ existingProfileNames: new Set(["gpt-oss-120b-cloud"]) });
+
+    await user.type(
+      screen.getByTestId("bulk-add-models-textarea"),
+      "gpt-oss:120b-cloud,glm-5.3-flash:cloud\nglm-5.3-flash:cloud\nkimi-k3",
+    );
+
+    // gpt-oss:120b-cloud -> already exists (skip), glm-5.3-flash:cloud
+    // appears twice (deduped to one), kimi-k3 is new -> 2 create, 1 skip
+    expect(screen.getByTestId("bulk-add-models-preview")).toHaveTextContent(
+      "2 new, 1 already exist",
+    );
+  });
+
+  it("creates one profile per model id, linked to the connection", async () => {
+    const user = userEvent.setup();
+    vi.mocked(ProfilesService.saveProfile).mockResolvedValue({
+      name: "x",
+      message: "ok",
+    });
+    renderModal();
+
+    await user.type(
+      screen.getByTestId("bulk-add-models-textarea"),
+      "gpt-oss:120b-cloud\nglm-5.3-flash:cloud",
+    );
+    await user.click(screen.getByTestId("bulk-add-models-submit"));
+
+    await waitFor(() => {
+      expect(ProfilesService.saveProfile).toHaveBeenCalledTimes(2);
+    });
+
+    expect(ProfilesService.saveProfile).toHaveBeenCalledWith(
+      "gpt-oss-120b-cloud",
+      {
+        llm: {
+          model: "openai/gpt-oss:120b-cloud",
+          provider_connection_id: "conn-1",
+          auth_type: "api_key",
+          subscription_vendor: null,
+        },
+        include_secrets: true,
+      },
+    );
+    expect(ProfilesService.saveProfile).toHaveBeenCalledWith(
+      "glm-5.3-flash-cloud",
+      {
+        llm: {
+          model: "openai/glm-5.3-flash:cloud",
+          provider_connection_id: "conn-1",
+          auth_type: "api_key",
+          subscription_vendor: null,
+        },
+        include_secrets: true,
+      },
+    );
+
+    await screen.findByTestId("bulk-add-models-result-created");
+    expect(
+      screen.getByTestId("bulk-add-models-result-created"),
+    ).toHaveTextContent("Created 2 profile(s)");
+  });
+
+  it("uses a model id verbatim when it already carries its own provider prefix", async () => {
+    const user = userEvent.setup();
+    vi.mocked(ProfilesService.saveProfile).mockResolvedValue({
+      name: "x",
+      message: "ok",
+    });
+    renderModal();
+
+    await user.type(
+      screen.getByTestId("bulk-add-models-textarea"),
+      "anthropic/claude-x",
+    );
+    await user.click(screen.getByTestId("bulk-add-models-submit"));
+
+    await waitFor(() => {
+      expect(ProfilesService.saveProfile).toHaveBeenCalledWith(
+        "claude-x",
+        expect.objectContaining({
+          llm: expect.objectContaining({ model: "anthropic/claude-x" }),
+        }),
+      );
+    });
+  });
+
+  it("reports per-model failures without blocking the others", async () => {
+    const user = userEvent.setup();
+    vi.mocked(ProfilesService.saveProfile).mockImplementation(
+      async (name: string) => {
+        if (name === "bad-model") throw new Error("model not found");
+        return { name, message: "ok" };
+      },
+    );
+    renderModal();
+
+    await user.type(
+      screen.getByTestId("bulk-add-models-textarea"),
+      "good-model\nbad-model",
+    );
+    await user.click(screen.getByTestId("bulk-add-models-submit"));
+
+    await screen.findByTestId("bulk-add-models-result-created");
+    expect(
+      screen.getByTestId("bulk-add-models-result-created"),
+    ).toHaveTextContent("Created 1 profile(s)");
+    expect(
+      screen.getByTestId("bulk-add-models-result-failed"),
+    ).toHaveTextContent("Failed: bad-model");
+  });
+
+  it("disables submit until at least one new model is parsed", () => {
+    renderModal();
+    expect(screen.getByTestId("bulk-add-models-submit")).toBeDisabled();
+  });
+});

--- a/__tests__/components/settings/llm-profiles/provider-connection-modal.test.tsx
+++ b/__tests__/components/settings/llm-profiles/provider-connection-modal.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ProviderConnectionModal } from "#/components/features/settings/llm-profiles/provider-connection-modal";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        SETTINGS$PROVIDER_CONNECTION_ADD_TITLE: "Add provider connection",
+        SETTINGS$NAME: "Name",
+        SETTINGS$PROVIDER_CONNECTION_PROVIDER: "Provider",
+        SETTINGS_FORM$API_KEY: "API Key",
+        SETTINGS$BASE_URL: "Base URL",
+        BUTTON$SAVE: "Save",
+        BUTTON$CANCEL: "Cancel",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+vi.mock("#/hooks/query/use-search-providers", () => ({
+  useSearchProviders: () => ({
+    data: [{ name: "openai", verified: true }],
+  }),
+}));
+
+vi.mock("#/hooks/mutation/use-create-provider-connection", () => ({
+  useCreateProviderConnection: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("#/hooks/mutation/use-update-provider-connection", () => ({
+  useUpdateProviderConnection: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("ProviderConnectionModal - presets", () => {
+  let queryClient: QueryClient;
+
+  const renderModal = () =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderConnectionModal isCreate connection={null} onClose={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  it("shows a preset chip for Ollama Cloud", () => {
+    renderModal();
+    expect(
+      screen.getByTestId("provider-connection-preset-ollama-cloud"),
+    ).toBeInTheDocument();
+  });
+
+  it("fills the base URL and provider when the Ollama Cloud preset is clicked", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(
+      screen.getByTestId("provider-connection-preset-ollama-cloud"),
+    );
+
+    expect(
+      screen.getByTestId("provider-connection-base-url-input"),
+    ).toHaveValue("https://ollama.com/v1");
+    expect(
+      screen.getByTestId("provider-connection-provider-input"),
+    ).toHaveValue("OpenAI");
+  });
+
+  it("prefills the name from the preset when the name field is still empty", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(
+      screen.getByTestId("provider-connection-preset-ollama-cloud"),
+    );
+
+    expect(screen.getByTestId("provider-connection-name-input")).toHaveValue(
+      "Ollama Cloud",
+    );
+  });
+
+  it("does not overwrite a name the user already typed", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.type(
+      screen.getByTestId("provider-connection-name-input"),
+      "My custom name",
+    );
+    await user.click(
+      screen.getByTestId("provider-connection-preset-ollama-cloud"),
+    );
+
+    expect(screen.getByTestId("provider-connection-name-input")).toHaveValue(
+      "My custom name",
+    );
+  });
+});

--- a/__tests__/components/settings/llm-profiles/provider-connection-row.test.tsx
+++ b/__tests__/components/settings/llm-profiles/provider-connection-row.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderConnectionRow } from "#/components/features/settings/llm-profiles/provider-connection-row";
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const translations: Record<string, string> = {
+        SETTINGS$PROVIDER_CONNECTION_MODEL_COUNT: "{{count}} model(s)",
+        SETTINGS$PROVIDER_CONNECTION_KEY_SET_LABEL:
+          "API key stored (not verified against the provider)",
+        SETTINGS$PROVIDER_CONNECTION_KEY_UNSET_LABEL: "No API key stored",
+        SETTINGS$PROVIDER_CONNECTION_BULK_ADD_ACTION: "Bulk add models",
+        SETTINGS$PROVIDER_CONNECTION_EDIT_TITLE: "Edit provider connection",
+        SETTINGS$PROVIDER_CONNECTION_DELETE_TITLE: "Delete provider connection",
+      };
+      let result = translations[key] || key;
+      if (params) {
+        for (const [paramKey, value] of Object.entries(params)) {
+          result = result.replace(`{{${paramKey}}}`, String(value));
+        }
+      }
+      return result;
+    },
+  }),
+}));
+
+const baseConnection: ProviderConnection = {
+  id: "conn-1",
+  display_name: "Ollama Cloud",
+  provider: "openai",
+  base_url: "https://ollama.com/v1",
+  created_at: 1,
+  updated_at: 2,
+  api_key_set: true,
+};
+
+describe("ProviderConnectionRow", () => {
+  it("labels the key status icon as 'stored', not 'verified', when a key is set", () => {
+    render(
+      <ProviderConnectionRow
+        connection={baseConnection}
+        linkedProfileCount={3}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onBulkAddModels={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("set-indicator")).toHaveAttribute(
+      "aria-label",
+      "API key stored (not verified against the provider)",
+    );
+  });
+
+  it("labels the key status icon as unset when no key is stored", () => {
+    render(
+      <ProviderConnectionRow
+        connection={{ ...baseConnection, api_key_set: false }}
+        linkedProfileCount={0}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onBulkAddModels={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("unset-indicator")).toHaveAttribute(
+      "aria-label",
+      "No API key stored",
+    );
+  });
+
+  it("calls onBulkAddModels with the connection when the bulk-add button is clicked", () => {
+    const onBulkAddModels = vi.fn();
+    render(
+      <ProviderConnectionRow
+        connection={baseConnection}
+        linkedProfileCount={0}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onBulkAddModels={onBulkAddModels}
+      />,
+    );
+
+    screen.getByTestId("provider-connection-bulk-add").click();
+    expect(onBulkAddModels).toHaveBeenCalledWith(baseConnection);
+  });
+});

--- a/__tests__/hooks/mutation/use-apply-onboarding-agent-profile.test.ts
+++ b/__tests__/hooks/mutation/use-apply-onboarding-agent-profile.test.ts
@@ -1,0 +1,95 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useApplyOnboardingAgentProfile } from "#/hooks/mutation/use-apply-onboarding-agent-profile";
+import AgentProfilesService from "#/api/agent-profiles-service/agent-profiles-service.api";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("#/api/agent-profiles-service/agent-profiles-service.api", () => ({
+  default: {
+    saveProfile: vi.fn(),
+    getProfile: vi.fn(),
+    activateProfile: vi.fn(),
+  },
+  WELL_KNOWN_DEFAULT_AGENT_PROFILE_NAME: "default",
+}));
+
+const { displayWarningToast } = vi.hoisted(() => ({
+  displayWarningToast: vi.fn(),
+}));
+vi.mock("#/utils/custom-toast-handlers", () => ({
+  displayWarningToast,
+}));
+
+function renderApplyHook() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return renderHook(() => useApplyOnboardingAgentProfile(), {
+    wrapper: ({ children }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        children,
+      ),
+  });
+}
+
+describe("useApplyOnboardingAgentProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("activates the profile by id after saving, without warning the user", async () => {
+    vi.mocked(AgentProfilesService.saveProfile).mockResolvedValue({
+      name: "default",
+    } as never);
+    vi.mocked(AgentProfilesService.getProfile).mockResolvedValue({
+      profile: { id: "profile-uuid" },
+    } as never);
+    vi.mocked(AgentProfilesService.activateProfile).mockResolvedValue(
+      undefined as never,
+    );
+
+    const { result } = renderApplyHook();
+    await result.current({
+      agent_kind: "openhands",
+      llm_profile_ref: "gpt-4o",
+    });
+
+    expect(AgentProfilesService.activateProfile).toHaveBeenCalledWith(
+      "profile-uuid",
+    );
+    expect(displayWarningToast).not.toHaveBeenCalled();
+  });
+
+  it("does not block on failure, but warns the user instead of failing silently", async () => {
+    // Regression: this was try/catch-swallowed to a bare console.error with
+    // no user-visible signal at all — the active agent profile is left
+    // stranded on its old/seeded config with zero indication anything went
+    // wrong, in the one flow (first-run onboarding) where that matters most.
+    vi.mocked(AgentProfilesService.saveProfile).mockRejectedValue(
+      new Error("network down"),
+    );
+
+    const { result } = renderApplyHook();
+
+    // Doesn't throw — the "never block onboarding" guarantee still holds.
+    await expect(
+      result.current({ agent_kind: "openhands", llm_profile_ref: "gpt-4o" }),
+    ).resolves.toBeUndefined();
+
+    await waitFor(() => {
+      expect(displayWarningToast).toHaveBeenCalledWith(
+        "ONBOARDING$LLM_FINALIZE_FAILED",
+      );
+    });
+    expect(AgentProfilesService.activateProfile).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/routes/llm-settings.test.tsx
+++ b/__tests__/routes/llm-settings.test.tsx
@@ -517,6 +517,35 @@ describe("LlmSettingsScreen - provider connection selector", () => {
       "openai/glm-5.3-flash:cloud",
     );
   });
+
+  it("makes the Basic tab unreachable for a profile linked to a provider connection", async () => {
+    // Companion to the initial-view fix above: even if something else were to
+    // land the form on Basic, the tab itself shouldn't be reachable for a
+    // connection-linked profile — that tier has no way to represent the
+    // connection at all, and its Model dropdown renders blank for any model
+    // absent from the resolved provider's catalog.
+    vi.spyOn(activeBackendContext, "useActiveBackend").mockReturnValue({
+      backend: mockLocalBackend,
+    } as ReturnType<typeof activeBackendContext.useActiveBackend>);
+    vi.spyOn(ProviderConnectionsService, "list").mockResolvedValue([
+      connection,
+    ]);
+
+    renderLlmSettingsScreen({
+      embedded: true,
+      hideSaveButton: true,
+      showProviderConnection: true,
+      initialValueOverrides: {
+        "llm.model": "openai/glm-5.3-flash:cloud",
+        "llm.provider_connection_id": "conn-1",
+      },
+    });
+
+    await screen.findByTestId("llm-settings-screen");
+    expect(
+      screen.queryByTestId("sdk-section-basic-toggle"),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("LlmSettingsScreen - OpenHands provider on cloud", () => {

--- a/__tests__/routes/llm-settings.test.tsx
+++ b/__tests__/routes/llm-settings.test.tsx
@@ -481,6 +481,42 @@ describe("LlmSettingsScreen - provider connection selector", () => {
       await screen.findByTestId("llm-provider-connection-input"),
     ).toBeInTheDocument();
   });
+
+  it("opens on a non-Basic tab when linked to a provider connection, even if the active settings look like Basic defaults (bug repro)", async () => {
+    // Regression: getInitialView used to infer the tab from the globally
+    // active settings only, ignoring initialValueOverrides entirely. A
+    // profile linked to a connection (whose credential/base_url live off
+    // the profile, not inline) would then silently open on the Basic tab
+    // whenever the *active* settings happened to look like a plain default
+    // model — regardless of what the profile being edited actually
+    // contains. On the Basic tab, ModelSelector binds its Model dropdown to
+    // a key absent from the resolved provider's real catalog for any model
+    // string not in that catalog, and HeroUI's Autocomplete silently
+    // rewrites it to an unrelated model once the list loads — corrupting
+    // `llm.model`.
+    vi.spyOn(activeBackendContext, "useActiveBackend").mockReturnValue({
+      backend: mockLocalBackend,
+    } as ReturnType<typeof activeBackendContext.useActiveBackend>);
+    vi.spyOn(ProviderConnectionsService, "list").mockResolvedValue([
+      connection,
+    ]);
+
+    renderLlmSettingsScreen({
+      embedded: true,
+      hideSaveButton: true,
+      showProviderConnection: true,
+      initialValueOverrides: {
+        "llm.model": "openai/glm-5.3-flash:cloud",
+        "llm.provider_connection_id": "conn-1",
+      },
+    });
+
+    await screen.findByTestId("llm-settings-screen");
+    expect(screen.queryByTestId("llm-provider-input")).not.toBeInTheDocument();
+    expect(await screen.findByTestId("llm-custom-model-input")).toHaveValue(
+      "openai/glm-5.3-flash:cloud",
+    );
+  });
 });
 
 describe("LlmSettingsScreen - OpenHands provider on cloud", () => {

--- a/src/components/features/onboarding/steps/setup-llm-step.tsx
+++ b/src/components/features/onboarding/steps/setup-llm-step.tsx
@@ -14,6 +14,7 @@ import {
 } from "#/hooks/query/use-free-models";
 import { LlmSettingsInputsSkeleton } from "#/components/features/settings/llm-settings/llm-settings-inputs-skeleton";
 import { deriveProfileNameFromModel } from "#/utils/derive-profile-name";
+import { displayWarningToast } from "#/utils/custom-toast-handlers";
 
 interface SetupLlmStepProps {
   onBack: () => void;
@@ -92,12 +93,18 @@ export function SetupLlmStep({ onBack, onNext }: SetupLlmStepProps) {
       await activateProfile.mutateAsync(name);
       return name;
     } catch (error) {
-      // Best-effort: the agent_settings save already succeeded, so the
-      // user is not blocked from completing onboarding.
+      // Best-effort: the agent_settings save already succeeded, so the user
+      // is not blocked from completing onboarding — but silently swallowing
+      // this left a real failure mode invisible: the active agent profile
+      // keeps its seeded, keyless llm_profile_ref, and the user's first
+      // conversation fails with no way to trace it back to this step. A
+      // non-blocking warning preserves "never block" while not stranding
+      // them with zero diagnosis path.
       console.error("Failed to persist onboarding LLM as profile:", error);
+      displayWarningToast(t(I18nKey.ONBOARDING$LLM_FINALIZE_FAILED));
       return null;
     }
-  }, [isLocalBackend, saveControl, saveProfile, activateProfile]);
+  }, [isLocalBackend, saveControl, saveProfile, activateProfile, t]);
 
   const handleSaveSuccess = React.useCallback(async () => {
     setIsFinalizing(true);

--- a/src/components/features/settings/key-status-icon.tsx
+++ b/src/components/features/settings/key-status-icon.tsx
@@ -4,11 +4,24 @@ import { cn } from "#/utils/utils";
 interface KeyStatusIconProps {
   testId?: string;
   isSet: boolean;
+  /**
+   * Accessible/visible-on-hover text. Defaults to a plain "a key string is
+   * stored" reading, which is all this icon actually checks — it never pings
+   * the provider. Override with a context-specific label anywhere the icon
+   * sits apart from the key field itself (e.g. a connection row), where
+   * "stored" on its own could read as "verified working."
+   */
+  label?: string;
 }
 
-export function KeyStatusIcon({ testId, isSet }: KeyStatusIconProps) {
+export function KeyStatusIcon({ testId, isSet, label }: KeyStatusIconProps) {
+  const resolvedLabel = label ?? (isSet ? "API key set" : "API key not set");
   return (
-    <span data-testid={testId || (isSet ? "set-indicator" : "unset-indicator")}>
+    <span
+      data-testid={testId || (isSet ? "set-indicator" : "unset-indicator")}
+      title={resolvedLabel}
+      aria-label={resolvedLabel}
+    >
       <SuccessIcon className={cn(isSet ? "text-success" : "text-danger")} />
     </span>
   );

--- a/src/components/features/settings/llm-profiles/bulk-add-models-modal.tsx
+++ b/src/components/features/settings/llm-profiles/bulk-add-models-modal.tsx
@@ -1,0 +1,243 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { BrandButton } from "#/components/features/settings/brand-button";
+import { LoadingSpinner } from "#/components/shared/loading-spinner";
+import { ApiKeyModalBase } from "#/components/features/settings/api-key-modal-base";
+import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
+import { useSaveLlmProfile } from "#/hooks/mutation/use-save-llm-profile";
+import { deriveProfileNameFromModel } from "#/utils/derive-profile-name";
+import { getApiErrorMessage } from "#/utils/api-error-message";
+import { I18nKey } from "#/i18n/declaration";
+
+interface BulkAddModelsModalProps {
+  /** When `null` the modal is closed. */
+  connection: ProviderConnection | null;
+  /** Names of profiles that already exist, so pasted models that would
+   * collide are skipped instead of erroring. */
+  existingProfileNames: Set<string>;
+  onClose: () => void;
+}
+
+/** One parsed model id from the textarea, paired with its derived profile name. */
+interface ParsedModel {
+  modelId: string;
+  profileName: string;
+}
+
+type ResultStatus = "created" | "failed";
+
+/**
+ * Splits pasted text into model ids: newline- or comma-separated, trimmed,
+ * empty entries dropped, duplicates collapsed (first occurrence wins).
+ */
+function parseModelIds(raw: string): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const line of raw.split(/[\n,]/)) {
+    const trimmed = line.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    ids.push(trimmed);
+  }
+  return ids;
+}
+
+/**
+ * A model id pasted with its own provider prefix (e.g. "openai/gpt-4o") is
+ * used verbatim; a bare id (e.g. "gpt-oss:120b") is prefixed with the
+ * connection's provider so it routes through the connection correctly.
+ */
+function buildModelString(connection: ProviderConnection, modelId: string) {
+  return modelId.includes("/") ? modelId : `${connection.provider}/${modelId}`;
+}
+
+/**
+ * Creates one LLM profile per pasted model id, all linked to the same
+ * provider connection. There is no live "discover this connection's models"
+ * endpoint (that needs a server-side proxy that doesn't exist here — a
+ * browser `fetch` to an arbitrary base URL is blocked by CORS), so the user
+ * supplies the id list themselves — e.g. from their own `curl .../v1/models`
+ * output or the provider's docs.
+ */
+export function BulkAddModelsModal({
+  connection,
+  existingProfileNames,
+  onClose,
+}: BulkAddModelsModalProps) {
+  const { t } = useTranslation("openhands");
+  const saveProfile = useSaveLlmProfile();
+  const [rawInput, setRawInput] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [results, setResults] = useState<
+    { modelId: string; status: ResultStatus; error?: string }[] | null
+  >(null);
+
+  const { toCreate, toSkip }: { toCreate: ParsedModel[]; toSkip: string[] } =
+    useMemo(() => {
+      const create: ParsedModel[] = [];
+      const skip: string[] = [];
+      for (const modelId of parseModelIds(rawInput)) {
+        const profileName = deriveProfileNameFromModel(modelId);
+        if (existingProfileNames.has(profileName)) {
+          skip.push(modelId);
+        } else {
+          create.push({ modelId, profileName });
+        }
+      }
+      return { toCreate: create, toSkip: skip };
+    }, [rawInput, existingProfileNames]);
+
+  if (!connection) return null;
+
+  const handleClose = () => {
+    if (isSubmitting) return;
+    setRawInput("");
+    setResults(null);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (toCreate.length === 0 || isSubmitting) return;
+    setIsSubmitting(true);
+    // Sequential, not Promise.all: keeps this from hammering the agent-server
+    // with a burst of concurrent saves, and each result is attributable to
+    // its own model as it lands rather than resolved all-at-once.
+    const outcomes: {
+      modelId: string;
+      status: ResultStatus;
+      error?: string;
+    }[] = [];
+    for (const { modelId, profileName } of toCreate) {
+      try {
+        await saveProfile.mutateAsync({
+          name: profileName,
+          request: {
+            llm: {
+              model: buildModelString(connection, modelId),
+              provider_connection_id: connection.id,
+              auth_type: "api_key",
+              subscription_vendor: null,
+            },
+            include_secrets: true,
+          },
+        });
+        outcomes.push({ modelId, status: "created" });
+      } catch (error) {
+        outcomes.push({
+          modelId,
+          status: "failed",
+          error: getApiErrorMessage(error, t(I18nKey.ERROR$GENERIC)),
+        });
+      }
+    }
+    setResults(outcomes);
+    setIsSubmitting(false);
+  };
+
+  const createdCount =
+    results?.filter((r) => r.status === "created").length ?? 0;
+  const failed = results?.filter((r) => r.status === "failed") ?? [];
+
+  const footer = results ? (
+    <BrandButton
+      testId="bulk-add-models-done"
+      type="button"
+      variant="primary"
+      onClick={handleClose}
+    >
+      {t(I18nKey.BUTTON$CLOSE)}
+    </BrandButton>
+  ) : (
+    <>
+      <BrandButton
+        type="button"
+        variant="tertiary"
+        onClick={handleClose}
+        isDisabled={isSubmitting}
+      >
+        {t(I18nKey.BUTTON$CANCEL)}
+      </BrandButton>
+      <BrandButton
+        testId="bulk-add-models-submit"
+        type="button"
+        variant="primary"
+        onClick={handleSubmit}
+        isDisabled={isSubmitting || toCreate.length === 0}
+        aria-busy={isSubmitting}
+      >
+        {isSubmitting ? (
+          <LoadingSpinner size="small" />
+        ) : (
+          t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_SUBMIT, {
+            count: toCreate.length,
+          })
+        )}
+      </BrandButton>
+    </>
+  );
+
+  return (
+    <ApiKeyModalBase
+      isOpen
+      title={t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TITLE)}
+      footer={footer}
+      onClose={handleClose}
+    >
+      <div data-testid="bulk-add-models-modal" className="flex flex-col gap-4">
+        {results ? (
+          <div className="flex flex-col gap-2 text-sm">
+            <p data-testid="bulk-add-models-result-created">
+              {t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_CREATED, {
+                count: createdCount,
+              })}
+            </p>
+            {failed.length > 0 ? (
+              <p
+                data-testid="bulk-add-models-result-failed"
+                className="text-danger"
+              >
+                {t(
+                  I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_FAILED,
+                  { names: failed.map((f) => f.modelId).join(", ") },
+                )}
+              </p>
+            ) : null}
+          </div>
+        ) : (
+          <>
+            <fieldset className="flex flex-col gap-2.5 w-full">
+              <label className="text-sm" htmlFor="bulk-add-models-textarea">
+                {t(
+                  I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TEXTAREA_LABEL,
+                )}
+              </label>
+              <textarea
+                id="bulk-add-models-textarea"
+                data-testid="bulk-add-models-textarea"
+                className="w-full min-h-32 rounded-lg border border-[var(--oh-border)] bg-base-secondary px-3 py-2 text-sm text-white"
+                value={rawInput}
+                onChange={(event) => setRawInput(event.target.value)}
+                // eslint-disable-next-line i18next/no-literal-string -- example value, not translatable
+                placeholder={"gpt-oss:120b-cloud\nglm-5.3-flash:cloud"}
+              />
+              <p className="text-xs text-[var(--oh-muted)]">
+                {t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_HINT)}
+              </p>
+            </fieldset>
+            {toCreate.length > 0 || toSkip.length > 0 ? (
+              <p
+                data-testid="bulk-add-models-preview"
+                className="text-xs text-[var(--oh-muted)]"
+              >
+                {t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_PREVIEW, {
+                  create: toCreate.length,
+                  skip: toSkip.length,
+                })}
+              </p>
+            ) : null}
+          </>
+        )}
+      </div>
+    </ApiKeyModalBase>
+  );
+}

--- a/src/components/features/settings/llm-profiles/llm-profiles-manager.tsx
+++ b/src/components/features/settings/llm-profiles/llm-profiles-manager.tsx
@@ -71,6 +71,10 @@ export function LlmProfilesManager({
     }
     return counts;
   }, [profiles]);
+  const existingProfileNames = useMemo(
+    () => new Set(profiles.map((p) => p.name)),
+    [profiles],
+  );
 
   const handleActivate = async (name: string) => {
     try {
@@ -162,6 +166,7 @@ export function LlmProfilesManager({
           <ProviderConnectionsManager
             connections={connectionList}
             linkedCountById={linkedCountById}
+            existingProfileNames={existingProfileNames}
             isLoading={isLoadingConnections}
             loadError={connectionsError ?? null}
           />

--- a/src/components/features/settings/llm-profiles/provider-connection-modal.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connection-modal.tsx
@@ -26,6 +26,27 @@ import { heroUiAutocompleteSelectorButtonClassName } from "#/ui/combobox-caret";
 
 const DEFAULT_PROVIDER = "custom";
 
+/**
+ * OpenAI-API-compatible cloud services that aren't their own litellm
+ * provider (so they're reached via `provider: "openai"` + a custom
+ * `base_url`, not picked from the main Provider dropdown). Kept short and
+ * limited to base URLs actually verified against the live service — a wrong
+ * or stale preset silently misconfigures a credential, which is worse than
+ * no preset at all. Extend this list only from a source that's been tested,
+ * not copied from docs.
+ */
+const OPENAI_COMPATIBLE_PRESETS: {
+  id: string;
+  label: string;
+  baseUrl: string;
+}[] = [
+  {
+    id: "ollama-cloud",
+    label: "Ollama Cloud",
+    baseUrl: "https://ollama.com/v1",
+  },
+];
+
 interface ProviderConnectionModalProps {
   /** When `null` the modal is closed; otherwise it edits that connection. */
   connection?: ProviderConnection | null;
@@ -96,6 +117,14 @@ export function ProviderConnectionModal({
 
   const handleClose = () => {
     if (!isPending) onClose();
+  };
+
+  const handleApplyPreset = (
+    preset: (typeof OPENAI_COMPATIBLE_PRESETS)[number],
+  ) => {
+    setProvider("openai");
+    setBaseUrl(preset.baseUrl);
+    if (!displayName.trim()) setDisplayName(preset.label);
   };
 
   const handleSubmit = async () => {
@@ -263,17 +292,35 @@ export function ProviderConnectionModal({
               : undefined
           }
         />
-        <SettingsInput
-          testId="provider-connection-base-url-input"
-          label={t(I18nKey.SETTINGS$BASE_URL)}
-          type="text"
-          className="w-full"
-          value={baseUrl}
-          // eslint-disable-next-line i18next/no-literal-string -- example value, not translatable
-          placeholder="https://api.openai.com"
-          onChange={setBaseUrl}
-          showOptionalTag
-        />
+        <div className="flex flex-col gap-2">
+          <SettingsInput
+            testId="provider-connection-base-url-input"
+            label={t(I18nKey.SETTINGS$BASE_URL)}
+            type="text"
+            className="w-full"
+            value={baseUrl}
+            // eslint-disable-next-line i18next/no-literal-string -- example value, not translatable
+            placeholder="https://api.openai.com"
+            onChange={setBaseUrl}
+            showOptionalTag
+          />
+          <div
+            className="flex flex-wrap gap-2"
+            data-testid="provider-connection-presets"
+          >
+            {OPENAI_COMPATIBLE_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                data-testid={`provider-connection-preset-${preset.id}`}
+                onClick={() => handleApplyPreset(preset)}
+                className="rounded-full border border-[var(--oh-border)] px-3 py-1 text-xs text-[var(--oh-muted)] hover:text-white hover:border-white/40"
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
     </ApiKeyModalBase>
   );

--- a/src/components/features/settings/llm-profiles/provider-connection-row.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connection-row.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import EditIcon from "#/icons/u-edit.svg?react";
 import DeleteIcon from "#/icons/u-delete.svg?react";
+import PlusIcon from "#/icons/u-plus.svg?react";
 import { KeyStatusIcon } from "#/components/features/settings/key-status-icon";
 import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
 import { cn } from "#/utils/utils";
@@ -16,6 +17,7 @@ interface ProviderConnectionRowProps {
   linkedProfileCount: number;
   onEdit: (connection: ProviderConnection) => void;
   onDelete: (connection: ProviderConnection) => void;
+  onBulkAddModels: (connection: ProviderConnection) => void;
 }
 
 export function ProviderConnectionRow({
@@ -23,6 +25,7 @@ export function ProviderConnectionRow({
   linkedProfileCount,
   onEdit,
   onDelete,
+  onBulkAddModels,
 }: ProviderConnectionRowProps) {
   const { t } = useTranslation("openhands");
 
@@ -49,6 +52,15 @@ export function ProviderConnectionRow({
         <KeyStatusIcon isSet={connection.api_key_set} />
       </div>
       <div className="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          data-testid="provider-connection-bulk-add"
+          aria-label={t(I18nKey.SETTINGS$PROVIDER_CONNECTION_BULK_ADD_ACTION)}
+          className={settingsListIconActionButtonClassName}
+          onClick={() => onBulkAddModels(connection)}
+        >
+          <PlusIcon width={16} height={16} />
+        </button>
         <button
           type="button"
           data-testid="provider-connection-edit"

--- a/src/components/features/settings/llm-profiles/provider-connection-row.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connection-row.tsx
@@ -49,7 +49,14 @@ export function ProviderConnectionRow({
             count: linkedProfileCount,
           })}
         </span>
-        <KeyStatusIcon isSet={connection.api_key_set} />
+        <KeyStatusIcon
+          isSet={connection.api_key_set}
+          label={t(
+            connection.api_key_set
+              ? I18nKey.SETTINGS$PROVIDER_CONNECTION_KEY_SET_LABEL
+              : I18nKey.SETTINGS$PROVIDER_CONNECTION_KEY_UNSET_LABEL,
+          )}
+        />
       </div>
       <div className="flex shrink-0 items-center gap-1">
         <button

--- a/src/components/features/settings/llm-profiles/provider-connections-manager.tsx
+++ b/src/components/features/settings/llm-profiles/provider-connections-manager.tsx
@@ -4,6 +4,7 @@ import { BrandButton } from "#/components/features/settings/brand-button";
 import { ProviderConnectionRow } from "./provider-connection-row";
 import { ProviderConnectionModal } from "./provider-connection-modal";
 import { DeleteProviderConnectionModal } from "./delete-provider-connection-modal";
+import { BulkAddModelsModal } from "./bulk-add-models-modal";
 import type { ProviderConnection } from "#/api/provider-connections-service/provider-connections-service.api";
 import { cn } from "#/utils/utils";
 import {
@@ -17,6 +18,8 @@ interface ProviderConnectionsManagerProps {
   connections: ProviderConnection[];
   /** Number of LLM profiles linked to each connection id. */
   linkedCountById: Record<string, number>;
+  /** Existing profile names, so bulk-add can skip ones that already exist. */
+  existingProfileNames?: Set<string>;
   isLoading: boolean;
   loadError: Error | null;
 }
@@ -29,6 +32,7 @@ interface ProviderConnectionsManagerProps {
 export function ProviderConnectionsManager({
   connections,
   linkedCountById,
+  existingProfileNames = new Set(),
   isLoading,
   loadError,
 }: ProviderConnectionsManagerProps) {
@@ -37,6 +41,8 @@ export function ProviderConnectionsManager({
   const [connectionToEdit, setConnectionToEdit] =
     useState<ProviderConnection | null>(null);
   const [connectionToDelete, setConnectionToDelete] =
+    useState<ProviderConnection | null>(null);
+  const [connectionToBulkAdd, setConnectionToBulkAdd] =
     useState<ProviderConnection | null>(null);
 
   const renderBody = () => {
@@ -82,6 +88,7 @@ export function ProviderConnectionsManager({
             linkedProfileCount={linkedCountById[connection.id] ?? 0}
             onEdit={setConnectionToEdit}
             onDelete={setConnectionToDelete}
+            onBulkAddModels={setConnectionToBulkAdd}
           />
         ))}
       </div>
@@ -128,6 +135,11 @@ export function ProviderConnectionsManager({
       <DeleteProviderConnectionModal
         connection={connectionToDelete}
         onClose={() => setConnectionToDelete(null)}
+      />
+      <BulkAddModelsModal
+        connection={connectionToBulkAdd}
+        existingProfileNames={existingProfileNames}
+        onClose={() => setConnectionToBulkAdd(null)}
       />
     </>
   );

--- a/src/components/features/settings/sdk-settings/sdk-section-page.tsx
+++ b/src/components/features/settings/sdk-settings/sdk-section-page.tsx
@@ -193,6 +193,7 @@ export function SdkSectionPage({
   getInitialView,
   forceShowAdvancedView = false,
   allowAllView = true,
+  hideBasicView = false,
   initialValueOverrides,
   markInitialOverridesDirty = true,
   embedded = false,
@@ -226,6 +227,16 @@ export function SdkSectionPage({
   ) => SettingsView;
   forceShowAdvancedView?: boolean;
   allowAllView?: boolean;
+  /**
+   * Hide the Basic tab regardless of the schema's critical fields. For a
+   * section whose Basic-tier UI can't represent the current value at all
+   * (e.g. an LLM profile linked to a provider connection, or a custom model
+   * absent from the selected provider's catalog) — showing Basic there
+   * doesn't just look wrong, its controls silently overwrite the real value
+   * with the nearest thing they *can* represent. Floors the view at
+   * Advanced/All instead of letting it be reached.
+   */
+  hideBasicView?: boolean;
   /**
    * Per-field initial value overrides that win over the values derived from
    * `useSettings`. When {@link markInitialOverridesDirty} is true (default),
@@ -329,9 +340,9 @@ export function SdkSectionPage({
   // The basic tier only exists when some field renders in it; a critical-less
   // page (e.g. Memory, whose only field is major) hides the Basic tab and
   // floors its view at "advanced".
-  const showBasic = resolvedSources.some((src) =>
-    hasCriticalSettings(src.filteredSchema),
-  );
+  const showBasic =
+    !hideBasicView &&
+    resolvedSources.some((src) => hasCriticalSettings(src.filteredSchema));
   const showAdvanced =
     forceShowAdvancedView ||
     resolvedSources.some((src) => hasAdvancedSettings(src.filteredSchema));

--- a/src/hooks/mutation/use-apply-onboarding-agent-profile.ts
+++ b/src/hooks/mutation/use-apply-onboarding-agent-profile.ts
@@ -1,10 +1,13 @@
 import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import AgentProfilesService, {
   WELL_KNOWN_DEFAULT_AGENT_PROFILE_NAME,
   type AgentProfileSaveInput,
 } from "#/api/agent-profiles-service/agent-profiles-service.api";
 import { useSaveAgentProfile } from "#/hooks/mutation/use-save-agent-profile";
 import { useActivateAgentProfile } from "#/hooks/mutation/use-activate-agent-profile";
+import { displayWarningToast } from "#/utils/custom-toast-handlers";
+import { I18nKey } from "#/i18n/declaration";
 
 /**
  * The well-known agent profile onboarding configures. Conversations launch from
@@ -27,6 +30,7 @@ export const ONBOARDING_AGENT_PROFILE_NAME =
  * setup steps already wrote remain the fallback.
  */
 export function useApplyOnboardingAgentProfile() {
+  const { t } = useTranslation("openhands");
   const saveProfile = useSaveAgentProfile();
   const activateProfile = useActivateAgentProfile();
 
@@ -50,9 +54,15 @@ export function useApplyOnboardingAgentProfile() {
         const id = detail.profile.id;
         if (id) await activateProfile.mutateAsync(id);
       } catch (error) {
+        // Best-effort by design (see doc comment), but silently swallowing
+        // this left the failure invisible: the active agent profile keeps
+        // pointing at its old/seeded config with no visible sign anything
+        // went wrong. A non-blocking warning preserves "never block" while
+        // giving the user somewhere to look.
         console.error("Failed to configure onboarding agent profile:", error);
+        displayWarningToast(t(I18nKey.ONBOARDING$LLM_FINALIZE_FAILED));
       }
     },
-    [saveProfile, activateProfile],
+    [saveProfile, activateProfile, t],
   );
 }

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -41913,5 +41913,11 @@
   },
   "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_FAILED": {
     "en": "Failed: {{names}}"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_KEY_SET_LABEL": {
+    "en": "API key stored (not verified against the provider)"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_KEY_UNSET_LABEL": {
+    "en": "No API key stored"
   }
 }

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -14262,7 +14262,6 @@
     "uk": "Повідомлено користувацькі метадані завдання.",
     "ca": "S'han informat metadades personalitzades de la tasca."
   },
-
   "AUTOMATIONS$DETAIL$VIEW_CONVERSATION_FOR_RUN": {
     "en": "View conversation for run at {{timestamp}}",
     "ja": "{{timestamp}} の実行の会話を表示",
@@ -14280,7 +14279,6 @@
     "uk": "Переглянути розмову для запуску о {{timestamp}}",
     "ca": "Mostra la conversa de l'execució a {{timestamp}}"
   },
-
   "AUTOMATIONS$DETAIL$PHASE": {
     "ar": "المرحلة",
     "ca": "Fase",
@@ -41888,5 +41886,32 @@
     "uk": "Попередній перегляд зображення в повному розмірі",
     "zh-CN": "原始尺寸图片预览",
     "zh-TW": "原始尺寸圖片預覽"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_ACTION": {
+    "en": "Bulk add models"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TITLE": {
+    "en": "Bulk add models"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_TEXTAREA_LABEL": {
+    "en": "Model IDs"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_HINT": {
+    "en": "Paste model IDs, one per line (or comma-separated). Each becomes its own profile linked to this connection."
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_PREVIEW": {
+    "en": "{{create}} new, {{skip}} already exist"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_SUBMIT": {
+    "en": "Create {{count}} profile(s)"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_CREATED": {
+    "en": "Created {{count}} profile(s)"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_SKIPPED": {
+    "en": "Skipped {{count}} (already exist)"
+  },
+  "SETTINGS$PROVIDER_CONNECTION_BULK_ADD_RESULT_FAILED": {
+    "en": "Failed: {{names}}"
   }
 }

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -41919,5 +41919,8 @@
   },
   "SETTINGS$PROVIDER_CONNECTION_KEY_UNSET_LABEL": {
     "en": "No API key stored"
+  },
+  "ONBOARDING$LLM_FINALIZE_FAILED": {
+    "en": "Your settings were saved, but couldn't be fully applied. Check Settings → LLM to confirm your model is set up correctly."
   }
 }

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -218,15 +218,47 @@ export function LlmSettingsScreen({
         return schemaView;
       }
 
-      const currentModel = currentSettings.llm_model ?? "";
-      const trimmedBaseUrl = currentSettings.llm_base_url?.trim() ?? "";
+      // Embedded profile forms (create/edit) seed values via
+      // `initialValueOverrides`, which this callback previously ignored —
+      // it read only the globally active settings. That let editing a
+      // profile with a custom model/base URL (or one linked to a provider
+      // connection) silently land on the Basic tab regardless of what the
+      // profile being edited actually contains. Once there, ModelSelector
+      // binds its Model dropdown to a key absent from the resolved
+      // provider's real catalog, and HeroUI's Autocomplete silently
+      // reconciles that to an unrelated model once its list loads —
+      // corrupting `llm.model`. Prefer the overrides here so the tab is
+      // inferred from the profile actually being edited.
+      const overrideConnectionId =
+        initialValueOverrides?.[LLM_PROVIDER_CONNECTION_KEY];
+      const isLinkedToConnection =
+        typeof overrideConnectionId === "string" &&
+        overrideConnectionId.length > 0;
+      // A connection-linked profile carries no inline base_url of its own
+      // (see llm-settings-local-view.tsx's save logic), so there is nothing
+      // here to compare against a provider default. The Basic tab has no
+      // concept of provider connections at all, so always defer to "all".
+      if (isLinkedToConnection) {
+        return "all";
+      }
+
+      const overrideModel = initialValueOverrides?.["llm.model"];
+      const overrideBaseUrl = initialValueOverrides?.["llm.base_url"];
+      const currentModel =
+        typeof overrideModel === "string"
+          ? overrideModel
+          : (currentSettings.llm_model ?? "");
+      const trimmedBaseUrl =
+        typeof overrideBaseUrl === "string"
+          ? overrideBaseUrl.trim()
+          : (currentSettings.llm_base_url?.trim() ?? "");
       const hasCustomBaseUrl =
         trimmedBaseUrl.length > 0 &&
         !isProviderDefaultBaseUrl(currentModel, trimmedBaseUrl);
 
       return hasCustomBaseUrl ? "all" : "basic";
     },
-    [],
+    [initialValueOverrides],
   );
 
   const buildHeader = React.useCallback(

--- a/src/routes/llm-settings.tsx
+++ b/src/routes/llm-settings.tsx
@@ -654,6 +654,35 @@ export function LlmSettingsScreen({
     [schema, subscriptionModels, isCloud],
   );
 
+  // Mirrors getInitialView's own "does Basic even represent this?" check
+  // (only meaningful in embedded profile-editor mode; initialValueOverrides
+  // is empty on the standalone Settings page, so this is a no-op there).
+  // ModelSelector's Model dropdown renders blank whenever the current model
+  // isn't in the resolved provider's fetched catalog — true for any
+  // connection-linked profile (whose credential/base_url aren't on the
+  // profile itself) and for any custom model paired with a non-default base
+  // URL. Rather than let a user tab into a Basic view that can't represent
+  // their config and silently discard it, the tab isn't reachable at all.
+  const overrideConnectionId =
+    initialValueOverrides?.[LLM_PROVIDER_CONNECTION_KEY];
+  const isLinkedToConnectionOverride =
+    typeof overrideConnectionId === "string" && overrideConnectionId.length > 0;
+  const overrideModelForBasicGate = initialValueOverrides?.["llm.model"];
+  const overrideBaseUrlForBasicGate = initialValueOverrides?.["llm.base_url"];
+  const trimmedOverrideBaseUrl =
+    typeof overrideBaseUrlForBasicGate === "string"
+      ? overrideBaseUrlForBasicGate.trim()
+      : "";
+  const hasCustomBaseUrlOverride =
+    typeof overrideModelForBasicGate === "string" &&
+    trimmedOverrideBaseUrl.length > 0 &&
+    !isProviderDefaultBaseUrl(
+      overrideModelForBasicGate,
+      trimmedOverrideBaseUrl,
+    );
+  const hideBasicViewForEmbeddedProfile =
+    isLinkedToConnectionOverride || hasCustomBaseUrlOverride;
+
   return (
     <SdkSectionPage
       scope={scope}
@@ -669,6 +698,7 @@ export function LlmSettingsScreen({
       getInitialView={getInitialView}
       forceShowAdvancedView
       allowAllView
+      hideBasicView={hideBasicViewForEmbeddedProfile}
       onSaveSuccess={onSaveSuccess}
       initialValueOverrides={initialValueOverrides}
       markInitialOverridesDirty={markInitialOverridesDirty}


### PR DESCRIPTION
## Summary

During first-run onboarding, `setup-llm-step.tsx`'s `persistAsProfile` saves the chosen LLM as a profile and then activates it as the default agent's config, after the base settings save has already succeeded. That finalization step (and its counterpart in `use-apply-onboarding-agent-profile.ts`) was wrapped in try/catch with only a `console.error` on failure — while `finally { onNext(); }` always advances the wizard regardless. A user's very first onboarding run could therefore complete with the wizard reporting "done" while the active agent profile silently keeps pointing at its old/seeded config, with no visible signal and no path to diagnose it — in the one flow where a broken config matters most (their first conversation).

- Added a new i18n key, `ONBOARDING$LLM_FINALIZE_FAILED`, with a message pointing the user to Settings → LLM.
- `setup-llm-step.tsx`'s `persistAsProfile` catch block now calls `displayWarningToast(...)` alongside the existing `console.error`.
- `use-apply-onboarding-agent-profile.ts`'s catch block does the same.
- Both keep the existing "never block onboarding" guarantee — the warning is non-blocking, the wizard still advances.

## Test plan

- [x] New test file `__tests__/hooks/mutation/use-apply-onboarding-agent-profile.test.ts`: covers (1) the success path — profile activates by id, no warning shown — and (2) the failure path — the hook resolves without throwing (doesn't block onboarding) while showing the warning toast with the correct i18n key, and `activateProfile` is never called.
- [x] `npx eslint` clean on all touched files
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run __tests__/hooks/mutation/use-apply-onboarding-agent-profile.test.ts` — 2/2 passing
- [x] Deliberately skipped a full component test for `setup-llm-step.tsx`'s equivalent catch block — the change there is a one-line addition already covered structurally by the hook test, and a full component test would require disproportionate mocking for the marginal coverage gained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ach3EeSEJZkWbGNHggYEAa