### PR TITLE
Use the active LLM profile when creating automations

### DIFF
--- a/__tests__/manifests/automation-setup.test.ts
+++ b/__tests__/manifests/automation-setup.test.ts
@@ -239,6 +239,22 @@ describe("buildCreatePayload", () => {
     },
   );
 
+  it("includes the selected LLM profile in bundle create payloads", () => {
+    // Arrange
+    const entry = requireEntry("github-pr-reviewer");
+
+    // Act
+    const payload = buildCreatePayload(
+      entry,
+      { repositories: ["OpenHands/automation"] },
+      "/tmp/automation.tar.gz",
+      "chatgpt-subscription",
+    );
+
+    // Assert
+    expect(payload?.model).toBe("chatgpt-subscription");
+  });
+
   it("names an automation after the one repository it watches", () => {
     // Arrange
     const entry = requireEntry("github-pr-reviewer");

--- a/src/components/features/manifest/manifest-setup-dialog.tsx
+++ b/src/components/features/manifest/manifest-setup-dialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
@@ -12,6 +13,12 @@ import { getApiErrorBody } from "#/utils/api-error-message";
 import { useTracking } from "#/hooks/use-tracking";
 import { useSetupCapabilities } from "#/hooks/query/use-manifest-capabilities";
 import { useSetupPrerequisites } from "#/hooks/query/use-manifest-prerequisites";
+import {
+  LLM_PROFILES_QUERY_KEYS,
+  useLlmProfiles,
+} from "#/hooks/query/use-llm-profiles";
+import ProfilesService from "#/api/profiles-service/profiles-service.api";
+import { useActiveBackend } from "#/contexts/active-backend-context";
 import { useSetupPreflight } from "#/hooks/use-manifest-preflight";
 import { useSetupAction } from "#/manifests/manifest-actions";
 import {
@@ -88,6 +95,8 @@ export interface SetupDialogProps {
 export function SetupDialog({ entry, onClose }: SetupDialogProps) {
   const { t } = useTranslation("openhands");
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { backend, orgId } = useActiveBackend();
 
   const capabilities = useSetupCapabilities(entry);
   const prerequisites = useSetupPrerequisites(entry);
@@ -99,6 +108,15 @@ export function SetupDialog({ entry, onClose }: SetupDialogProps) {
     trackAutomationSetupCreated,
     trackAutomationSetupFailed,
   } = useTracking();
+  const { data: llmProfiles } = useLlmProfiles();
+  const selectedLlmProfile = llmProfiles?.active_profile ?? null;
+  const resolveSelectedLlmProfile = async () => {
+    const profiles = await queryClient.ensureQueryData({
+      queryKey: [...LLM_PROFILES_QUERY_KEYS.all, backend.id, orgId],
+      queryFn: ProfilesService.listProfiles,
+    });
+    return profiles.active_profile ?? null;
+  };
 
   const [step, setStep] = useState<SetupStep>("prerequisites");
   const [values, setValues] = useState<SetupFormValues>(() =>
@@ -129,8 +147,8 @@ export function SetupDialog({ entry, onClose }: SetupDialogProps) {
     [entry, capabilities.capabilities],
   );
   const payload = useMemo(
-    () => buildCreatePayload(entry, values),
-    [entry, values],
+    () => buildCreatePayload(entry, values, undefined, selectedLlmProfile),
+    [entry, selectedLlmProfile, values],
   );
   const errorMap = useMemo(() => deriveErrorMap(entry), [entry]);
 
@@ -175,9 +193,11 @@ export function SetupDialog({ entry, onClose }: SetupDialogProps) {
   const handleFieldBlur = () => {
     if (blurTimerRef.current) window.clearTimeout(blurTimerRef.current);
     blurTimerRef.current = window.setTimeout(() => {
-      void runPreflight(valuesRef.current).then((result) => {
-        if (result) setServiceErrors(result);
-      });
+      void runPreflight(valuesRef.current, selectedLlmProfile).then(
+        (result) => {
+          if (result) setServiceErrors(result);
+        },
+      );
     }, PREFLIGHT_DEBOUNCE_MS);
   };
 
@@ -194,7 +214,8 @@ export function SetupDialog({ entry, onClose }: SetupDialogProps) {
     }
     setLocalErrors({});
 
-    const result = await runPreflight(values);
+    const model = await resolveSelectedLlmProfile();
+    const result = await runPreflight(values, model);
     if (result && hasAnyError(result)) {
       setServiceErrors(result);
       return;
@@ -211,7 +232,8 @@ export function SetupDialog({ entry, onClose }: SetupDialogProps) {
   ) => {
     setIsSubmitting(true);
     try {
-      const { response } = await runAction(entry, values, actionPayload);
+      const model = await resolveSelectedLlmProfile();
+      const { response } = await runAction(entry, values, actionPayload, model);
       trackAutomationSetupCreated({
         automationId: entry.id,
         setupMode,

--- a/src/hooks/use-manifest-preflight.ts
+++ b/src/hooks/use-manifest-preflight.ts
@@ -57,6 +57,7 @@ export function useSetupPreflight(entry: SetupEntry) {
   return useCallback(
     async (
       formValues: SetupFormValues,
+      model?: string | null,
     ): Promise<MappedManifestErrors | null> => {
       try {
         // Deriving the body is inside the guard too: a bundle entry resolves
@@ -65,7 +66,7 @@ export function useSetupPreflight(entry: SetupEntry) {
         // validator that will not answer, and left outside it rejected a
         // promise no caller handles - which reads as a Continue button that
         // does nothing at all.
-        const body = buildPreflightBody(entry, formValues);
+        const body = buildPreflightBody(entry, formValues, model);
         if (!body) return null;
 
         latestRequestRef.current += 1;

--- a/src/manifests/automation-setup.ts
+++ b/src/manifests/automation-setup.ts
@@ -187,10 +187,12 @@ export function buildCreatePayload(
   values: SetupFormValues,
   /** Bundle entries only: what the upload returned. */
   tarballPath: string = PREFLIGHT_TARBALL_PATH,
+  model?: string | null,
 ): SetupRequestBody | null {
   const { setup } = entry;
   if (setup.mode !== "direct") return null;
-  if (setup.bundle) return buildBundlePayload(entry, values, tarballPath);
+  if (setup.bundle)
+    return buildBundlePayload(entry, values, tarballPath, model);
   if (!setup.prompt) return null;
 
   const scope = { form: values, automation: entry };
@@ -200,6 +202,7 @@ export function buildCreatePayload(
   const payload: SetupRequestBody = {
     name: deriveName(entry, values),
     prompt: interpolateText(setup.prompt, scope),
+    ...(model?.trim() ? { model: model.trim() } : {}),
   };
 
   if (repos.length > 0 && repoPicker?.field.provider) {
@@ -296,12 +299,14 @@ function buildBundlePayload(
   entry: SetupEntry,
   values: SetupFormValues,
   tarballPath: string,
+  model?: string | null,
 ): SetupRequestBody {
   const bundle = entry.setup.bundle!;
   const scope = { form: values, automation: entry };
 
   const payload: SetupRequestBody = {
     name: deriveName(entry, values),
+    ...(model?.trim() ? { model: model.trim() } : {}),
   };
 
   const trigger = buildTrigger(entry, values);
@@ -353,8 +358,14 @@ function interpolateConfig(
 export function buildPreflightBody(
   entry: SetupEntry,
   values: SetupFormValues,
+  model?: string | null,
 ): SetupRequestBody | null {
-  const draft = buildCreatePayload(entry, values);
+  const draft = buildCreatePayload(
+    entry,
+    values,
+    PREFLIGHT_TARBALL_PATH,
+    model,
+  );
   if (!draft) return null;
 
   return {

--- a/src/manifests/manifest-actions.ts
+++ b/src/manifests/manifest-actions.ts
@@ -77,6 +77,7 @@ export function useSetupAction() {
       values: SetupFormValues,
       /** Present for a direct entry, and absent for an assisted one. */
       payload: SetupRequestBody | null,
+      model?: string | null,
     ): Promise<SetupActionResult> => {
       if (!payload) {
         return startConversation(buildAssistedMessage(entry, values));
@@ -97,15 +98,18 @@ export function useSetupAction() {
           );
           uploadedRef.current = { key, path: tarballPath };
         }
-        const body = buildCreatePayload(entry, values, tarballPath);
+        const body = buildCreatePayload(entry, values, tarballPath, model);
         if (!body) throw new Error(`'${entry.id}' produced no create request.`);
         return {
           response: await AutomationService.createAutomationDraft(body, entry),
         };
       }
 
+      const body =
+        buildCreatePayload(entry, values, undefined, model) ?? payload;
+      if (!body) throw new Error(`'${entry.id}' produced no create request.`);
       const response = await AutomationService.createAutomationDraft(
-        payload,
+        body,
         entry,
       );
       return { response };


### PR DESCRIPTION
## Why

Issue-driven automation was losing the selected LLM profile before the create request was built, so the downstream run could fall back to the wrong credential path.

## Summary

- Resolve the active LLM profile again at preflight and submit time.
- Thread it through direct and bundle create payloads.
- Add a regression test covering bundle payloads that now include `model`.

## Issue Number

Fixes #17051

## How to Test

- `npx vitest run __tests__/manifests/automation-setup.test.ts src/api/automation-service/automation-service.api.test.ts`
- `npm run lint`
- `npm run build`

## Video/Screenshots

Terminal logs are in the local review artifacts.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Supercedes #17087（原PR分支已删，按原提交重建）
