### PR TITLE
fix(canvas): persist workspace grouping across clients

### DIFF
--- a/__tests__/api/agent-server-adapter.test.ts
+++ b/__tests__/api/agent-server-adapter.test.ts
@@ -1069,6 +1069,55 @@ describe("toAppConversation", () => {
     expect(result.acp_server).toBeNull();
   });
 
+
+  describe("server-side tag fallback", () => {
+    const taggedInfo: DirectConversationInfo = {
+      ...baseInfo,
+      tags: {
+        repository: "OpenHands/OpenHands",
+        selected_branch: "main",
+        git_provider: "github",
+        workspace: "/Users/jane/projects/openhands",
+      },
+    };
+
+    afterEach(() => {
+      removeStoredConversationMetadata(baseInfo.id);
+    });
+
+    it("hydrates workspace/repo metadata from tags when localStorage has none", () => {
+      const result = toAppConversation(taggedInfo);
+
+      expect(result.selected_workspace).toBe("/Users/jane/projects/openhands");
+      expect(result.selected_repository).toBe("OpenHands/OpenHands");
+      expect(result.selected_branch).toBe("main");
+      expect(result.git_provider).toBe("github");
+    });
+
+    it("prefers stored metadata over tags so the creating client keeps its warm cache", () => {
+      setStoredConversationMetadata(baseInfo.id, {
+        selected_repository: "jane/local-fork",
+        selected_branch: "feature",
+        git_provider: "gitlab",
+        selected_workspace: "/Users/jane/projects/local-fork",
+      });
+
+      const result = toAppConversation(taggedInfo);
+
+      expect(result.selected_workspace).toBe("/Users/jane/projects/local-fork");
+      expect(result.selected_repository).toBe("jane/local-fork");
+    });
+
+    it("drops an unrecognized git_provider tag instead of casting it through", () => {
+      const result = toAppConversation({
+        ...baseInfo,
+        tags: { git_provider: "not-a-real-provider" },
+      });
+
+      expect(result.git_provider).toBeNull();
+    });
+  });
+
   it("ignores tags.acpserver on OpenHands conversations to prevent stray-tag bleed", () => {
     // The agent-server's pydantic model doesn't enforce that ``acpserver``
     // is only stamped on ACP conversations. Defensively gating on

--- a/__tests__/api/agent-server-conversation-service.test.ts
+++ b/__tests__/api/agent-server-conversation-service.test.ts
@@ -428,6 +428,47 @@ describe("AgentServerConversationService", () => {
       expect(payload.worktree).toBe(false);
     });
 
+
+    it("stamps workspace and repo metadata as server-side tags", async () => {
+      mockGetSettings.mockResolvedValue({
+        agent_settings: { llm: { model: "gpt-4o" } },
+        conversation_settings: {},
+      });
+      mockGetSettingsForConversation.mockResolvedValue({
+        agentSettings: { llm: { model: "gpt-4o" } },
+        conversationSettings: {},
+        secretsEncrypted: true,
+      });
+      mockHttpPost.mockResolvedValue({
+        data: {
+          id: "ignored-server-id",
+          created_at: "2024-01-01",
+          updated_at: "2024-01-01",
+        },
+      });
+
+      await AgentServerConversationService.createConversation(
+        undefined,
+        undefined,
+        undefined,
+        {
+          selected_repository: "OpenHands/OpenHands",
+          selected_branch: "main",
+          git_provider: "github",
+        },
+        "/Users/jane/projects/foo",
+      );
+
+      const [payloadCall] = mockHttpPost.mock.calls;
+      const payload = payloadCall[1] as { tags: Record<string, string> };
+      expect(payload.tags).toMatchObject({
+        repository: "OpenHands/OpenHands",
+        selected_branch: "main",
+        git_provider: "github",
+        workspace: "/Users/jane/projects/foo",
+      });
+    });
+
     it("honors an explicit new-worktree mode for a selected workspace", async () => {
       mockGetSettings.mockResolvedValue({
         agent_settings: { llm: { model: "gpt-4o" } },

--- a/__tests__/api/conversation-workspace-grouping.test.ts
+++ b/__tests__/api/conversation-workspace-grouping.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+import { ExecutionStatus } from "#/types/agent-server/core";
+import {
+  buildConversationMetadataTags,
+  resolveSelectedWorkspaceForGrouping,
+} from "#/api/conversation-workspace-grouping";
+
+const base: Omit<AppConversation, "id" | "title"> = {
+  selected_repository: null,
+  selected_branch: null,
+  git_provider: null,
+  updated_at: "2024-01-02T00:00:00.000Z",
+  created_at: "2024-01-01T00:00:00.000Z",
+  execution_status: ExecutionStatus.FINISHED,
+  conversation_url: null,
+  created_by_user_id: null,
+  metrics: null,
+  llm_model: null,
+  trigger: null,
+  pr_number: [],
+  session_api_key: null,
+  sandbox_id: null,
+  sub_conversation_ids: [],
+};
+
+describe("conversation-workspace-grouping", () => {
+  it("buildConversationMetadataTags omits empty workspace paths", () => {
+    expect(
+      buildConversationMetadataTags({
+        selectedWorkspace: "  /tmp/project///  ",
+        gitProvider: "github",
+      }),
+    ).toEqual({
+      git_provider: "github",
+      workspace: "/tmp/project",
+    });
+  });
+
+  it("resolveSelectedWorkspaceForGrouping matches registered working_dir for legacy conversations", () => {
+    const conversation: AppConversation = {
+      ...base,
+      id: "legacy",
+      title: "legacy",
+      selected_workspace: null,
+      workspace: { working_dir: "/data/my-app" },
+      tags: null,
+    };
+
+    expect(
+      resolveSelectedWorkspaceForGrouping(conversation, [
+        "/other",
+        "/data/my-app",
+      ]),
+    ).toBe("/data/my-app");
+  });
+
+  it("resolveSelectedWorkspaceForGrouping does not group arbitrary worktree paths", () => {
+    const conversation: AppConversation = {
+      ...base,
+      id: "worktree",
+      title: "worktree",
+      selected_workspace: null,
+      workspace: { working_dir: "/workspace/project/abc123" },
+      tags: null,
+    };
+
+    expect(
+      resolveSelectedWorkspaceForGrouping(conversation, ["/workspace/project"]),
+    ).toBeNull();
+  });
+});

--- a/__tests__/components/features/conversation-panel/conversation-panel-list-helpers.test.ts
+++ b/__tests__/components/features/conversation-panel/conversation-panel-list-helpers.test.ts
@@ -31,6 +31,32 @@ const base: Omit<AppConversation, "id" | "title" | "workspace"> = {
 };
 
 describe("conversation-panel-list-helpers", () => {
+  it("groups legacy local conversations by matching working_dir to registered workspaces", () => {
+    const legacy: AppConversation = {
+      ...base,
+      id: "legacy-local",
+      title: "legacy-local",
+      selected_workspace: null,
+      workspace: { working_dir: "/home/user/projects/demo" },
+      updated_at: "2024-01-05T00:00:00.000Z",
+    };
+    const groups = groupConversations(
+      [legacy],
+      "local",
+      "updated",
+      { emptyWorkspace: "No workspace", emptyRepository: "No repository" },
+      ["/home/user/projects/demo"],
+    );
+    expect(groups).toEqual([
+      expect.objectContaining({
+        id: "ws:/home/user/projects/demo",
+        label: "demo",
+        conversations: [legacy],
+      }),
+    ]);
+  });
+
+
   it("parseConversationTimeMs returns 0 for missing or unparseable timestamps and ms for ISO strings", () => {
     // Three branches in one assertion: missing input (undefined), malformed
     // string (NaN from Date.parse), and a real ISO timestamp.

--- a/src/api/agent-server-adapter.ts
+++ b/src/api/agent-server-adapter.ts
@@ -22,6 +22,13 @@ import {
 } from "./conversation-service/agent-server-conversation-service.types";
 import SettingsService from "./settings-service/settings-service.api";
 import { getStoredConversationMetadata } from "./conversation-metadata-store";
+import {
+  gitProviderFromTag,
+  GIT_PROVIDER_TAG_KEY,
+  REPOSITORY_TAG_KEY,
+  SELECTED_BRANCH_TAG_KEY,
+  WORKSPACE_TAG_KEY,
+} from "./conversation-workspace-grouping";
 import LLMSubscriptionService from "./llm-subscription-service";
 import {
   LLM_AUTH_TYPE_SUBSCRIPTION,
@@ -316,10 +323,16 @@ export function toAppConversation(
   return {
     id: info.id,
     created_by_user_id: null,
-    selected_repository: metadata?.selected_repository ?? null,
-    selected_branch: metadata?.selected_branch ?? null,
-    git_provider: metadata?.git_provider ?? null,
-    selected_workspace: metadata?.selected_workspace ?? null,
+    selected_repository:
+      metadata?.selected_repository ?? info.tags?.[REPOSITORY_TAG_KEY] ?? null,
+    selected_branch:
+      metadata?.selected_branch ?? info.tags?.[SELECTED_BRANCH_TAG_KEY] ?? null,
+    git_provider:
+      metadata?.git_provider ??
+      gitProviderFromTag(info.tags?.[GIT_PROVIDER_TAG_KEY]) ??
+      null,
+    selected_workspace:
+      metadata?.selected_workspace ?? info.tags?.[WORKSPACE_TAG_KEY] ?? null,
     active_profile: metadata?.active_profile ?? null,
     title: info.title?.trim()
       ? info.title
@@ -422,6 +435,13 @@ type ConversationSettingsPayload = SettingsRecord & {
 
 export const ACP_SERVER_TAG_KEY = "acpserver";
 
+export {
+  GIT_PROVIDER_TAG_KEY,
+  REPOSITORY_TAG_KEY,
+  SELECTED_BRANCH_TAG_KEY,
+  WORKSPACE_TAG_KEY,
+} from "./conversation-workspace-grouping";
+
 /**
  * Conversation tag keys Canvas itself stamps/consumes for internal routing.
  * They are already surfaced through dedicated UI (the ACP provider chip), so
@@ -429,6 +449,10 @@ export const ACP_SERVER_TAG_KEY = "acpserver";
  */
 export const RESERVED_CONVERSATION_TAG_KEYS: ReadonlySet<string> = new Set([
   ACP_SERVER_TAG_KEY,
+  REPOSITORY_TAG_KEY,
+  SELECTED_BRANCH_TAG_KEY,
+  GIT_PROVIDER_TAG_KEY,
+  WORKSPACE_TAG_KEY,
 ]);
 
 /**

--- a/src/api/conversation-service/agent-server-conversation-service.api.ts
+++ b/src/api/conversation-service/agent-server-conversation-service.api.ts
@@ -43,6 +43,7 @@ import {
   toAppConversation,
   toConversationPage,
 } from "../agent-server-adapter";
+import { buildConversationMetadataTags } from "../conversation-workspace-grouping";
 import { GetVSCodeUrlResponse } from "../open-hands.types";
 import {
   getAgentServerClientOptions,
@@ -445,6 +446,20 @@ class AgentServerConversationService {
       agentProfileKind,
       titleLlmProfile,
     });
+
+    const metadataTags = buildConversationMetadataTags({
+      selectedRepository: metadata?.selected_repository,
+      selectedBranch: metadata?.selected_branch,
+      gitProvider: metadata?.git_provider,
+      selectedWorkspace: workingDirOverride,
+    });
+    if (Object.keys(metadataTags).length > 0) {
+      const existingTags =
+        payload.tags && typeof payload.tags === "object"
+          ? (payload.tags as Record<string, string>)
+          : {};
+      payload.tags = { ...existingTags, ...metadataTags };
+    }
 
     const data = await new ConversationClient(
       getAgentServerClientOptions({ timeout: CREATE_CONVERSATION_TIMEOUT_MS }),

--- a/src/api/conversation-workspace-grouping.ts
+++ b/src/api/conversation-workspace-grouping.ts
@@ -1,0 +1,85 @@
+import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
+import { isProvider, type Provider } from "#/types/settings";
+
+export const REPOSITORY_TAG_KEY = "repository";
+export const SELECTED_BRANCH_TAG_KEY = "selected_branch";
+export const GIT_PROVIDER_TAG_KEY = "git_provider";
+export const WORKSPACE_TAG_KEY = "workspace";
+
+export function normalizeWorkspacePath(
+  path: string | null | undefined,
+): string {
+  const trimmed = path?.trim();
+  if (!trimmed) return "";
+  return trimmed.replace(/\/+$/, "");
+}
+
+export function gitProviderFromTag(value: string | undefined): Provider | null {
+  if (value && isProvider(value)) {
+    return value;
+  }
+  return null;
+}
+
+/**
+ * Resolve the workspace path used for sidebar grouping. Prefer explicit
+ * client metadata (already on the conversation), then server tags, then
+ * a direct match of runtime `working_dir` against registered workspaces
+ * for conversations created before tags existed.
+ */
+export function resolveSelectedWorkspaceForGrouping(
+  conversation: Pick<
+    AppConversation,
+    "selected_workspace" | "workspace" | "tags"
+  >,
+  registeredWorkspacePaths?: readonly string[],
+): string | null {
+  const fromMetadata = normalizeWorkspacePath(conversation.selected_workspace);
+  if (fromMetadata) {
+    return fromMetadata;
+  }
+
+  const fromTag = normalizeWorkspacePath(
+    conversation.tags?.[WORKSPACE_TAG_KEY],
+  );
+  if (fromTag) {
+    return fromTag;
+  }
+
+  const runtimeDir = normalizeWorkspacePath(
+    conversation.workspace?.working_dir,
+  );
+  if (!runtimeDir || !registeredWorkspacePaths?.length) {
+    return null;
+  }
+
+  const registered = new Set(
+    registeredWorkspacePaths
+      .map((path) => normalizeWorkspacePath(path))
+      .filter(Boolean),
+  );
+  return registered.has(runtimeDir) ? runtimeDir : null;
+}
+
+export function buildConversationMetadataTags(options: {
+  selectedRepository?: string | null;
+  selectedBranch?: string | null;
+  gitProvider?: Provider | null;
+  selectedWorkspace?: string | null;
+}): Record<string, string> {
+  const tags: Record<string, string> = {};
+  if (options.selectedRepository) {
+    tags[REPOSITORY_TAG_KEY] = options.selectedRepository;
+  }
+  if (options.selectedBranch) {
+    tags[SELECTED_BRANCH_TAG_KEY] = options.selectedBranch;
+  }
+  if (options.gitProvider) {
+    tags[GIT_PROVIDER_TAG_KEY] = options.gitProvider;
+  }
+  const workspace = normalizeWorkspacePath(options.selectedWorkspace);
+  if (workspace) {
+    tags[WORKSPACE_TAG_KEY] = workspace;
+  }
+  return tags;
+}

--- a/src/components/features/conversation-panel/conversation-panel-list-helpers.ts
+++ b/src/components/features/conversation-panel/conversation-panel-list-helpers.ts
@@ -1,6 +1,7 @@
 import type { AppConversation } from "#/api/conversation-service/agent-server-conversation-service.types";
 import type { BackendKind } from "#/api/backend-registry/types";
 import type { Provider } from "#/types/settings";
+import { resolveSelectedWorkspaceForGrouping } from "#/api/conversation-workspace-grouping";
 
 export type ConversationSortField = "created" | "updated";
 export type ThreadScope = "all" | "relevant";
@@ -146,22 +147,21 @@ export function sortConversationsByField(
   );
 }
 
-function workspaceGroup(conversation: AppConversation): {
+function workspaceGroup(
+  conversation: AppConversation,
+  registeredWorkspacePaths?: readonly string[],
+): {
   id: string;
   label: string;
 } {
   // Group by the user-selected workspace (a stable identifier shared by
   // every conversation launched from the same picker selection), not
-  // `workspace.working_dir` — that field holds the per-conversation
-  // worktree path the agent-server creates, which is unique per
-  // conversation and would fragment the grouping.
-  //
-  // Normalize first, then check emptiness: inputs like "/", "///", or
-  // "   ///" trim+strip to "" and must fall back to the "no workspace"
-  // bucket rather than producing a stray `ws:` group with no label.
-  const normalized = conversation.selected_workspace
-    ?.trim()
-    .replace(/\/+$/, "");
+  // per-conversation worktree paths. Server-side tags and registered
+  // workspace paths recover grouping when localStorage is missing.
+  const normalized = resolveSelectedWorkspaceForGrouping(
+    conversation,
+    registeredWorkspacePaths,
+  );
   if (!normalized) {
     return { id: "__none_workspace", label: "" };
   }
@@ -194,6 +194,7 @@ export function groupConversations(
   backendKind: BackendKind,
   sortField: ConversationSortField,
   labels: { emptyWorkspace: string; emptyRepository: string },
+  registeredWorkspacePaths?: readonly string[],
 ): {
   id: string;
   label: string;
@@ -207,7 +208,9 @@ export function groupConversations(
 
   for (const c of items) {
     const { id, label: rawLabel } =
-      backendKind === "local" ? workspaceGroup(c) : repositoryGroup(c);
+      backendKind === "local"
+        ? workspaceGroup(c, registeredWorkspacePaths)
+        : repositoryGroup(c);
     const label =
       id === "__none_workspace"
         ? labels.emptyWorkspace

--- a/src/components/features/conversation-panel/conversation-panel.tsx
+++ b/src/components/features/conversation-panel/conversation-panel.tsx
@@ -5,6 +5,7 @@ import { I18nKey } from "#/i18n/declaration";
 import { useNavigation } from "#/context/navigation-context";
 import { useActiveBackend } from "#/contexts/active-backend-context";
 import { usePaginatedConversations } from "#/hooks/query/use-paginated-conversations";
+import { useLocalWorkspaces } from "#/hooks/query/use-local-workspaces";
 import { useStartTasks } from "#/hooks/query/use-start-tasks";
 import { useDeleteConversation } from "#/hooks/mutation/use-delete-conversation";
 import { useUnifiedPauseConversation } from "#/hooks/mutation/use-unified-stop-conversation";
@@ -88,6 +89,14 @@ export function ConversationPanel({
   const { t } = useTranslation("openhands");
   const { conversationId: currentConversationId, navigate } = useNavigation();
   const { backend: activeBackend } = useActiveBackend();
+  const { data: localWorkspacesData } = useLocalWorkspaces({
+    enabled: activeBackend.kind === "local",
+  });
+  const registeredWorkspacePaths = React.useMemo(
+    () =>
+      localWorkspacesData?.workspaces.map((workspace) => workspace.path) ?? [],
+    [localWorkspacesData?.workspaces],
+  );
   // Click-outside is only relevant in the legacy drawer mode where an
   // onClose handler is provided. When the panel is rendered inline (e.g.
   // as the always-visible conversation list pane), clicking outside should
@@ -336,6 +345,7 @@ export function ConversationPanel({
       activeBackend.kind,
       conversationSort,
       groupLabels,
+      activeBackend.kind === "local" ? registeredWorkspacePaths : undefined,
     );
   }, [
     activeBackend.kind,
@@ -345,6 +355,7 @@ export function ConversationPanel({
     olderScoped,
     organizeMode,
     recentScoped,
+    registeredWorkspacePaths,
     showOlderConversations,
   ]);
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -11,6 +11,10 @@ export const ProviderOptions = {
 
 export type Provider = keyof typeof ProviderOptions;
 
+/** Narrow untrusted wire data (e.g. conversation tags) to a {@link Provider}. */
+export const isProvider = (value: unknown): value is Provider =>
+  typeof value === "string" && Object.hasOwn(ProviderOptions, value);
+
 export type ProviderToken = {
   token: string;
   host: string | null;


### PR DESCRIPTION
AGENT:

## Why

Local conversation sidebar grouping relied on browser-only `openhands-agent-server-conversation-metadata` localStorage. Clearing site data or opening the same agent-server from another browser dropped conversations into “No workspace” even when the backend still had the correct `workspace.working_dir`.

## Summary

- Stamp workspace/repo metadata as server-side conversation tags when creating local conversations.
- Hydrate `selected_workspace` (and related repo fields) from tags in `toAppConversation` when localStorage is missing; localStorage remains the preferred warm cache for the creating client.
- Recover legacy **local_repo** grouping by matching runtime `working_dir` against registered server workspaces when loading the grouped sidebar.

## Issue Number

Fixes #17386

## How to Test

1. Point agent-canvas at a local agent-server with at least one registered workspace.
2. Create a conversation in Local Repo mode from that workspace; confirm it appears under the workspace folder.
3. Clear `openhands-agent-server-conversation-metadata` in localStorage (or use a fresh browser/profile) and reload — grouping should remain (tags for new conversations; registered-path match for older local_repo conversations whose `working_dir` equals the workspace path).
4. Focused unit tests (not run to completion in this environment — vitest setup failed locally with `ReferenceError: TransformStream is not defined` from MSW during import):
   - `npx vitest run __tests__/api/conversation-workspace-grouping.test.ts __tests__/api/agent-server-adapter.test.ts __tests__/api/agent-server-conversation-service.test.ts __tests__/components/features/conversation-panel/conversation-panel-list-helpers.test.ts`

## Video/Screenshots

_Not run in this session (no browser E2E harness executed)._

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Related open draft [#16666](https://github.com/OpenHands/OpenHands/pull/16666) targets a similar localStorage problem for #15598; this PR additionally covers legacy recovery via registered workspace paths per #17386 acceptance criteria.
- Reserved tag keys are filtered from generic tag chips.